### PR TITLE
docs(readme): streamline setup + surface AI architect capability (v0.69.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "canvas-toolbox",
       "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Includes agent specs (8) and pedagogical knowledge files (20+) covering course design audits, FERPA-safe LLM grading, Canvas sync, and the BYU-I Learning Model.",
-      "version": "0.69.0",
+      "version": "0.69.1",
       "source": "./",
       "author": {
         "name": "Chaz Clark",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "canvas-toolbox",
   "displayName": "canvas-toolbox",
   "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Agent specs cover course audits (rubric coverage / quality, syllabus, CLO quality, alignment chain, accessibility, workload, grading structure / load, formative variety, learning model), Canvas sync paths (course / blueprint / Page-level orphan cleanup), and a generic LLM-grading pipeline (de-identify → consensus → reconcile → push). Knowledge files cover Canvas API + lessons learned, rubrics, assessments, backwards design, cognitive load theory, Hattie 3-phase, Merrill's First Principles, BYU-I Learning Model, BYUI Course Design Standards, and 14+ other pedagogical frameworks. Brain-agnostic by design: the LLM provider is your choice.",
-  "version": "0.69.0",
+  "version": "0.69.1",
   "author": {
     "name": "Chaz Clark",
     "url": "https://github.com/chaz-clark"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,46 @@ private channel is for security.
 
 _Last updated: 2026-06-26_
 
-### Recent: Title IV course-engagement audit + Downloads-folder FERPA tier 3 (v0.69.0, 2026-06-26)
+### Recent: README streamline — cut technical setup options + surface AI architect capability (v0.69.1, 2026-06-26)
+
+**v0.69.1** — docs-only patch. Two operator-flagged issues:
+
+1. **Setup steps had too many forks** — the non-technical
+   agent-driven prompt was buried under TL;DR one-liner + Option B
+   (manual fast-path cb-init + manual long path) + Option C. Cut
+   Option B entirely. Cut TL;DR one-liner. Promoted Option A as
+   THE path; faculty pastes one prompt to their agent and the
+   agent handles git/uv/Python/deps. Option C (colleague-handover)
+   retained as a small sub-section. Migration paragraph kept as
+   one-line footer for existing users.
+
+   **Rationale:** technical users will figure it out without
+   instructions; the README's job is to lower the bar for
+   non-technical faculty. Forks confuse the audience that needs
+   the most hand-holding.
+
+2. **AI architect capability not surfaced** — the toolkit ships
+   with 20+ pedagogical knowledge files (backwards design / Hattie
+   3-phase / Merrill / Kolb / Cognitive Load Theory / AAC&U
+   rubrics / Carnegie workload / etc.) that the agent uses when
+   designing a NEW course or redesigning an existing one. README
+   only documented audit / sync / grade flows — never said the
+   toolkit can help you BUILD a course. Added:
+
+   - **10th agent-prompt row**: *"Design or improve a course (AI
+     architect)"* — links to dedicated section
+   - **NEW dedicated section** *"Architecting a course with AI
+     assistance"* between Step 3 and Auditing — names the 22
+     design-relevant knowledge files in a table, names the
+     prompt, names the 6 things the agent walks the faculty
+     through (CLOs → assessments → module sequence → rubrics →
+     workload → accessibility), keeps the *"you stay the
+     architect; AI is the assistant"* framing
+
+**No code changes.** No new tests required. Version triple-sync
+0.69.0 → 0.69.1 (patch — docs only). 483 tests unchanged.
+
+### Earlier: Title IV course-engagement audit + Downloads-folder FERPA tier 3 (v0.69.0, 2026-06-26)
 
 **v0.69.0** — new audit tool category: federal Title IV last-date-
 of-engagement classifier for UW/UF reporting (R2T4 candidates).

--- a/README.md
+++ b/README.md
@@ -40,11 +40,12 @@ That's the grading workflow. The toolbox does more — audits, sync, sharing, se
 
 ## What you can ask your AI agent to do
 
-Nine workflows. Each one is a prompt your agent can act on.
+Ten workflows. Each one is a prompt your agent can act on.
 
 | You want to… | Ask your agent | What happens |
 |---|---|---|
 | **Pull your Canvas course to your computer** | *"Pull my Canvas course into a local folder so I can start working with it"* | Mirrors all modules, pages, assignments, quizzes, discussions, syllabus into a `course/` folder. Edit any file locally; push back when ready. |
+| **Design or improve a course (AI architect)** | *"Help me design a new course on [topic]"* / *"Architect a new course"* / *"Improve the design of this course"* | Agent walks you through CLOs → assessments backward from outcomes → module sequence (Hattie / Merrill / Kolb) → rubrics → workload calibration. Uses 18+ pedagogical knowledge files. See [Architecting a course](#architecting-a-course-with-ai-assistance) below. |
 | **Get a quick health check** | *"Run a course health audit"* | 4-audit summary in ~30 seconds (rubrics, syllabus, outcomes, outcome quality) → verdict + top things to fix. |
 | **Run the full pre-publish sweep** | *"Run the full course health sweep and share the results"* | 11 read-only audits composed into one report — alignment chain, learning model, accessibility, workload, grading load, formative variety. PDF + MD per finding. |
 | **Build a Course Map + Schedule** | *"Build a Course Map and 14-week schedule from this course"* | Architects-of-Learning–style map: CLOs, per-module outcomes, 14-week pacing analysis. |
@@ -165,139 +166,23 @@ Use the subscription you **already have** so you don't pay twice. In your IDE, o
 
 ## Step 3 — Get the toolkit running
 
-Three paths. **Most non-technical faculty use Option A.** Technical users with a terminal habit start with the TL;DR.
-
-### TL;DR — one-line install (macOS / Linux)
-
-If you already have `git` and a terminal habit:
-
-```bash
-curl -fsSL https://raw.githubusercontent.com/chaz-clark/canvas-toolbox/main/scripts/install.sh | bash
-```
-
-The script installs `uv` if missing, clones `canvas-toolbox/` into your current directory, and runs `cb-init`. It halts after writing a `.env` stub — fill in your `CANVAS_API_TOKEN` + `CANVAS_BASE_URL`, then:
-
-```bash
-cd canvas-toolbox && uv run python lib/tools/cb_init.py
-```
-
-Total time on a fresh machine: ~3 minutes.
-
-**Windows users**, or anyone who'd rather have their AI assistant walk them through it: skip the one-liner and use **Option A** below.
-
----
-
-### Option A — Start here: your agent sets it up
-
-Create a new empty folder on your computer, open it in the IDE you set up in Steps 1 and 2, then give your AI assistant this prompt:
+**Create an empty folder on your computer, open it in the IDE you set up in Steps 1 and 2, and paste this prompt to your AI assistant:**
 
 > *"Help me set up Canvas Toolbox for my Canvas course. The toolkit is at https://github.com/chaz-clark/canvas-toolbox — please clone it, install dependencies, and walk me through connecting it to my course."*
 
-The agent checks what's installed, handles anything missing, and guides you through the rest. You just answer its questions.
-
-**Agent setup checklist** *(the agent follows these steps; you respond when asked)*
-
-1. **Check git** — `git --version`. If missing:
-   - Mac: `xcode-select --install`
-   - Windows: `winget install --id Git.Git -e --source winget` (or download from [git-scm.com/download/win](https://git-scm.com/download/win))
-
-2. **Clone the toolkit**
-   ```bash
-   git clone https://github.com/chaz-clark/canvas-toolbox.git canvas_toolbox
-   ```
-
-3. **Check uv** — `uv --version`. If missing:
-   - Mac/Linux: `curl -LsSf https://astral.sh/uv/install.sh | sh`
-   - Windows: `powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"`
-
-4. **Install dependencies** (one-time)
-   ```bash
-   cd canvas_toolbox && uv sync && cd ..
-   ```
-
-5. **Create config files**
-   ```bash
-   cp canvas_toolbox/scaffold/.env.example .env
-   cp canvas_toolbox/scaffold/gitignore .gitignore
-   ```
-
-6. **Collect Canvas credentials** — you'll need:
-   - **Course ID** — the number after `/courses/` in your Canvas course URL
-   - **API token** — Canvas → Account → Settings → Approved Integrations → New Access Token (requires instructor or admin role)
-   - **Institution URL** — your Canvas login address (e.g., `https://byui.instructure.com`)
-
-7. **Fill in `.env`** with your credentials:
-   ```
-   CANVAS_API_TOKEN=your_token
-   CANVAS_BASE_URL=https://your-institution.instructure.com
-   CANVAS_COURSE_ID=123456
-   ```
-
-8. **Pull the course**
-   ```bash
-   uv run python canvas_toolbox/lib/tools/canvas_sync.py --init
-   ```
-   This mirrors the entire course — modules, pages, assignments, quizzes, discussions, syllabus — into a `course/` folder. Takes about a minute.
-
----
-
-### Option B — Manual setup
-
-Use this if you prefer to run each step yourself, or if your AI tool doesn't run terminal commands.
-
-**Open a terminal:**
-- **Mac:** Cmd + Space → type "Terminal" → Enter
-- **Windows:** Windows key → type "PowerShell" → Enter
-
-#### Fast path — `cb-init` (3 lines, fully interactive, any OS)
-
-```bash
-git clone https://github.com/chaz-clark/canvas-toolbox.git canvas-toolbox
-cd canvas-toolbox
-uv run python lib/tools/cb_init.py
-```
-
-`cb-init` is **idempotent** — re-running is safe and fast. It installs `uv` if missing, installs Python 3.14, writes a `.env` stub (then stops so you can fill in your Canvas credentials), installs all dev tools, smoke-tests your Canvas API token, and surfaces `AGENTS.md`.
-
-Useful flags:
-
-| Flag | Use |
-|---|---|
-| `--check` | Dry-run: shows what each step would do, writes nothing |
-| `--yes` | Skip all y/n prompts (for CI / Codespaces) |
-| `--skip-playwright` | Skip the 92 MB Chromium download |
-
-If `cb-init` runs cleanly, skip the rest of Option B and go straight to **"Pull your course"**.
-
-#### Manual long path
-
-```bash
-git clone https://github.com/chaz-clark/canvas-toolbox.git canvas_toolbox
-cd canvas_toolbox && uv sync && cd ..
-cp canvas_toolbox/scaffold/.env.example .env
-cp canvas_toolbox/scaffold/gitignore .gitignore
-```
-
-Then fill in `.env` with your Canvas credentials (see the agent checklist above, step 6 + 7).
-
-> **Can't see the `.env` file?** Its name starts with a dot, which hides it by default. **Mac:** Cmd + Shift + . in Finder. **Windows:** File Explorer → View → check "Hidden items".
-
-**Pull your course:**
-```bash
-uv run python canvas_toolbox/lib/tools/canvas_sync.py --init
-```
-
----
-
-### Option C — A colleague is setting it up for you
-
-Gather three pieces of information and hand them over:
+That's it. The agent handles git, `uv`, Python, dependencies, and the `.env` file. You'll just need to provide three pieces of information when it asks:
 
 - **Course ID** — the number after `/courses/` in your Canvas course URL
 - **API token** — Canvas → Account → Settings → Approved Integrations → New Access Token (requires instructor or admin role)
 - **Institution URL** — your Canvas login address (e.g., `https://byui.instructure.com`)
 
-Share them in this format:
+Total time on a fresh machine: ~5 minutes (most of it is the agent installing dependencies in the background).
+
+---
+
+### If a colleague is setting it up for you
+
+Just hand them those three pieces of information in this format:
 
 ```
 CANVAS_API_TOKEN=your_token_here
@@ -309,15 +194,53 @@ They'll handle the rest.
 
 ---
 
-### Already have an older canvas-toolbox setup? Migrate it.
+> **Already have an older canvas-toolbox setup?** Ask your agent to run `python3 canvas-toolbox/scaffold/migrate_to_clone_layout.py` — it dry-runs by default, reports what it would change, and only writes when you re-run with `--apply`.
 
-If you have a Canvas course repo with an *older* canvas-toolbox layout — vendored as a git subtree, or in a folder your parent repo still tracks — there's a one-command migration:
+---
 
-```bash
-python3 canvas-toolbox/scaffold/migrate_to_clone_layout.py
-```
+# Architecting a course with AI assistance
 
-**Dry-run by default** — inspects your repo, reports its state, prints the exact plan it would run. Re-run with `--apply` to execute. Backs up existing canvas-toolbox content to `/tmp/` before changing anything. Safe to run on a setup that's already correct (reports *"Already on the new layout. Nothing to do."*).
+**Canvas Toolbox isn't only for existing courses — the agent can help you build one.**
+
+The toolkit ships with **20+ pedagogical knowledge files** the agent reads when you're designing or redesigning a course. You stay the architect; the AI is the assistant — it asks questions, surfaces tradeoffs, and writes drafts you approve.
+
+**What the agent has on hand:**
+
+| Topic | Knowledge surface |
+|---|---|
+| **Backwards design** | Wiggins & McTighe Understanding by Design — outcomes → evidence → activities |
+| **Designer thinking** | BYUI's 5-stage course-design process |
+| **Learning models** | Hattie 3-phase (Surface → Deep → Transfer), Merrill's First Principles, Kolb experiential cycle, inverted Bloom's |
+| **CLO quality** | BYUI Assurance of Learning 6-criteria rubric, Bloom's revised taxonomy, three domains (cognitive / affective / psychomotor) |
+| **Assessment design** | Formative vs summative, evidence-centered design, AI-era productive friction |
+| **Rubric design** | AAC&U VALUE rubrics + 4-criterion backbone; analytic / holistic / single-point / developmental |
+| **Workload calibration** | Carnegie credit-hour budget + Wake Forest workload estimator |
+| **Cognitive load** | Sweller's CLT — intrinsic / extraneous / germane load management |
+| **Course design standards** | BYUI Campus Online + NWCCU cross-walk |
+| **Content representation** | Multiple representations, accessibility (WCAG 2.1 AA), universal design |
+| **Critical thinking** | Paul-Elder framework; embedding intellectual standards into tasks |
+| **Course design language** | Shared vocabulary so the agent and faculty mean the same thing |
+
+**Ask your agent:**
+
+> *"Help me design a new course on [topic]. It's [X credits] / [length weeks]. The outcomes I have in mind are [...]."*
+>
+> Or, for an existing course you want to improve:
+>
+> *"Architect a redesign of this course — start with the CLOs and work outward."*
+
+**The agent walks you through:**
+
+1. **CLOs (Course Learning Outcomes)** — drafted and refined against the BYUI AoL 6-criteria rubric; measurable, aligned, appropriately scoped
+2. **Assessment plan (backward design)** — what evidence demonstrates each CLO; pick formative vs summative; design for AI-resistant evidence where it matters
+3. **Module sequence** — Hattie 3-phase, Merrill's First Principles, Kolb cycle, or experience-first — pick the framework that fits your discipline
+4. **Rubric drafts** — analytic / holistic / single-point / developmental — agent recommends based on the assessment type, then drafts the rubric
+5. **Workload calibration** — Carnegie credit-hour budget; distribution across the term; flag overloaded weeks before you publish
+6. **Accessibility + AI-era design** — WCAG 2.1 AA defaults; productive friction patterns for AI-resistant evidence
+
+**You can write the artifacts straight into your Canvas course (via the sync tools), into a `course/` folder for review first, or into a fresh repo if you haven't pulled anything yet.**
+
+For an existing course you want to *improve* (not redesign), start with the [full health check](#auditing-your-course) — the audit reports surface what to redesign first.
 
 ---
 
@@ -502,6 +425,6 @@ The architecture (FERPA two-zone, voice-preservation contract, consensus-based g
 
 ---
 
-**Current version:** v0.69.x · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 483 unit tests · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
+**Current version:** v0.69.1 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 483 unit tests · 20+ pedagogical knowledge files for AI-architected course design · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
 
 For help, see the doc tree above or file a `cb-report-bug` (~1 second roundtrip; no GitHub account needed).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "0.69.0"
+version = "0.69.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "0.69.0"
+version = "0.69.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Two operator-flagged README issues:

- **Setup steps had too many forks** — the non-technical agent-driven prompt was buried under TL;DR one-liner + Option B (cb-init + manual long path). Cut Option B and TL;DR entirely; promoted the agent prompt as THE path. Faculty pastes one prompt; the agent handles git/uv/Python/deps. Option C (colleague-handover) and the migration paragraph kept as a small sub-section + one-line footer.
- **AI architect capability not surfaced** — the toolkit ships with 20+ pedagogical knowledge files (backwards design, Hattie, Merrill, Kolb, CLT, AAC&U rubrics, Carnegie workload, etc.) that the agent uses when designing a NEW course. README only documented audit/sync/grade flows. Added a 10th agent-prompt row and a NEW dedicated section "Architecting a course with AI assistance" between Step 3 and Auditing.

Docs-only. No code changes. Version triple-sync 0.69.0 → 0.69.1.

## What changed

- `README.md` — Step 3 streamlined (Options A/B/TL;DR collapsed into one prompt + 3 credentials); 10th workflow row in the agent-prompt table; NEW "Architecting a course" section with 22-knowledge-file table; trailing version line updated
- `AGENTS.md` — Active Context entry for v0.69.1
- `pyproject.toml`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `uv.lock` — version triple-sync 0.69.0 → 0.69.1

## Test plan

- [x] 483 tests still pass (7 pre-existing sprint failures unrelated, present on main)
- [x] Pre-commit hooks pass (ruff/actionlint/shellcheck skipped — no relevant files changed)
- [ ] GH-render README and confirm:
  - [ ] Step 3 reads as a single clear path (paste prompt → answer 3 questions → done)
  - [ ] "Design or improve a course (AI architect)" row appears in the workflow table
  - [ ] "Architecting a course with AI assistance" section is well-positioned between Step 3 and Auditing
  - [ ] Knowledge-file table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
