### PR TITLE
docs(readme): restore faculty install scaffold + rewrite in Chaz's voice (v0.68.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "canvas-toolbox",
       "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Includes agent specs (8) and pedagogical knowledge files (20+) covering course design audits, FERPA-safe LLM grading, Canvas sync, and the BYU-I Learning Model.",
-      "version": "0.68.0",
+      "version": "0.68.1",
       "source": "./",
       "author": {
         "name": "Chaz Clark",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "canvas-toolbox",
   "displayName": "canvas-toolbox",
   "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Agent specs cover course audits (rubric coverage / quality, syllabus, CLO quality, alignment chain, accessibility, workload, grading structure / load, formative variety, learning model), Canvas sync paths (course / blueprint / Page-level orphan cleanup), and a generic LLM-grading pipeline (de-identify → consensus → reconcile → push). Knowledge files cover Canvas API + lessons learned, rubrics, assessments, backwards design, cognitive load theory, Hattie 3-phase, Merrill's First Principles, BYU-I Learning Model, BYUI Course Design Standards, and 14+ other pedagogical frameworks. Brain-agnostic by design: the LLM provider is your choice.",
-  "version": "0.68.0",
+  "version": "0.68.1",
   "author": {
     "name": "Chaz Clark",
     "url": "https://github.com/chaz-clark"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,6 +248,73 @@ private channel is for security.
 
 _Last updated: 2026-06-26_
 
+### Recent: README correction — restored faculty install scaffold + voice rewrite in Chaz's voice (v0.68.1, 2026-06-26)
+
+**v0.68.1** — corrects v0.68.0 after operator feedback: *"the quick
+start is too small compared to the old readme.md remember our
+audiance is mostly non-technical faculty you lost our audiance with
+your research of GH"* and *"your voicing is too AI for the readme.md
+you should scal all my *-master courses for their voicing."*
+
+**Two things were wrong with v0.68.0:**
+
+1. **Audience mismatch.** v0.68.0 was researched against top-starred
+   GH READMEs (Astro, Tailwind, shadcn/ui, etc.) — all aimed at
+   developer-fluent audiences. canvas-toolbox's audience is
+   non-technical faculty. The legacy 862-line README's verbose
+   Step 1/2/3 install scaffold wasn't bloat — it was THE entry
+   point. v0.68.0 compressed install to ~5 lines + TODO links.
+   That's wrong for the audience.
+
+2. **Voice mismatch.** The v0.68.0 prose read as marketing-formal
+   ("The architectural commitment isn't rhetoric. It's enforced in
+   code") — not Chaz's voice. Six parallel Explore agents scanned
+   `*-master` repos (itm327, ds250-onln, ds250-onml, ds460, m119,
+   cse450) to extract Chaz's actual writing voice from his
+   README.md / AGENTS.md / handoffs/. Consistent signature
+   surfaced: short + punchy alternated with structured detail;
+   imperative + consequence ("Edit X first. Never push Y."); "This
+   is / This is NOT" scope framing; "My lean:" for opinions;
+   "Source of truth:" framing; "Note:" / "Never..." / "Always..."
+   markers; explicit trade-offs with named costs; no marketing
+   speak ("leveraging", "seamlessly", "powerful"); no hedging
+   ("might", "perhaps", "may want to").
+
+**The fix:**
+
+1. **Restored** the full Step 1 → Step 2 → Step 3 install scaffold
+   from the legacy README. Step 1 (pick an IDE) + Step 2 (pick an
+   AI assistant) + Step 3 (TL;DR / Option A agent-driven / Option B
+   manual / Option C colleague-handover / migration). Plus the
+   audit-tool catalog + grading pipeline detail (condensed but
+   present, not TODO-linked).
+2. **Rewrote** the prose throughout in Chaz's voice. Marketing
+   wedge + safety-gate table kept (those landed well in v0.68.0);
+   the connective tissue is now matter-of-fact + imperative + no
+   filler. Example: v0.68.0 said *"Eleven coded safety gates like
+   this one stand between AI-assisted grading and the student's
+   gradebook — accumulated from real lived failures, not
+   speculative design."* v0.68.1 says: *"Eleven safety gates
+   between AI-assisted grading and the student's gradebook. Each
+   one came from a real incident. Each one shipped within hours of
+   being filed."*
+3. **Length** — 447 lines (up from v0.68.0's 206, down from
+   legacy's 862). The audit-tool catalog stays inline; grading
+   pipeline links to `grading_readme.md`; no TODO links to
+   nonexistent `INSTALL.md` / `OPERATIONS.md` (those references
+   were premature in v0.68.0 — the legacy is still in
+   `lib/marketing/README-LEGACY-2026-06-26.md` as source material
+   if those docs are extracted later).
+4. **Voice research** captured to
+   `handoffs/2026-06-26_chaz-voice-extraction.md` (gitignored;
+   six per-repo agent reports synthesized).
+
+**Branch protection — first PR-flow test.** v0.68.1 ships via PR
+on `feat/readme-restore-faculty-scaffold` branch (not direct push)
+since branch protection went live earlier this session. CI
+required + linear history + force-push-blocked. Auto-merge on CI
+green.
+
 ### Recent: Marketing-perspective README pass — Phase 2 (v0.68.0, 2026-06-26)
 
 **v0.68.0** — replaces the 862-line developer-doc README with a

--- a/README.md
+++ b/README.md
@@ -4,13 +4,17 @@
 
 **FERPA-safe AI-assisted Canvas LMS toolkit. Your voice. Your accountability. Your students' privacy.**
 
-> This is not an AI grader. It is how an instructor uses AI to grade *with* them — staying the author of every grade and every word the student reads.
+> **This is** how an instructor uses AI to grade *with* them — staying the author of every grade and every word the student reads.
+>
+> **This is NOT** an AI grader. The AI doesn't sign its name to the comment. You do.
+
+Built at BYU-Idaho. Designed for all instructors. Works with any Canvas institution. You don't have to be a developer — the agent handles the technical bits; you answer its questions.
 
 ---
 
 ## What it looks like in practice
 
-When an instructor's grading workflow includes a regression, the tool stops it before it reaches the student:
+When a re-grade would silently lower an existing student grade, the tool stops it before it reaches Canvas:
 
 ```
 $ uv run python lib/tools/grader_push.py --challenge-dir grading/kc1 --push
@@ -27,153 +31,368 @@ Pushed 21/22; 1 regression row skipped (--allow-lower forces it through;
 manual review recommended).
 ```
 
-Eleven coded safety gates like this one stand between AI-assisted grading and the student's gradebook — accumulated from real lived failures, not speculative design. Every gate was driven by a documented incident in production grading.
+Eleven safety gates between AI-assisted grading and the student's gradebook. Each one came from a real incident. Each one shipped within hours of being filed.
 
 ---
 
 ## Why this exists
 
-Two faculty teaching the same Canvas course shouldn't have to choose between *AI does the grading and signs the AI's name to it* and *the instructor does every comment by hand*. Both have real costs. The first surrenders pedagogical authorship; the second doesn't scale.
+Two faculty teaching the same Canvas course shouldn't have to choose between:
 
-Canvas Toolbox is the third option: **AI-assisted grading where the instructor stays the author.** The AI helps produce comments in the instructor's voice. The instructor reviews and approves every grade. The student sees their professor — not "AI Grader" — as the author of the feedback.
+1. **AI does the grading and signs the AI's name to it.** Students see "AI Grader" as the comment author.
+2. **The instructor does every comment by hand.** Doesn't scale past 30 students.
+
+Canvas Toolbox is the third option: **AI-assisted grading where the instructor stays the author.** The AI helps produce comments in the instructor's voice. The instructor reviews and approves every grade. The student sees their professor — not "AI Grader" — as the author.
 
 ### What changes
 
 | | AI-grading-as-a-service | Canvas Toolbox |
 |---|---|---|
-| **Comment authorship** | "AI Grader" — students KNOW it's AI | The instructor — their voice, their accountability |
-| **FERPA boundary** | Trust the vendor's tenant | Two-zone architecture: cloud sees keys only, never names |
+| **Comment authorship** | "AI Grader" — students know it's AI | The instructor — their voice, their accountability |
+| **FERPA boundary** | Trust the vendor's tenant | Two zones — cloud sees keys only, never names |
 | **LLM provider** | Locked to one vendor | Brain-agnostic — Claude / GPT / Gemini / local Ollama |
-| **Canvas auth** | One institutional key | Per-faculty Canvas token (faculty's own login) |
-| **Adoption gate** | Institution must procure / contract | Faculty pulls and runs — no procurement |
+| **Canvas auth** | One institutional key | Per-faculty Canvas token (your own login) |
+| **Adoption gate** | Institution must procure / contract | Pull and run — no procurement |
 
-The architectural commitment ("instructor stays the author") isn't rhetoric. It's enforced in code: when an instructor exports their grader to share with another faculty teaching the same course, their personal voice file is **refused by the export** by design. The receiving faculty builds their own voice. Both faculty's students hear their own professor.
+**Voice-preservation is in the code, not just in the docs.** When you export a grader to share with another faculty teaching the same course, your personal voice file is REFUSED by the export — by design. The receiving faculty builds their own voice. Both faculty's students hear their own professor.
 
 ---
 
 ## What you can trust
 
-Eleven production safety gates and three architectural commitments — each driven by a documented incident, each landed within hours of being filed:
+Eleven safety gates, each driven by a documented incident, each landed within hours of being filed. Every gate refuses by default; every gate has an explicit opt-out flag for the rare intentional case.
 
-### Architectural commitments
+### The architecture
 
-- **FERPA two-zone architecture** — the cloud sees opaque keys (`KC1-A1B2C3`); only the local zone has names. The AI never reads a student name. Files on disk are keyed by `user_id`, never by name.
-- **Voice-preservation contract** — per-instructor voice files are NEVER copied, exported, or shared between faculty. Each instructor's voice is theirs alone; the system is built to keep it that way.
-- **Brain-agnostic LLM** — Claude, GPT, Gemini, or local Ollama. The toolkit doesn't lock you into a vendor.
+- **FERPA two-zone** — the cloud sees opaque keys (`KC1-A1B2C3`). Only the local zone has names. The AI never reads a student name. Files on disk are keyed by `user_id`, never by name.
+- **Voice-preservation** — per-instructor voice files are NEVER copied, exported, or shared between faculty. Your voice is yours alone.
+- **Brain-agnostic LLM** — Claude, GPT, Gemini, or local Ollama. You're not locked into a vendor.
 
-### Safety gates (each one is a refused-by-default behavior with an explicit opt-out)
+### The gates
 
 | # | The gate | What it prevents |
 |---|---|---|
-| 1 | **Pull-latest-by-default** (#103) | Grading a stale attempt-1 file when the student has resubmitted attempt-2 |
-| 2 | **Grading-type validation** (#99) | Canvas silently coercing `(held)` to `incomplete` on a pass/fail assignment |
-| 3 | **3-pass consensus enforced** (#95) | Single-pass grading slipping through without inter-rater-reliability check |
-| 4 | **Regression direction gate** (#96) | A re-grade silently lowering a student's existing grade |
-| 5 | **Existing-grade awareness** (#96 part 3) | Grading cold without knowing the student already has a Canvas grade |
-| 6 | **Human-review gate** (#97) | An agent self-attesting review with `--yes` instead of a human typing 'reviewed' |
-| 7 | **Inline triage of student replies** (#98) | Skipping a held row without seeing why the student replied |
-| 8 | **Uncalibrated-cohort warning** (#101) | Unanimous consensus reading as confidence when the rubric itself was wrong |
-| 9 | **Student-facing task spec as source-of-truth** (#102) | Grading against what the solution code happens to do, not what students were asked |
-| 10 | **Group-assignment first-class workflow** (#100) | Re-grading 21 identical group-submission rows independently with inconsistent comments |
-| 11 | **Cross-faculty sharing with voice-preservation** (v0.67.0) | Exporting a grader package and accidentally locking the receiving faculty into the sending faculty's voice |
+| 1 | Pull-latest-by-default (#103) | Grading a stale attempt-1 file when the student has resubmitted attempt-2 |
+| 2 | Grading-type validation (#99) | Canvas silently coercing `(held)` to `incomplete` on a pass/fail assignment |
+| 3 | 3-pass consensus enforced (#95) | A single grading pass slipping through without inter-rater check |
+| 4 | Regression direction gate (#96) | A re-grade silently lowering a student's existing grade |
+| 5 | Existing-grade awareness (#96 part 3) | Grading cold without knowing the student already has a Canvas grade |
+| 6 | Human-review gate (#97) | An agent self-attesting review with `--yes` instead of you typing 'reviewed' |
+| 7 | Inline triage of student replies (#98) | Skipping a held row without seeing why the student replied |
+| 8 | Uncalibrated-cohort warning (#101) | Unanimous consensus reading as confidence when the rubric itself was wrong |
+| 9 | Student-facing task spec as source-of-truth (#102) | Grading against what the solution code happens to do, not what students were asked |
+| 10 | Group-assignment first-class workflow (#100) | Re-grading 21 identical group-submission rows with inconsistent comments |
+| 11 | Cross-faculty sharing with voice-preservation (v0.67.0) | Exporting a grader and accidentally locking the receiver into your voice |
 
-Every gate refuses by default; every gate has a documented opt-out flag for the rare intentional case (e.g., `--allow-lower` for a legitimate academic-integrity reversal). Operators can audit which gates fired in a push from the per-row console output and the `.push_log.md` audit trail.
-
-**Total tests in the verification suite: 439.** Every safety gate has unit tests covering the lived failure mode + the bypass path.
+Audit which gates fired in a push from the per-row console output + `.push_log.md`. **Total tests covering these:** 439.
 
 ---
 
-## Quick start
+# Getting started
 
-The toolkit installs as a single Python package; agents pick it up automatically when you run the included install script.
+Three small choices before the toolkit is yours:
+
+1. **Pick an IDE** — the app where you'll open files and talk to your AI assistant.
+2. **Pick an AI assistant** — use whichever AI subscription you already have, so you don't pay twice. (If you don't have one, there's a generous free path.)
+3. **Get the toolkit running** — your AI agent walks you through it (recommended), or do the steps yourself.
+
+You don't have to be a developer. The agent handles the technical bits; you answer its questions.
+
+---
+
+## Step 1 — Pick your IDE
+
+An **IDE** ("integrated development environment") is the app you'll work in. Pick one, download it, and install it like any other application.
+
+| If you… | Use | Free? | Download |
+|---|---|---|---|
+| **have no strong preference** *(the safe default)* | **Visual Studio Code** — the standard, with the largest selection of AI assistant extensions | yes | [code.visualstudio.com](https://code.visualstudio.com/) |
+| **want the AI to drive** *(and want a generous free option built in)* | **Antigravity IDE** — Google's agent-first IDE; Gemini AI is built in, no separate extension needed | yes (public preview, full Gemini 3 Pro, no usage limits announced) | [antigravityide.org](https://antigravityide.org/) |
+| **teach data science** *(R, Python, Quarto)* | **Positron** — Posit's data-science IDE, with a built-in AI assistant called *Positron Assistant* | yes | [positron.posit.co/download](https://positron.posit.co/download.html) |
+
+> ⚠️ **About Antigravity IDE:** it has Gemini built in and is **locked to Gemini** — you can't plug a ChatGPT, Claude, or Copilot subscription into it. Pick Antigravity if you're happy using Gemini (free now, paid tiers available). If you have a ChatGPT, Claude, or Copilot subscription you want to use, pick **Visual Studio Code** here and the matching extension in Step 2.
+
+---
+
+## Step 2 — Pick your AI assistant
+
+Use the subscription you **already have** so you don't pay twice. In your IDE, open the **Extensions panel** (the icon that looks like four squares on the side bar), search by the name below, click **Install**, then **sign in** when it prompts you.
+
+| You already have… | Install this | Sign in with | Link |
+|---|---|---|---|
+| **ChatGPT** *(Plus / Pro / Business / Edu / Enterprise)* | **Codex — OpenAI's coding agent** | your ChatGPT account | [Marketplace](https://marketplace.visualstudio.com/items?itemName=openai.chatgpt) |
+| **Claude** *(Pro / Team / Max)* | **Claude Code** *(official Anthropic extension)* | your Claude account | [Marketplace](https://marketplace.visualstudio.com/items?itemName=anthropic.claude-code) |
+| **GitHub Copilot** | **GitHub Copilot** + **GitHub Copilot Chat** | your GitHub account | [Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) · [Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) |
+| **Local models (Ollama)** *(no subscription, no cloud, data stays on your machine)* | **Continue.dev** (preferred) — or **Cline** as an alternative — both open-source agentic extensions; configure with your local Ollama models | no account — set the Ollama backend in the extension's settings | [Continue](https://marketplace.visualstudio.com/items?itemName=Continue.continue) · [Cline](https://marketplace.visualstudio.com/items?itemName=saoudrizwan.claude-dev) · [Ollama](https://ollama.com) |
+| **None of those** | Use **Antigravity IDE** instead of VS Code (from Step 1) — it's free, no extension to install, Gemini is built in | a Google account | [antigravityide.org](https://antigravityide.org/) |
+
+> 💡 **A common mix-up:** GitHub Copilot is a *separate* Microsoft/GitHub subscription — it does **not** connect to a ChatGPT account, even though they're both AI tools. If you have ChatGPT Plus, install **Codex** (first row). If you have Copilot, install **Copilot** (third row). Each is tied to its own account.
+
+> 🦙 **About Ollama + Continue.dev / Cline:** Both are open-source and fully agentic — they read files, run terminal commands, edit code, the same workflow as the cloud extensions above. **Continue.dev** is the safer first pick (Apache 2.0, broader adoption, more stable backend abstraction). **Cline** is a strong alternative — newer but capable for the same workflow. Both are local-first; nothing leaves your machine. Good fit for FERPA-strict institutions or cost-conscious workflows. The honest trade: today's local code models (e.g. `qwen2.5-coder`, `deepseek-coder-v2`, `codestral`) handle deterministic + structural work well, but need extra calibration for nuanced prose grading compared to Claude / GPT-4. Start with a recent code-focused model; tune from there.
+
+> 📓 **Positron users:** Positron has a built-in **Positron Assistant** — you don't need to install an extension for AI help. Skip Step 2 and go to Step 3.
+
+---
+
+## Step 3 — Get the toolkit running
+
+Three paths. **Most non-technical faculty use Option A.** Technical users with a terminal habit start with the TL;DR.
+
+### TL;DR — one-line install (macOS / Linux)
+
+If you already have `git` and a terminal habit:
 
 ```bash
-git clone https://github.com/chaz-clark/canvas-toolbox.git
-cd canvas-toolbox
-./scripts/install.sh
+curl -fsSL https://raw.githubusercontent.com/chaz-clark/canvas-toolbox/main/scripts/install.sh | bash
 ```
 
-Then point your AI assistant at the repo. The toolkit supports any of:
+The script installs `uv` if missing, clones `canvas-toolbox/` into your current directory, and runs `cb-init`. It halts after writing a `.env` stub — fill in your `CANVAS_API_TOKEN` + `CANVAS_BASE_URL`, then:
 
-- **Claude Code** (keyless-by-default; faculty use their existing subscription)
-- **Cursor / Continue.dev / Cline** (also work; see [`INSTALL.md`](INSTALL.md) Step 2)
-- **Local Ollama** (FERPA-strict / cost-conscious deployments)
+```bash
+cd canvas-toolbox && uv run python lib/tools/cb_init.py
+```
 
-For institutions with API keys (Anthropic, OpenAI, or Azure OpenAI), the `grader_grade.py` orchestrator runs the grading pipeline programmatically. For BYUI-style institutions where faculty can't get API keys, the keyless-agent path is the production default — the agent under the operator's existing subscription IS the grader.
+Total time on a fresh machine: ~3 minutes.
 
-**Full install + your-IDE-of-choice setup:** [`INSTALL.md`](INSTALL.md) *(extracted from this README in the marketing pass — TODO if not yet present)*.
+**Windows users**, or anyone who'd rather have their AI assistant walk them through it: skip the one-liner and use **Option A** below.
 
 ---
 
-## What it does
+### Option A — Start here: your agent sets it up
 
-The toolkit covers two workflow categories:
+Create a new empty folder on your computer, open it in the IDE you set up in Steps 1 and 2, then give your AI assistant this prompt:
 
-### Auditing your course (read-only)
+> *"Help me set up Canvas Toolbox for my Canvas course. The toolkit is at https://github.com/chaz-clark/canvas-toolbox — please clone it, install dependencies, and walk me through connecting it to my course."*
 
-| Audit | What it checks |
+The agent checks what's installed, handles anything missing, and guides you through the rest. You just answer its questions.
+
+**Agent setup checklist** *(the agent follows these steps; you respond when asked)*
+
+1. **Check git** — `git --version`. If missing:
+   - Mac: `xcode-select --install`
+   - Windows: `winget install --id Git.Git -e --source winget` (or download from [git-scm.com/download/win](https://git-scm.com/download/win))
+
+2. **Clone the toolkit**
+   ```bash
+   git clone https://github.com/chaz-clark/canvas-toolbox.git canvas_toolbox
+   ```
+
+3. **Check uv** — `uv --version`. If missing:
+   - Mac/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
+   - Windows: `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
+
+4. **Install dependencies** (one-time)
+   ```bash
+   cd canvas_toolbox && uv sync && cd ..
+   ```
+
+5. **Create config files**
+   ```bash
+   cp canvas_toolbox/scaffold/.env.example .env
+   cp canvas_toolbox/scaffold/gitignore .gitignore
+   ```
+
+6. **Collect Canvas credentials** — you'll need:
+   - **Course ID** — the number after `/courses/` in your Canvas course URL
+   - **API token** — Canvas → Account → Settings → Approved Integrations → New Access Token (requires instructor or admin role)
+   - **Institution URL** — your Canvas login address (e.g., `https://byui.instructure.com`)
+
+7. **Fill in `.env`** with your credentials:
+   ```
+   CANVAS_API_TOKEN=your_token
+   CANVAS_BASE_URL=https://your-institution.instructure.com
+   CANVAS_COURSE_ID=123456
+   ```
+
+8. **Pull the course**
+   ```bash
+   uv run python canvas_toolbox/lib/tools/canvas_sync.py --init
+   ```
+   This mirrors the entire course — modules, pages, assignments, quizzes, discussions, syllabus — into a `course/` folder. Takes about a minute.
+
+---
+
+### Option B — Manual setup
+
+Use this if you prefer to run each step yourself, or if your AI tool doesn't run terminal commands.
+
+**Open a terminal:**
+- **Mac:** Cmd + Space → type "Terminal" → Enter
+- **Windows:** Windows key → type "PowerShell" → Enter
+
+#### Fast path — `cb-init` (3 lines, fully interactive, any OS)
+
+```bash
+git clone https://github.com/chaz-clark/canvas-toolbox.git canvas-toolbox
+cd canvas-toolbox
+uv run python lib/tools/cb_init.py
+```
+
+`cb-init` is **idempotent** — re-running is safe and fast. It installs `uv` if missing, installs Python 3.14, writes a `.env` stub (then stops so you can fill in your Canvas credentials), installs all dev tools, smoke-tests your Canvas API token, and surfaces `AGENTS.md`.
+
+Useful flags:
+
+| Flag | Use |
 |---|---|
-| **Full health sweep** — `course_audit.py --full` | 11 read-only audits composed (rubrics · syllabus · outcomes · alignment chain · learning model · formative variety · grading structure · grading load · accessibility · workload) |
-| **Module + item visibility** | Items students can't find; empty modules; broken module structure |
-| **Date validation** | Due dates in the right window, in the right order, not duplicated |
-| **Outcome alignment chain** | Rubric criteria → module outcomes → course outcomes — does the chain actually connect? |
-| **Pedagogy phase coverage** | Does each module exercise BYUI Learning Model / Kolb / Hattie 3-phase / Merrill's First Principles? |
-| **WCAG 2.1 AA aid** | Alt-text, captions, headings, reading level, color-only signaling, distracting elements |
-| **Syllabus completeness** | BYU-I 25-item rubric scored; link-presence detection for required policy links |
+| `--check` | Dry-run: shows what each step would do, writes nothing |
+| `--yes` | Skip all y/n prompts (for CI / Codespaces) |
+| `--skip-playwright` | Skip the 92 MB Chromium download |
 
-Each audit produces a paired `.md` + `.pdf` report when you use `--report <name>.md`.
+If `cb-init` runs cleanly, skip the rest of Option B and go straight to **"Pull your course"**.
 
-**Full audit-tool catalog:** [`OPERATIONS.md`](OPERATIONS.md) *(TODO if not yet present)*.
+#### Manual long path
 
-### Grading an assignment (FERPA-safe, instructor-author-first)
+```bash
+git clone https://github.com/chaz-clark/canvas-toolbox.git canvas_toolbox
+cd canvas_toolbox && uv sync && cd ..
+cp canvas_toolbox/scaffold/.env.example .env
+cp canvas_toolbox/scaffold/gitignore .gitignore
+```
 
-Fetch → de-identify → grade (3-pass consensus) → review → push. The AI never sees a student name. The instructor reviews and approves every grade. Gated end-to-end:
+Then fill in `.env` with your Canvas credentials (see the agent checklist above, step 6 + 7).
+
+> **Can't see the `.env` file?** Its name starts with a dot, which hides it by default. **Mac:** Cmd + Shift + . in Finder. **Windows:** File Explorer → View → check "Hidden items".
+
+**Pull your course:**
+```bash
+uv run python canvas_toolbox/lib/tools/canvas_sync.py --init
+```
+
+---
+
+### Option C — A colleague is setting it up for you
+
+Gather three pieces of information and hand them over:
+
+- **Course ID** — the number after `/courses/` in your Canvas course URL
+- **API token** — Canvas → Account → Settings → Approved Integrations → New Access Token (requires instructor or admin role)
+- **Institution URL** — your Canvas login address (e.g., `https://byui.instructure.com`)
+
+Share them in this format:
+
+```
+CANVAS_API_TOKEN=your_token_here
+CANVAS_BASE_URL=https://byui.instructure.com
+CANVAS_COURSE_ID=123456
+```
+
+They'll handle the rest.
+
+---
+
+### Already have an older canvas-toolbox setup? Migrate it.
+
+If you have a Canvas course repo with an *older* canvas-toolbox layout — vendored as a git subtree, or in a folder your parent repo still tracks — there's a one-command migration:
+
+```bash
+python3 canvas-toolbox/scaffold/migrate_to_clone_layout.py
+```
+
+**Dry-run by default** — inspects your repo, reports its state, prints the exact plan it would run. Re-run with `--apply` to execute. Backs up existing canvas-toolbox content to `/tmp/` before changing anything. Safe to run on a setup that's already correct (reports *"Already on the new layout. Nothing to do."*).
+
+---
+
+# Auditing your course
+
+Read-only. Reports findings, never changes anything. Run as often as you like.
+
+**Not sure where to start?** Run the health check below — it composes the rubric, syllabus, and outcome audits and gives you one summary.
+
+## "Give me a full health check"
+
+Two tiers — pick by where you are in the course lifecycle.
+
+### QUICK — mid-authoring, ~30 seconds
+
+**Ask your agent:** *"Run a course health audit"*
+
+```bash
+uv run python canvas_toolbox/lib/tools/course_audit.py
+```
+
+Runs the four core read-only audits — rubric coverage, rubric quality, syllabus completeness, outcome quality — and composes one report: overall verdict (**HEALTHY / REVIEW / NEEDS ATTENTION**) plus a "top things to fix" list.
+
+### FULL — pre-publish / pre-semester sweep
+
+**Ask your agent:** *"Run the full course health sweep and share the results"*
+
+```bash
+uv run python canvas_toolbox/lib/tools/course_audit.py --full
+```
+
+Composes 11 read-only audits into one report — rubrics · syllabus · outcomes · alignment chain · learning model · formative variety · grading structure · grading load · accessibility · workload. Each finding gets a single page with what was checked, what was found, and what to do.
+
+Every audit produces a paired `.md` + `.pdf` when you use `--report <name>.md`. PDF is the faculty-friendly default; MD is the editable source.
+
+## What else the audits cover
+
+- **Items students can't find** — broken module structure, items not linked from any module
+- **Date validation** — due dates in the right window, in the right order, not duplicated
+- **Outcome alignment chain** — rubric criteria → module outcomes → course outcomes (does the chain actually connect?)
+- **Pedagogy phase coverage** — does each module exercise BYUI Learning Model / Kolb / Hattie 3-phase / Merrill's First Principles?
+- **WCAG 2.1 AA aid** — alt-text, captions, headings, reading level, color-only signaling, distracting elements (aids review, doesn't certify compliance)
+- **Unused files** — files sitting in Canvas that nothing links to
+- **Course Map & Schedule** — Architects-of-Learning–style course map (CLOs, per-module outcomes, 14-week schedule, pacing analysis)
+- **Syllabus scored against the BYU-I Completeness Rubric** — 25 specific items + link-presence detection for required policy links (Grievance / FERPA / Honor Code / Policy Library)
+- **New Quiz response data** — the New Quizzes API doesn't expose per-student responses directly; `grader_fetch_nq_responses` reads them via the student-analysis report. FERPA-safe by default (uid-keyed; names opt-in via `--include-names`)
+
+Full audit catalog + agent framework references: [`lib/agents/knowledge/README.md`](lib/agents/knowledge/README.md).
+
+---
+
+# Grading an assignment
+
+Fetch → de-identify → grade → review → push. The AI never sees a student name. The instructor reviews and approves every grade. Gated end-to-end.
 
 1. **Fetch** — `grader_fetch.py` pulls submissions keyed by user_id (no name in any filename); detects resubmissions and pulls the latest attempt
 2. **De-identify** — adapters for docx / databricks / pdf / xlsx / jupyter; output is `submissions_deid/<KEY>.<ext>`
-3. **Grade** — 3 independent grader passes per submission; consensus + spread → NEEDS-REVIEW queue (default: agent-in-the-loop on the operator's existing subscription; optional: `grader_grade.py` orchestrator for keyholders)
+3. **Grade** — 3 independent grader passes per submission; consensus + spread → NEEDS-REVIEW queue. The default is **agent-in-the-loop on your existing subscription**; `grader_grade.py` is an optional orchestrator for institutions with API keys
 4. **Review** — instructor reads `_all_comments.md`, edits in their voice, the toolkit syncs back to per-student files
-5. **Push** — `grader_push.py` with `--mark-reviewed` gate; eleven safety gates run before each grade reaches Canvas
+5. **Push** — `grader_push.py` with `--mark-reviewed` gate. Eleven safety gates run before each grade reaches Canvas
+
+The push surface refuses by default in the dangerous direction. Every refusal has a documented opt-out flag.
 
 **Full grading pipeline:** [`grading_readme.md`](grading_readme.md) — canonical folder layout + 8-step pipeline + dual-push pattern + setup interview.
 
 ---
 
-## Sharing your grader with another faculty
+# Sharing your grader with another faculty
 
-When two faculty teach the same Canvas course, the second one shouldn't start from scratch. v0.67.0 ships `grader_export.py` + `grader_import.py` for cross-faculty sharing.
+When two faculty teach the same Canvas course, the second one shouldn't start from scratch.
 
 ```bash
-# Faculty A (the sender) bundles their course substrate:
+# You bundle your course substrate:
 uv run python lib/tools/grader_export.py \
   --course-label "DS 250 — Data Science for Business" \
   --out ds250-share-2026-06.zip
 
-# Faculty B (the receiver) imports it:
+# The receiving faculty imports it:
 uv run python lib/tools/grader_import.py --zip ds250-share-2026-06.zip
 ```
 
 **What's IN the export:** rubrics, task specs, per-challenge configs, course-level voice pitfalls (course-content insights, NOT instructor voice), and a manifest documenting the canvas-toolbox version.
 
-**What's NEVER in the export:** the sending faculty's per-instructor voice file, any student submissions, any feedback files, any grading artifacts, any identity bridges. Defense-in-depth: a FERPA blacklist refuses to write OR extract any of these files even if a manifest tried to include them.
+**What's NEVER in the export:** your per-instructor voice file. Any student submissions. Any feedback files. Any grading artifacts. Any identity bridges. A FERPA blacklist refuses to write OR extract any of these — defense in depth.
 
-**Version compatibility:** if the receiver's canvas-toolbox is older than the export's required version, `grader_import.py` HARD REFUSES with the exact upgrade command. No silent feature-mismatch failures.
+**Version compatibility:** if the receiver's canvas-toolbox is older than the export's, `grader_import.py` REFUSES with the exact upgrade command. No silent feature-mismatch failures.
 
-The voice-preservation contract is reasserted in the receiver's README inside the ZIP: *"Your voice is the asset. The imported substrate is a starting point."* Faculty B runs the voice articulation interview from [`voice_coaching_knowledge.md §5`](lib/agents/knowledge/voice_coaching_knowledge.md) (~30 min) to build their own voice file — they never see Faculty A's.
+The receiver's README inside the ZIP says it plainly: *"Your voice is the asset. The imported substrate is a starting point."* The receiving faculty runs the voice articulation interview from [`voice_coaching_knowledge.md §5`](lib/agents/knowledge/voice_coaching_knowledge.md) (~30 min) and builds their own voice file. They never see yours.
+
+Full sharing pattern: [`grader_knowledge.md §17`](lib/agents/knowledge/grader_knowledge.md).
 
 ---
 
-## Who uses it
+# Who uses it
 
 - **BYU-Idaho** (institutional pilot) — multiple faculty across DS 250, DS 460, and CE 162 (Land Surveying)
 - **DS 250 Online** — ~448 student-cohort observations across 27 sections (the deepest production validation; the 11 safety gates were driven by lived failures in DS 250 grading)
-- **CE 162 Land Surveying** — first non-DS adoption (filed the group-assignment workflow enhancement that became v0.64.0 with a fully-worked local prototype)
+- **CE 162 Land Surveying** — first non-DS adoption; filed the group-assignment workflow enhancement that became v0.64.0 with a fully-worked local prototype
 
-If you're piloting at another institution: file an issue ([`cb-report-bug`](#sharing-back-with-the-project)) — adoption stories help shape the next safety gate.
+If you're piloting at another institution, file an issue (see below). Adoption stories shape the next safety gate.
 
 ---
 
-## Sharing back with the project
+# Sharing back with the project
 
 Three lightweight paths, all under one tool:
 
@@ -183,15 +402,37 @@ Three lightweight paths, all under one tool:
 ./bin/cb-share         # share something you built locally (auto-prefix: share:)
 ```
 
-These open your editor for a description, scrub PII locally (names, emails, `/Users` paths), bundle your toolkit version + last 150 log lines + sanitized cwd, and post to a Cloudflare-fronted intake worker that files the GitHub issue using the maintainer's PAT. No GitHub account required.
+These open your editor for a description, scrub PII locally (names, emails, `/Users` paths), bundle your toolkit version + last 150 log lines + sanitized cwd, and post to a Cloudflare-fronted intake worker that files the GitHub issue using the maintainer's PAT. **No GitHub account required.** Roundtrip: ~1 second.
 
-Standard PRs are also welcome — see [`CONTRIBUTING.md`](CONTRIBUTING.md) for the fork → branch → PR shape.
+| You want to… | Use | What happens |
+|---|---|---|
+| **Report a bug** (toolkit deviated from documented behavior) | `cb-report-bug` with title `bug: <short description>` | Files an issue tagged `agent-submitted`. ~1 second. |
+| **Request a feature** | `cb-report-bug` with title `enhancement: <short description>` | Same path; title prefix triages it. |
+| **Share something you built** (a tool, config, workflow extension) | `cb-share` with title `share: <short description>` + a body that links or pastes the code | Same path; `share:` prefix tells the maintainer this is contribution-shaped. |
+| **Push code via a PR** | Standard GitHub PR workflow | See [`CONTRIBUTING.md`](CONTRIBUTING.md). |
 
-**The bug-intake loop is the heartbeat of this project.** Eleven issues filed via the worker have closed in the last three days — every one drove a coded safety gate that's now live. If you find a hole, fill it via the worker; the loop closes within hours.
+**Want shorter commands?** Put `bin/` on your PATH:
+
+```bash
+echo 'export PATH="'"$(pwd)"'/bin:$PATH"' >> ~/.zshrc   # or ~/.bashrc
+source ~/.zshrc
+# now: cb-init, cb-report-bug, cb-share work from anywhere
+```
+
+**Fallbacks** (work if `bin/` isn't on PATH):
+
+```bash
+uv run python lib/tools/cb_report_bug.py    # long-form, equivalent
+gh issue create -R chaz-clark/canvas-toolbox  # if you have gh + a GitHub account
+```
+
+Or go directly: <https://github.com/chaz-clark/canvas-toolbox/issues/new>.
+
+The bug-intake loop is the heartbeat of this project. Eleven issues filed via the worker have closed in the last three days — every one drove a coded safety gate. If you find a hole, fill it via the worker. The loop closes within hours.
 
 ---
 
-## License + acknowledgments
+# License + acknowledgments
 
 MIT. See [`LICENSE`](LICENSE).
 
@@ -201,6 +442,6 @@ The architecture (FERPA two-zone, voice-preservation contract, consensus-based g
 
 ---
 
-## Current version
+**Current version:** v0.68.x · 11 safety gates · 439 unit tests · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
 
-**v0.67.1** — 11 production safety gates across 11 closed issues; 439 unit tests; ~70 versioned releases since v0.1. See [`AGENTS.md`](AGENTS.md) Active Context for the running release log + per-feature lived-experience rationale.
+For help, see the doc tree above or file a `cb-report-bug` (~1 second roundtrip; no GitHub account needed).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "0.68.0"
+version = "0.68.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "0.68.0"
+version = "0.68.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Corrects v0.68.0 after operator feedback that two things were wrong:

1. **Audience mismatch** — v0.68.0 was researched against top-starred GH READMEs (Astro, Tailwind, shadcn/ui) all aimed at developer-fluent audiences. canvas-toolbox's audience is **non-technical faculty**. The legacy 862-line README's verbose Step 1/2/3 install scaffold wasn't bloat — it was THE entry point. v0.68.0 compressed install to ~5 lines + TODO links. Wrong for the audience.
2. **Voice mismatch** — v0.68.0 prose read as marketing-formal, not Chaz's voice. Six parallel Explore agents scanned `*-master` repos (itm327, ds250-onln, ds250-onml, ds460, m119, cse450) to extract Chaz's actual writing voice. Consistent signature surfaced: short + punchy alternated with structured detail; imperative + consequence ("Edit X first. Never push Y."); "This is / This is NOT" scope framing; "My lean:" for opinions; no marketing speak ("leveraging", "seamlessly", "powerful"); no hedging ("might", "perhaps").

## What changed

- **Restored** full Step 1 → Step 2 → Step 3 install scaffold (IDE pick + AI-assistant pick + TL;DR / Option A agent-driven / Option B manual / Option C colleague-handover / migration path)
- **Restored** audit-tool catalog + grading pipeline detail (condensed; no TODO-link deferrals)
- **Kept** marketing wedge opener + safety-gate trust table from v0.68.0 (those landed well)
- **Rewrote** connective tissue in Chaz's voice — matter-of-fact + imperative + no filler

## Length

| Version | Lines |
|---|---|
| Legacy (pre-v0.68.0) | 862 |
| v0.68.0 (overcompressed) | 206 |
| **v0.68.1 (this PR)** | **447** |

## First PR under branch protection

This is the first PR-flow test of the Option C branch protection applied earlier this session:
- ✅ CI must be green to merge
- ✅ Linear history required
- ✅ 0 approvals self-merge (solo maintainer)
- ✅ Force-push + deletion blocked
- ✅ Admin bypass available for emergencies

## Test plan

- [x] `wc -l README.md` = 447 (within 400-500 target)
- [x] `uv run pytest lib/tests/ -k "not sprint"` = 439 passing
- [x] `uv run pre-commit run --all-files` = all hooks pass
- [x] No code changes; markdown-only
- [ ] Operator GH-renders the README + comes back with any tweaks (the original "review in GH rendered" promise from earlier this session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)