### PR TITLE
feat: course-wide de-id master + per-student late-work accommodation (v0.70.0, closes #109)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "canvas-toolbox",
       "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Includes agent specs (8) and pedagogical knowledge files (20+) covering course design audits, FERPA-safe LLM grading, Canvas sync, and the BYU-I Learning Model.",
-      "version": "0.69.1",
+      "version": "0.70.0",
       "source": "./",
       "author": {
         "name": "Chaz Clark",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "canvas-toolbox",
   "displayName": "canvas-toolbox",
   "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Agent specs cover course audits (rubric coverage / quality, syllabus, CLO quality, alignment chain, accessibility, workload, grading structure / load, formative variety, learning model), Canvas sync paths (course / blueprint / Page-level orphan cleanup), and a generic LLM-grading pipeline (de-identify → consensus → reconcile → push). Knowledge files cover Canvas API + lessons learned, rubrics, assessments, backwards design, cognitive load theory, Hattie 3-phase, Merrill's First Principles, BYU-I Learning Model, BYUI Course Design Standards, and 14+ other pedagogical frameworks. Brain-agnostic by design: the LLM provider is your choice.",
-  "version": "0.69.1",
+  "version": "0.70.0",
   "author": {
     "name": "Chaz Clark",
     "url": "https://github.com/chaz-clark"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,74 @@ private channel is for security.
 
 _Last updated: 2026-06-26_
 
-### Recent: README streamline — cut technical setup options + surface AI architect capability (v0.69.1, 2026-06-26)
+### Recent: Course-wide de-id master + per-student late-work accommodation primitives (v0.70.0, 2026-06-26)
+
+**v0.70.0** — closes issue #109 (agent-submitted ~10 min after v0.69.1
+shipped, from the DS 460 pilot). Two related primitives + four-mode
+scoping + the README cleanups Chaz flagged mid-build.
+
+**The missing primitive** — until v0.70.0, the toolkit could de-identify
+within a single grading workflow (per-assignment keymaps) and could
+scrub names (.known_names.txt) but had NO course-wide stable
+`code ↔ user_id ↔ name` surface. That's the primitive every keyed /
+FERPA workflow actually wants — and it's what enables the accommodation
+tool to take `--deid-code S-95DBB6` instead of `--user-id 173819`
+(so the operator never speaks the student's name to the agent).
+
+**What landed:**
+
+1. **`lib/tools/build_deid_master.py`** — fetches Canvas People with
+   ALL enrollment states (active + invited + inactive + completed),
+   hashes user_id → `S-XXXXXX` (6 hex from sha256, configurable
+   prefix + hash-bits), writes `grading/.deid_master.csv` (FERPA
+   tier 2). Auto-writes `grading/.gitignore` to make tier 2 bulletproof.
+   Detects collisions at write-time with clear recovery message
+   (`--hash-bits 8`). Default prefix `S-`; opt out via `--prefix`.
+
+2. **`lib/tools/student_late_accommodation.py`** — lifted from DS 460
+   pilot + generalized. Writes per-student assignment overrides that
+   keep `unlock_at` + `due_at` but omit `lock_at` (no close date).
+   **Four scoping modes** (the v0.70.0 mid-build operator ask):
+   - `--assignment-id` — ONE assignment
+   - `--all` — every published, backdated
+   - `--from YYYY-MM-DD` — due on/after a specific date
+   - `--from-days-ago N` — rolling window (recommended default; e.g.
+     `--from-days-ago 14` = last 2 weeks through end of term)
+   Resolves student via `--user-id` OR `--deid-code` (PII-free).
+   `--remove` flag works with any scope.
+
+3. **`lib/agents/knowledge/deid_master_knowledge.md`** — the
+   4-column contract, collision math, FERPA tier 2 explanation,
+   how downstream tools should consume the master (never read
+   `sortable_name` unless explicit).
+
+4. **54 new tests passing** (543 passing total, up from 489;
+   Title IV pure-helper pattern continued — function in/out, no
+   Canvas API mocking).
+
+5. **README mid-build tweaks** (Chaz-flagged):
+   - Step 3 prompt now explicitly invokes `cb-init` (so the agent
+     uses our purpose-built idempotent bootstrap, not its own ad-hoc
+     sequence)
+   - `byui.instructure.com` → `your-institution.instructure.com`
+     (generic across institutions)
+   - "Who uses it" section DROPPED (was leading with BYUI specifics)
+   - "Sharing back with the project" SIMPLIFIED from a technical
+     PATH/fallback wall to a 3-row agent-prompt table
+   - 11th workflow row added: "Give one student late-work accommodation"
+   - NEW dedicated section "Per-student late-work accommodation"
+     with the 4-mode scope table
+   - Trailing version line names the new primitives
+
+**Field validation** (from issue #109 author):
+- DS 460 pilot: 1 real student, 36 assignments, `--all` applied
+  cleanly — every override kept original open/due with lock=null
+- 30 active → 37 total → 7 withdrawn surfaced (the `withdrawn` flag's
+  value, hidden by the active-only People view)
+- Canvas GET overrides slow-path caveat baked into the tool: APPLY
+  POSTs directly without listing existing overrides; only REMOVE reads
+
+### Earlier: README streamline — cut technical setup options + surface AI architect capability (v0.69.1, 2026-06-26)
 
 **v0.69.1** — docs-only patch. Two operator-flagged issues:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That's the grading workflow. The toolbox does more — audits, sync, sharing, se
 
 ## What you can ask your AI agent to do
 
-Ten workflows. Each one is a prompt your agent can act on.
+Eleven workflows. Each one is a prompt your agent can act on.
 
 | You want to… | Ask your agent | What happens |
 |---|---|---|
@@ -52,6 +52,7 @@ Ten workflows. Each one is a prompt your agent can act on.
 | **Pull New Quiz response data** | *"Pull the per-student responses from quiz <id>"* | The New Quizzes API doesn't expose responses directly; the toolkit reads them via the student-analysis report. FERPA-safe by default (uid-keyed; names opt-in). |
 | **Grade an assignment end-to-end** | *"Grade the KC1 assignment"* | Fetch → de-identify → 3-pass consensus → review surface (`_all_comments.md`) → push gated behind `--mark-reviewed`. You approve every grade. |
 | **Run a UW / UF check (Title IV)** | *"Run a UW check with UF date 2026-04-15"* or *"Last participation report"* | Classifies each enrolled student as ACTIVE / UW / UF / NEVER_PARTICIPATED by their last academically related activity vs your UF cutoff. PDF + MD report drops in **~/Downloads/** (outside the repo — FERPA tier 3). Compliant with 34 CFR 668.22 + the 2025-2026 FSA Handbook (verified 2026-06-26). |
+| **Give one student late-work accommodation** | *"Give student S-95DBB6 late-work grace for the rest of the semester"* / *"…starting from the last 2 weeks"* / *"…on assignment 1234 only"* | Writes per-student assignment overrides that keep the original open + due dates but **drop the close date** — so the student can submit after the deadline (marked late, still accepted) without affecting the class. **4 scoping modes**: one assignment, whole semester, from a date forward, or rolling window (e.g. last 14 days through end of term). Resolves the target student PII-free via the [de-id master](#the-de-id-master--the-primitive-under-everything). |
 | **Share your grader with another faculty teaching the same course** | *"Bundle this course's rubrics and configs to share with another faculty"* | Exports a ZIP with rubrics, task specs, configs, course-level pitfalls. Your personal voice file is REFUSED by the export — by design. They build their own voice. |
 | **Roll out a new semester** | *"Sync my master course to the spring section"* | Master → Blueprint; Canvas handles section distribution. Safety gates keep section edits from leaking back to master. |
 
@@ -168,13 +169,13 @@ Use the subscription you **already have** so you don't pay twice. In your IDE, o
 
 **Create an empty folder on your computer, open it in the IDE you set up in Steps 1 and 2, and paste this prompt to your AI assistant:**
 
-> *"Help me set up Canvas Toolbox for my Canvas course. The toolkit is at https://github.com/chaz-clark/canvas-toolbox — please clone it, install dependencies, and walk me through connecting it to my course."*
+> *"Help me set up Canvas Toolbox for my Canvas course. Please clone https://github.com/chaz-clark/canvas-toolbox into this folder, run `cb-init` to bootstrap everything, and walk me through filling in my Canvas credentials when it pauses."*
 
-That's it. The agent handles git, `uv`, Python, dependencies, and the `.env` file. You'll just need to provide three pieces of information when it asks:
+That's it. `cb-init` is our one-command bootstrap — it installs `uv` and Python, writes a `.env` stub, syncs dependencies, smoke-tests your Canvas API token, and is **idempotent** (safe to re-run). You'll just need to provide three pieces of information when it asks:
 
 - **Course ID** — the number after `/courses/` in your Canvas course URL
 - **API token** — Canvas → Account → Settings → Approved Integrations → New Access Token (requires instructor or admin role)
-- **Institution URL** — your Canvas login address (e.g., `https://byui.instructure.com`)
+- **Institution URL** — your Canvas login address (e.g., `https://your-institution.instructure.com`)
 
 Total time on a fresh machine: ~5 minutes (most of it is the agent installing dependencies in the background).
 
@@ -186,7 +187,7 @@ Just hand them those three pieces of information in this format:
 
 ```
 CANVAS_API_TOKEN=your_token_here
-CANVAS_BASE_URL=https://byui.instructure.com
+CANVAS_BASE_URL=https://your-institution.instructure.com
 CANVAS_COURSE_ID=123456
 ```
 
@@ -339,6 +340,61 @@ Full audit documentation: [`course_engagement_audit_knowledge.md`](lib/agents/kn
 
 ---
 
+# Per-student late-work accommodation
+
+When ONE student needs permission to submit late — for any reason, on some or all assignments — the toolkit writes Canvas **assignment overrides** that keep the original open and due dates but **drop the close date**. The student still sees the original due date (no artificial deadline extension shown), but submitting after it stays accepted, marked "late." The class is unaffected.
+
+## Four scoping modes
+
+Pick the one that matches the accommodation you're granting:
+
+| Scope flag | What it covers | When you'd use it |
+|---|---|---|
+| `--assignment-id <id>` | ONE specific assignment | Single missed item with a known reason |
+| `--all` | EVERY published assignment | Whole-semester grace (backdates retroactively too) |
+| `--from YYYY-MM-DD` | Assignments due on/after the date | "From spring break onward" / specific start date |
+| `--from-days-ago N` | Assignments due in the last N days through end of term | **Recommended default** — *"They hit the wall 1-2 weeks ago; grace from there forward."* Try `--from-days-ago 14`. |
+
+```bash
+# Preview (dry-run by default — use --apply to actually write)
+uv run python lib/tools/student_late_accommodation.py \
+  --deid-code S-95DBB6 --from-days-ago 14
+
+# Apply for one specific assignment
+uv run python lib/tools/student_late_accommodation.py \
+  --deid-code S-95DBB6 --assignment-id 123 --apply
+
+# Apply from a specific date forward (rest of semester)
+uv run python lib/tools/student_late_accommodation.py \
+  --deid-code S-95DBB6 --from 2026-04-01 --apply
+
+# Apply across whole semester with backdating
+uv run python lib/tools/student_late_accommodation.py \
+  --deid-code S-95DBB6 --all --apply
+
+# Undo cleanly — same scope flags work for --remove
+uv run python lib/tools/student_late_accommodation.py \
+  --deid-code S-95DBB6 --from-days-ago 14 --remove --apply
+```
+
+## The de-id master — the primitive under everything
+
+`--deid-code S-95DBB6` resolves to a Canvas user_id **without anyone ever speaking the student's name to the agent**. That works because of a new primitive in v0.70.0: a **course-wide de-identification master** at `grading/.deid_master.csv` (gitignored, FERPA tier 2).
+
+Build it once, refresh when your roster changes:
+
+```bash
+uv run python lib/tools/build_deid_master.py
+```
+
+One row per enrolled student, four columns: `deid_code, user_id, sortable_name, withdrawn`. The `withdrawn` flag catches students who dropped mid-semester — the default Canvas People view silently hides them, and that's how 7 dropped students went missing from one pilot's final-grade analysis until this primitive existed.
+
+**You** look up "Sydney" in the local CSV → see `S-95DBB6` → hand the agent only that code. The tool reads only the `user_id` column. Names never cross the LLM boundary.
+
+Full knowledge file: [`deid_master_knowledge.md`](lib/agents/knowledge/deid_master_knowledge.md).
+
+---
+
 # Sharing your grader with another faculty
 
 When two faculty teach the same Canvas course, the second one shouldn't start from scratch.
@@ -365,53 +421,17 @@ Full sharing pattern: [`grader_knowledge.md §17`](lib/agents/knowledge/grader_k
 
 ---
 
-# Who uses it
-
-- **BYU-Idaho** (institutional pilot) — multiple faculty across DS 250, DS 460, and CE 162 (Land Surveying)
-- **DS 250 Online** — ~448 student-cohort observations across 27 sections (the deepest production validation; the 11 safety gates were driven by lived failures in DS 250 grading)
-- **CE 162 Land Surveying** — first non-DS adoption; filed the group-assignment workflow enhancement that became v0.64.0 with a fully-worked local prototype
-
-If you're piloting at another institution, file an issue (see below). Adoption stories shape the next safety gate.
-
----
-
 # Sharing back with the project
 
-Three lightweight paths, all under one tool:
+Three things you can ask your agent to do:
 
-```bash
-./bin/cb-report-bug    # report a bug (auto-prefix: bug:)
-./bin/cb-report-bug    # request a feature (auto-prefix: enhancement:)
-./bin/cb-share         # share something you built locally (auto-prefix: share:)
-```
-
-These open your editor for a description, scrub PII locally (names, emails, `/Users` paths), bundle your toolkit version + last 150 log lines + sanitized cwd, and post to a Cloudflare-fronted intake worker that files the GitHub issue using the maintainer's PAT. **No GitHub account required.** Roundtrip: ~1 second.
-
-| You want to… | Use | What happens |
+| You want to… | Ask your agent | What happens |
 |---|---|---|
-| **Report a bug** (toolkit deviated from documented behavior) | `cb-report-bug` with title `bug: <short description>` | Files an issue tagged `agent-submitted`. ~1 second. |
-| **Request a feature** | `cb-report-bug` with title `enhancement: <short description>` | Same path; title prefix triages it. |
-| **Share something you built** (a tool, config, workflow extension) | `cb-share` with title `share: <short description>` + a body that links or pastes the code | Same path; `share:` prefix tells the maintainer this is contribution-shaped. |
-| **Push code via a PR** | Standard GitHub PR workflow | See [`CONTRIBUTING.md`](CONTRIBUTING.md). |
+| **Report a bug** | *"Report a bug: [what went wrong]"* | Agent runs `cb-report-bug`. Opens your editor for the description, scrubs PII locally (names, emails, `/Users` paths), bundles your toolkit version + last 150 log lines, files the GitHub issue. ~1 second. No GitHub account needed. |
+| **Ask for a feature** | *"Ask for this feature: [what you want]"* | Same path as bug reporting; the title prefix triages it. |
+| **Share something you built** | *"Share this with the project: [link / paste]"* | Agent runs `cb-share`. Same intake path; `share:` prefix tells the maintainer this is contribution-shaped. |
 
-**Want shorter commands?** Put `bin/` on your PATH:
-
-```bash
-echo 'export PATH="'"$(pwd)"'/bin:$PATH"' >> ~/.zshrc   # or ~/.bashrc
-source ~/.zshrc
-# now: cb-init, cb-report-bug, cb-share work from anywhere
-```
-
-**Fallbacks** (work if `bin/` isn't on PATH):
-
-```bash
-uv run python lib/tools/cb_report_bug.py    # long-form, equivalent
-gh issue create -R chaz-clark/canvas-toolbox  # if you have gh + a GitHub account
-```
-
-Or go directly: <https://github.com/chaz-clark/canvas-toolbox/issues/new>.
-
-The bug-intake loop is the heartbeat of this project. Eleven issues filed via the worker have closed in the last three days — every one drove a coded safety gate. If you find a hole, fill it via the worker. The loop closes within hours.
+The intake loop is fast — issues filed via the worker have been driving new safety gates within hours.
 
 ---
 
@@ -425,6 +445,6 @@ The architecture (FERPA two-zone, voice-preservation contract, consensus-based g
 
 ---
 
-**Current version:** v0.69.1 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 483 unit tests · 20+ pedagogical knowledge files for AI-architected course design · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
+**Current version:** v0.70.0 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 543 unit tests · 20+ pedagogical knowledge files for AI-architected course design · course-wide de-id master + per-student accommodation primitives · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
 
 For help, see the doc tree above or file a `cb-report-bug` (~1 second roundtrip; no GitHub account needed).

--- a/lib/agents/knowledge/deid_master_knowledge.md
+++ b/lib/agents/knowledge/deid_master_knowledge.md
@@ -1,0 +1,153 @@
+# De-identification master — the foundational primitive
+
+**The missing primitive that sits underneath every keyed / FERPA workflow.**
+
+Status: introduced in v0.70.0 (2026-06-26) per issue #109.
+Built by: `lib/tools/build_deid_master.py`.
+Consumed by: `lib/tools/student_late_accommodation.py`, and future
+keyed-grading + PR-check tools.
+
+---
+
+## Why this exists
+
+Before v0.70.0, the canvas-toolbox had two ways to identify a student
+PII-free:
+
+- **Per-assignment keymaps** — generated during `grader_fetch` for each
+  assignment. The same student gets a DIFFERENT key in each set, tied
+  to the assignment's filenames. Useful for the grading pipeline; not
+  useful for course-wide cross-tool reference.
+- **`.known_names.txt`** — flat name roster used by the scrub pass.
+  Has no stable id surface.
+
+What's been missing: a **course-wide stable** `code ↔ user_id ↔ name`
+master. One row per enrolled student. Same code for the same student
+across every tool, every run, every refresh. That's what this file is.
+
+---
+
+## The 4-column contract
+
+```csv
+deid_code,user_id,sortable_name,withdrawn
+S-95DBB6,173819,"Ahlstrom, Sydney",0
+S-A8FE4E,18065,"Alfaia Monteiro, Ronaldo",1
+```
+
+| Column | Type | Meaning | Read by tools? |
+|---|---|---|---|
+| `deid_code` | `str` | Stable opaque code, format `<prefix><N-hex-chars>` | YES — primary key |
+| `user_id` | `int` | Canvas numeric user_id, source of truth | YES — for API calls |
+| `sortable_name` | `str` | `"Lastname, Firstname"` from Canvas | **NO** unless explicit |
+| `withdrawn` | `int` | `1` if enrollment is `inactive`/`completed`/`deleted`, else `0` | YES — for analysis |
+
+**The `sortable_name` column is for the OPERATOR's local lookup only.**
+Tools must not read it (and must not echo it) unless the operator has
+explicitly requested re-identification (e.g., the Title IV report's
+final step, which writes outside the repo).
+
+---
+
+## How `deid_code` is computed
+
+```python
+deid_code = f"{prefix}{sha256(str(user_id))[:hash_bits].upper()}"
+```
+
+- **Default prefix:** `S-` (Student). Override via `--prefix DS-` or similar.
+- **Default hash bits:** 6 hex chars. Format example: `S-95DBB6`.
+- **Stable:** same `user_id` → same `deid_code` across every run.
+- **Order-free:** doesn't depend on roster position or fetch order.
+- **Collision-aware:** the build tool detects duplicates at write-time
+  and errors out with instructions to re-run with `--hash-bits 8`.
+
+Collision math (sha256 first N hex chars, birthday paradox):
+
+| Hash bits | Collision-free space | 50 students | 200 | 500 | 1000 | 5000 |
+|---|---|---|---|---|---|---|
+| 6 | 16M | 0.007% | 0.12% | 0.7% | 3% | — |
+| 8 | 4B | — | — | 0.003% | 0.01% | 0.3% |
+| 10 | 1T | practically collision-free at any class size |
+
+For typical 30–200 student courses, 6 hex is safe and far more typeable
+(`S-95DBB6` vs `S-95DBB6A8`).
+
+---
+
+## Why `withdrawn` matters
+
+The default Canvas People view shows ACTIVE students only. Final-grade
+analysis, last-engagement audits (`course_engagement_audit.py`), and
+accommodations frequently need visibility into students who **dropped
+mid-semester** (state: `inactive` / `completed` / `deleted`).
+
+In one DS 460 pilot: **30 active → 37 total → 7 withdrawn**.
+
+The withdrawn flag lets downstream tools either include or exclude
+withdrawn students depending on the use case (engagement audit:
+include; gradebook reconcile: probably include; accommodation: usually
+exclude — withdrawn students don't need accommodations).
+
+---
+
+## FERPA tier — gitignored repo file (tier 2)
+
+This file lives in the repo at `grading/.deid_master.csv` but is
+**git-ignored**. The build tool writes a `grading/.gitignore` (containing
+`*`) the first time it creates the directory — so even if the operator
+forgets to add `grading/` to their main `.gitignore`, the directory's own
+`.gitignore` prevents tracked commits.
+
+| Tier | Surface | What lives here | Defense |
+|---|---|---|---|
+| 1 (cloud) | LLM token I/O | deid_code only; never user_id or name | The keymap is here |
+| **2 (gitignored repo file)** | **local filesystem in repo** | **`.deid_master.csv`, keymaps, `.known_names.txt`, `.env`** | **`grading/.gitignore`** |
+| 3 (outside repo) | `~/Downloads/` | Named PDF / MD reports | LLM has no cwd access there |
+
+---
+
+## How downstream tools consume the master
+
+**Resolve `deid_code` → `user_id`, read ONLY the user_id column:**
+
+```python
+from lib.tools.build_deid_master import resolve_user_id_from_master  # pseudo
+uid = resolve_user_id_from_master(Path("grading/.deid_master.csv"), "S-95DBB6")
+# uid is now 173819. sortable_name was never read.
+```
+
+**Reference implementation:** `lib/tools/student_late_accommodation.py`
+(`resolve_user_id_from_master`) — reads only the `user_id` column, raises
+clear errors when the master doesn't exist or the code isn't present.
+
+**Operators tell their agent:**
+> *"Give student S-95DBB6 late-work accommodation on all assignments."*
+
+The agent passes the code (not the name) to the tool. The tool resolves
+the code locally. The name never crosses the LLM boundary.
+
+---
+
+## Refresh discipline
+
+Re-run `build_deid_master.py` when:
+
+- New students enroll
+- Students drop / are dropped
+- The enrollment-state field flips (inactive → active or vice versa)
+
+The tool refuses to overwrite an existing master without `--force`. This
+is a deliberate friction point — re-running silently could invalidate
+deid_code references in operator notes / handoffs / Slack messages.
+Always check the diff (`git diff` won't help — file is gitignored —
+but `--dry-run` previews changes).
+
+---
+
+## Related knowledge
+
+- `grader_knowledge.md §1` — the three FERPA tiers + zone discipline
+- `course_engagement_audit_knowledge.md` — Title IV pattern; also uses
+  re-identification at the last step
+- Issue #109 — the original ask that led to this primitive

--- a/lib/tests/test_build_deid_master_helpers.py
+++ b/lib/tests/test_build_deid_master_helpers.py
@@ -1,0 +1,246 @@
+"""Tier 1 unit tests — build_deid_master pure-logic helpers.
+
+Source: lib/tools/build_deid_master.py
+  - deid_code_for       (sha256-based stable hash)
+  - is_withdrawn        (enrollment-state classification)
+  - student_to_row      (full record builder)
+  - detect_collisions   (defense against rare hash collisions)
+  - render_csv_rows     (deterministic CSV output)
+
+No Canvas API calls. No filesystem writes. Pure functions in/out.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from build_deid_master import (  # noqa: E402
+    StudentRow,
+    deid_code_for,
+    detect_collisions,
+    is_withdrawn,
+    render_csv_rows,
+    student_to_row,
+)
+
+
+# ---------------------------------------------------------------------------
+# deid_code_for — the stable hash
+# ---------------------------------------------------------------------------
+
+def test_deid_code_deterministic():
+    """Same user_id → same code, every run."""
+    assert deid_code_for(173819) == deid_code_for(173819)
+
+
+def test_deid_code_different_users_different_codes():
+    """Different user_ids → different codes (almost always)."""
+    assert deid_code_for(173819) != deid_code_for(18065)
+
+
+def test_deid_code_default_format():
+    """Default: S- prefix, 6 hex chars uppercase."""
+    code = deid_code_for(173819)
+    assert code.startswith("S-")
+    body = code[2:]
+    assert len(body) == 6
+    assert body.isalnum()
+    assert body.upper() == body
+
+
+def test_deid_code_custom_prefix():
+    code = deid_code_for(173819, prefix="DS-")
+    assert code.startswith("DS-")
+    assert len(code) == 3 + 6  # "DS-" + 6 hex
+
+
+def test_deid_code_custom_hash_bits():
+    """--hash-bits 8 should give an 8-char code body."""
+    code = deid_code_for(173819, hash_bits=8)
+    assert code.startswith("S-")
+    assert len(code[2:]) == 8
+
+
+def test_deid_code_int_or_str_user_id():
+    """int and str user_ids should hash identically — defends against
+    Canvas API returning user_id as int while operator passes a string."""
+    assert deid_code_for(173819) == deid_code_for(int("173819"))
+
+
+# ---------------------------------------------------------------------------
+# is_withdrawn — enrollment-state classification
+# ---------------------------------------------------------------------------
+
+def test_withdrawn_no_enrollments_returns_zero():
+    """A user with no enrollments isn't withdrawn (defensive default)."""
+    assert is_withdrawn([]) == 0
+    assert is_withdrawn(None) == 0
+
+
+def test_withdrawn_active_only():
+    assert is_withdrawn([{"enrollment_state": "active"}]) == 0
+
+
+def test_withdrawn_invited_only():
+    """Invited students haven't withdrawn yet — they're pending acceptance."""
+    assert is_withdrawn([{"enrollment_state": "invited"}]) == 0
+
+
+def test_withdrawn_inactive():
+    assert is_withdrawn([{"enrollment_state": "inactive"}]) == 1
+
+
+def test_withdrawn_completed():
+    assert is_withdrawn([{"enrollment_state": "completed"}]) == 1
+
+
+def test_withdrawn_deleted():
+    assert is_withdrawn([{"enrollment_state": "deleted"}]) == 1
+
+
+def test_withdrawn_active_wins_over_dropped():
+    """A student with BOTH an active and an inactive enrollment is NOT
+    withdrawn — the active record wins."""
+    enrollments = [
+        {"enrollment_state": "active"},
+        {"enrollment_state": "inactive"},
+    ]
+    assert is_withdrawn(enrollments) == 0
+
+
+def test_withdrawn_unknown_state_falls_back_to_zero():
+    """An unknown state (future Canvas API addition?) isn't auto-classified
+    as withdrawn. Safer default."""
+    assert is_withdrawn([{"enrollment_state": "creator"}]) == 0
+
+
+# ---------------------------------------------------------------------------
+# student_to_row — full record builder
+# ---------------------------------------------------------------------------
+
+def test_student_to_row_basic():
+    user = {
+        "id": 173819,
+        "sortable_name": "Ahlstrom, Sydney",
+        "enrollments": [{"enrollment_state": "active"}],
+    }
+    row = student_to_row(user, prefix="S-", hash_bits=6)
+    assert isinstance(row, StudentRow)
+    assert row.user_id == 173819
+    assert row.sortable_name == "Ahlstrom, Sydney"
+    assert row.withdrawn == 0
+    assert row.deid_code == deid_code_for(173819, "S-", 6)
+
+
+def test_student_to_row_missing_sortable_name_falls_back_to_name():
+    """Some Canvas users return `name` but not `sortable_name`
+    (rare but happens for Test Student / API service users)."""
+    user = {
+        "id": 999,
+        "name": "Service Account",
+        "enrollments": [{"enrollment_state": "active"}],
+    }
+    row = student_to_row(user, "S-", 6)
+    assert row.sortable_name == "Service Account"
+
+
+def test_student_to_row_missing_both_names():
+    """Defensive: missing both name and sortable_name → empty string,
+    not a crash."""
+    user = {"id": 999, "enrollments": [{"enrollment_state": "active"}]}
+    row = student_to_row(user, "S-", 6)
+    assert row.sortable_name == ""
+
+
+def test_student_to_row_withdrawn_student():
+    user = {
+        "id": 18065,
+        "sortable_name": "Alfaia Monteiro, Ronaldo",
+        "enrollments": [{"enrollment_state": "inactive"}],
+    }
+    row = student_to_row(user, "S-", 6)
+    assert row.withdrawn == 1
+
+
+# ---------------------------------------------------------------------------
+# detect_collisions — defends against rare sha256-prefix duplication
+# ---------------------------------------------------------------------------
+
+def test_no_collisions_returns_empty_list():
+    rows = [
+        StudentRow("S-AAAAAA", 1, "A", 0),
+        StudentRow("S-BBBBBB", 2, "B", 0),
+        StudentRow("S-CCCCCC", 3, "C", 0),
+    ]
+    assert detect_collisions(rows) == []
+
+
+def test_collision_detected():
+    rows = [
+        StudentRow("S-AAAAAA", 1, "A", 0),
+        StudentRow("S-AAAAAA", 2, "B", 0),  # collision
+        StudentRow("S-CCCCCC", 3, "C", 0),
+    ]
+    result = detect_collisions(rows)
+    assert len(result) == 1
+    code, uids = result[0]
+    assert code == "S-AAAAAA"
+    assert sorted(uids) == [1, 2]
+
+
+def test_multiple_collisions_all_reported():
+    rows = [
+        StudentRow("S-AAAAAA", 1, "A", 0),
+        StudentRow("S-AAAAAA", 2, "B", 0),
+        StudentRow("S-BBBBBB", 3, "C", 0),
+        StudentRow("S-BBBBBB", 4, "D", 0),
+    ]
+    result = detect_collisions(rows)
+    assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# render_csv_rows — deterministic CSV output
+# ---------------------------------------------------------------------------
+
+def test_render_csv_rows_header_first():
+    """The first row must be the header."""
+    rows = [StudentRow("S-AAAAAA", 1, "Alpha, A", 0)]
+    out = render_csv_rows(rows)
+    assert out[0] == ["deid_code", "user_id", "sortable_name", "withdrawn"]
+
+
+def test_render_csv_rows_sorted_by_name():
+    """Rows are sorted by sortable_name (case-insensitive) for
+    deterministic output across runs."""
+    rows = [
+        StudentRow("S-AAA", 1, "Zoe", 0),
+        StudentRow("S-BBB", 2, "Alice", 0),
+        StudentRow("S-CCC", 3, "Mark", 0),
+    ]
+    out = render_csv_rows(rows)
+    names = [r[2] for r in out[1:]]
+    assert names == ["Alice", "Mark", "Zoe"]
+
+
+def test_render_csv_rows_withdrawn_serialized_as_int_string():
+    """Withdrawn should be '0' or '1', not 'True' or 'False'."""
+    rows = [
+        StudentRow("S-AAA", 1, "A", 0),
+        StudentRow("S-BBB", 2, "B", 1),
+    ]
+    out = render_csv_rows(rows)
+    assert out[1][3] in ("0", "1")
+    assert out[2][3] in ("0", "1")
+    assert {out[1][3], out[2][3]} == {"0", "1"}
+
+
+def test_render_csv_rows_deterministic():
+    """Two runs over the same input produce identical output."""
+    rows = [
+        StudentRow("S-AAA", 1, "A", 0),
+        StudentRow("S-BBB", 2, "B", 1),
+    ]
+    assert render_csv_rows(rows) == render_csv_rows(rows)

--- a/lib/tests/test_student_late_accommodation_helpers.py
+++ b/lib/tests/test_student_late_accommodation_helpers.py
@@ -1,0 +1,295 @@
+"""Tier 1 unit tests — student_late_accommodation pure-logic helpers.
+
+Source: lib/tools/student_late_accommodation.py
+  - resolve_user_id_from_master  (CSV lookup, PII-aware)
+  - build_override_payload       (override POST body construction)
+  - filter_my_overrides          (per-student override filter)
+
+No Canvas API calls. The CSV lookup uses tmp_path fixtures.
+"""
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from student_late_accommodation import (  # noqa: E402
+    build_override_payload,
+    cutoff_from_days_ago,
+    filter_assignments_by_due_from,
+    filter_my_overrides,
+    resolve_user_id_from_master,
+)
+
+
+# ---------------------------------------------------------------------------
+# resolve_user_id_from_master — CSV lookup
+# ---------------------------------------------------------------------------
+
+def _write_master(tmp_path: Path, rows: list[dict]) -> Path:
+    """Helper to write a small deid master CSV for testing."""
+    p = tmp_path / ".deid_master.csv"
+    with p.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["deid_code", "user_id",
+                                            "sortable_name", "withdrawn"])
+        w.writeheader()
+        for r in rows:
+            w.writerow(r)
+    return p
+
+
+def test_resolve_basic(tmp_path):
+    p = _write_master(tmp_path, [
+        {"deid_code": "S-95DBB6", "user_id": "173819",
+         "sortable_name": "Ahlstrom, Sydney", "withdrawn": "0"},
+    ])
+    assert resolve_user_id_from_master(p, "S-95DBB6") == 173819
+
+
+def test_resolve_case_insensitive(tmp_path):
+    """Operator can type s-95dbb6 or S-95DBB6 — both work."""
+    p = _write_master(tmp_path, [
+        {"deid_code": "S-95DBB6", "user_id": "173819",
+         "sortable_name": "Ahlstrom, Sydney", "withdrawn": "0"},
+    ])
+    assert resolve_user_id_from_master(p, "s-95dbb6") == 173819
+    assert resolve_user_id_from_master(p, "S-95dbb6") == 173819
+
+
+def test_resolve_strips_whitespace(tmp_path):
+    """Tolerate trailing/leading whitespace from copy-paste."""
+    p = _write_master(tmp_path, [
+        {"deid_code": "S-95DBB6", "user_id": "173819",
+         "sortable_name": "Ahlstrom, Sydney", "withdrawn": "0"},
+    ])
+    assert resolve_user_id_from_master(p, "  S-95DBB6  ") == 173819
+
+
+def test_resolve_missing_code_raises_keyerror(tmp_path):
+    p = _write_master(tmp_path, [
+        {"deid_code": "S-95DBB6", "user_id": "173819",
+         "sortable_name": "Ahlstrom, Sydney", "withdrawn": "0"},
+    ])
+    with pytest.raises(KeyError):
+        resolve_user_id_from_master(p, "S-DOESNOTEXIST")
+
+
+def test_resolve_missing_master_raises_filenotfound(tmp_path):
+    """The error must point the operator at build_deid_master.py."""
+    nope = tmp_path / "does_not_exist.csv"
+    with pytest.raises(FileNotFoundError) as exc_info:
+        resolve_user_id_from_master(nope, "S-95DBB6")
+    assert "build_deid_master" in str(exc_info.value)
+
+
+def test_resolve_returns_int_not_str(tmp_path):
+    """user_id must be returned as int — Canvas API takes int."""
+    p = _write_master(tmp_path, [
+        {"deid_code": "S-AAA", "user_id": "42",
+         "sortable_name": "Test", "withdrawn": "0"},
+    ])
+    uid = resolve_user_id_from_master(p, "S-AAA")
+    assert isinstance(uid, int)
+    assert uid == 42
+
+
+# ---------------------------------------------------------------------------
+# build_override_payload — the POST body builder
+# ---------------------------------------------------------------------------
+
+def test_payload_includes_student_id():
+    assignment = {"due_at": "2026-04-15T23:59:00Z",
+                  "unlock_at": "2026-04-01T00:00:00Z"}
+    payload = build_override_payload(assignment, user_id=173819)
+    assert payload["assignment_override[student_ids][]"] == 173819
+
+
+def test_payload_includes_title():
+    """The title makes the override identifiable in Canvas's UI."""
+    payload = build_override_payload({}, user_id=1)
+    assert "Late-work accommodation" in payload["assignment_override[title]"]
+
+
+def test_payload_keeps_due_at():
+    """Critical: the original due_at is preserved → student still sees
+    the original deadline in their student-view."""
+    assignment = {"due_at": "2026-04-15T23:59:00Z"}
+    payload = build_override_payload(assignment, user_id=1)
+    assert payload["assignment_override[due_at]"] == "2026-04-15T23:59:00Z"
+
+
+def test_payload_keeps_unlock_at():
+    """The original open date is preserved (student can't start early)."""
+    assignment = {"unlock_at": "2026-04-01T00:00:00Z"}
+    payload = build_override_payload(assignment, user_id=1)
+    assert payload["assignment_override[unlock_at]"] == "2026-04-01T00:00:00Z"
+
+
+def test_payload_omits_lock_at():
+    """THE CORE INVARIANT — lock_at MUST NOT appear in the payload.
+    Canvas interprets a missing lock_at as null (no close date), which
+    is exactly the accommodation. If lock_at ever bleeds into the payload
+    here, students lose late-submission access."""
+    assignment = {
+        "due_at": "2026-04-15T23:59:00Z",
+        "unlock_at": "2026-04-01T00:00:00Z",
+        "lock_at": "2026-05-01T23:59:00Z",  # SHOULD be ignored
+    }
+    payload = build_override_payload(assignment, user_id=1)
+    assert "assignment_override[lock_at]" not in payload
+
+
+def test_payload_handles_missing_due_at():
+    """Assignments without due dates (e.g. ungraded surveys) still
+    accept the override — payload just omits the due_at field."""
+    payload = build_override_payload({}, user_id=1)
+    assert "assignment_override[due_at]" not in payload
+    assert "assignment_override[unlock_at]" not in payload
+
+
+def test_payload_handles_null_due_at():
+    """Canvas returns null for missing due dates (not absent key).
+    Defensive: null due_at → don't include it in the payload."""
+    payload = build_override_payload({"due_at": None, "unlock_at": None},
+                                     user_id=1)
+    assert "assignment_override[due_at]" not in payload
+
+
+def test_payload_custom_title():
+    payload = build_override_payload({}, user_id=1, title="Custom title")
+    assert payload["assignment_override[title]"] == "Custom title"
+
+
+# ---------------------------------------------------------------------------
+# filter_my_overrides — per-student override filter
+# ---------------------------------------------------------------------------
+
+def test_filter_returns_only_target_user_overrides():
+    overrides = [
+        {"id": 1, "student_ids": [100, 200]},
+        {"id": 2, "student_ids": [100]},
+        {"id": 3, "student_ids": [300]},
+    ]
+    mine = filter_my_overrides(overrides, user_id=100)
+    assert sorted(o["id"] for o in mine) == [1, 2]
+
+
+def test_filter_empty_list_returns_empty():
+    assert filter_my_overrides([], user_id=100) == []
+
+
+def test_filter_none_returns_empty():
+    """Defensive: Canvas API can return None for empty override lists."""
+    assert filter_my_overrides(None, user_id=100) == []
+
+
+def test_filter_no_student_ids_key():
+    """Section overrides have no student_ids — filter should ignore them."""
+    overrides = [
+        {"id": 1, "course_section_id": 999},  # section override
+        {"id": 2, "student_ids": [100]},
+    ]
+    mine = filter_my_overrides(overrides, user_id=100)
+    assert len(mine) == 1
+    assert mine[0]["id"] == 2
+
+
+def test_filter_null_student_ids():
+    """Defensive: student_ids: null."""
+    overrides = [
+        {"id": 1, "student_ids": None},
+        {"id": 2, "student_ids": [100]},
+    ]
+    mine = filter_my_overrides(overrides, user_id=100)
+    assert len(mine) == 1
+
+
+# ---------------------------------------------------------------------------
+# cutoff_from_days_ago — rolling-window scope helper
+# ---------------------------------------------------------------------------
+
+def test_cutoff_zero_days_returns_today():
+    from datetime import date
+    today = date(2026, 6, 26)
+    assert cutoff_from_days_ago(0, today=today) == "2026-06-26"
+
+
+def test_cutoff_14_days_ago():
+    from datetime import date
+    today = date(2026, 6, 26)
+    assert cutoff_from_days_ago(14, today=today) == "2026-06-12"
+
+
+def test_cutoff_crosses_month_boundary():
+    from datetime import date
+    today = date(2026, 4, 5)
+    # 14 days before April 5 is March 22
+    assert cutoff_from_days_ago(14, today=today) == "2026-03-22"
+
+
+def test_cutoff_returns_iso_format():
+    """Must be YYYY-MM-DD for the string-prefix comparison to work."""
+    from datetime import date
+    out = cutoff_from_days_ago(7, today=date(2026, 6, 26))
+    assert len(out) == 10
+    assert out[4] == "-" and out[7] == "-"
+
+
+# ---------------------------------------------------------------------------
+# filter_assignments_by_due_from — date-scoped filtering
+# ---------------------------------------------------------------------------
+
+def _a(aid: int, due: str | None) -> dict:
+    return {"id": aid, "due_at": due}
+
+
+def test_filter_includes_assignment_on_cutoff_date():
+    """An assignment due ON the cutoff date is INCLUDED (>=)."""
+    assignments = [_a(1, "2026-04-15T23:59:00Z")]
+    out = filter_assignments_by_due_from(assignments, "2026-04-15")
+    assert len(out) == 1
+
+
+def test_filter_includes_assignment_after_cutoff():
+    assignments = [_a(1, "2026-04-20T23:59:00Z")]
+    out = filter_assignments_by_due_from(assignments, "2026-04-15")
+    assert len(out) == 1
+
+
+def test_filter_excludes_assignment_before_cutoff():
+    assignments = [_a(1, "2026-04-10T23:59:00Z")]
+    out = filter_assignments_by_due_from(assignments, "2026-04-15")
+    assert out == []
+
+
+def test_filter_excludes_null_due_at():
+    """Undated assignments aren't part of a date-scoped accommodation."""
+    assignments = [_a(1, None), _a(2, "2026-04-20T23:59:00Z")]
+    out = filter_assignments_by_due_from(assignments, "2026-04-15")
+    assert len(out) == 1
+    assert out[0]["id"] == 2
+
+
+def test_filter_excludes_missing_due_at_key():
+    """Defensive: due_at key absent entirely."""
+    assignments = [{"id": 1}, _a(2, "2026-04-20T23:59:00Z")]
+    out = filter_assignments_by_due_from(assignments, "2026-04-15")
+    assert len(out) == 1
+    assert out[0]["id"] == 2
+
+
+def test_filter_mixed_pre_and_post_cutoff():
+    """Realistic scenario: 5 assignments spanning the cutoff."""
+    assignments = [
+        _a(1, "2026-04-01T23:59:00Z"),  # before
+        _a(2, "2026-04-10T23:59:00Z"),  # before
+        _a(3, "2026-04-15T23:59:00Z"),  # ON (included)
+        _a(4, "2026-04-20T23:59:00Z"),  # after
+        _a(5, None),                      # null (excluded)
+    ]
+    out = filter_assignments_by_due_from(assignments, "2026-04-15")
+    assert [a["id"] for a in out] == [3, 4]

--- a/lib/tools/build_deid_master.py
+++ b/lib/tools/build_deid_master.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+"""
+build_deid_master.py — Build the course-wide de-identification master CSV.
+
+The MISSING PRIMITIVE that sits underneath all keyed / FERPA workflows.
+
+Today, the canvas-toolbox uses:
+  - per-assignment keymaps (a student gets a DIFFERENT key per assignment),
+  - a flat `.known_names.txt` roster for the scrub pass.
+
+Both work, but they don't give the operator a single, stable, course-wide
+identity surface. This tool fixes that — one CSV, one row per enrolled
+student, with a stable opaque code the operator can hand to other tools
+WITHOUT ever speaking the student's name to the agent or the cloud LLM.
+
+THE 4-COLUMN CONTRACT
+  deid_code     — stable opaque code, e.g. S-95DBB6 (sha256(user_id)[:6])
+  user_id       — Canvas numeric user_id, the source of truth
+  sortable_name — "Lastname, Firstname" (NEVER read by tools unless explicit)
+  withdrawn     — 1 if enrollment state is inactive/completed/deleted else 0
+
+The `sortable_name` column lets the OPERATOR look up a student in their
+LOCAL gitignored file ("find Sydney → S-95DBB6") and hand the agent / tool
+only the code. The tool resolves code → user_id reading ONLY that column.
+
+WHY `withdrawn` MATTERS
+  The default Canvas People view shows ACTIVE students only. Final-grade
+  analysis, last-engagement audits, and accommodations frequently need
+  visibility into students who DROPPED mid-semester (state: inactive /
+  completed / deleted). In one pilot: 30 active → 37 total → 7 withdrawn.
+
+FERPA — TIER 2 GITIGNORED
+  This file LIVES in the repo but is GITIGNORED. To make that bulletproof,
+  the tool writes a `grading/.gitignore` (containing `*`) the first time
+  it creates the directory — so even if the operator forgets to add
+  `grading/` to their main .gitignore, the directory's own .gitignore
+  prevents any tracked commits.
+
+USAGE
+  # Build / refresh the master (writes to ./grading/.deid_master.csv)
+  uv run python lib/tools/build_deid_master.py
+
+  # Custom prefix (default S-)
+  uv run python lib/tools/build_deid_master.py --prefix DS-
+
+  # Custom output location
+  uv run python lib/tools/build_deid_master.py --out /path/to/master.csv
+
+  # Refuse to overwrite an existing master without --force
+  uv run python lib/tools/build_deid_master.py --force
+
+  # Dry-run: print the rows that would be written, don't touch the file
+  uv run python lib/tools/build_deid_master.py --dry-run
+
+  # If a collision is detected (very rare under ~1000 students), re-run
+  # with a longer hash. Default is 6 hex chars; --hash-bits 8 doubles the
+  # collision-free range.
+  uv run python lib/tools/build_deid_master.py --hash-bits 8
+
+COLLISION MATH (sha256, first N hex chars uppercase, ~birthday paradox)
+  6 hex (16M codes): 50 students → 0.007% | 200 → 0.12% | 500 → 0.7% | 1000 → 3%
+  8 hex (4B codes):  1000 students → 0.01% | 5000 → 0.3% | 10000 → 1.2%
+  10 hex: practically collision-free at any class size.
+
+REQUIRES in .env: CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID
+
+Resolves issue #109 — course-wide de-id master + per-student
+accommodation primitives (the accommodation tool consumes this CSV).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import hashlib
+import os
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+_DEFAULT_PREFIX = "S-"
+_DEFAULT_HASH_BITS = 6
+_DEFAULT_OUT = Path("grading/.deid_master.csv")
+_WITHDRAWN_STATES = {"inactive", "completed", "deleted"}
+_TIMEOUT = 30
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no I/O — easy to unit-test)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class StudentRow:
+    """One row of the de-id master CSV."""
+    deid_code: str
+    user_id: int
+    sortable_name: str
+    withdrawn: int  # 0 or 1
+
+
+def deid_code_for(user_id: int, prefix: str = _DEFAULT_PREFIX,
+                  hash_bits: int = _DEFAULT_HASH_BITS) -> str:
+    """Compute the stable opaque code for a Canvas user_id.
+
+    Format: {prefix}{first N hex chars of sha256(user_id), uppercased}
+    Deterministic: same user_id always yields the same code.
+    """
+    h = hashlib.sha256(str(int(user_id)).encode("utf-8")).hexdigest()
+    return f"{prefix}{h[:hash_bits].upper()}"
+
+
+def is_withdrawn(enrollments: list[dict]) -> int:
+    """Withdrawn=1 if any enrollment is in {inactive, completed, deleted}.
+
+    A student with BOTH an active enrollment and a dropped enrollment is
+    NOT withdrawn (active wins). The check is order-free: presence of any
+    "still active" enrollment overrides the presence of a withdrawn one.
+    """
+    if not enrollments:
+        return 0
+    states = {e.get("enrollment_state") for e in enrollments}
+    if "active" in states or "invited" in states:
+        return 0
+    return 1 if states & _WITHDRAWN_STATES else 0
+
+
+def student_to_row(user: dict, prefix: str, hash_bits: int) -> StudentRow:
+    """Build one StudentRow from a Canvas /users response item."""
+    uid = int(user["id"])
+    return StudentRow(
+        deid_code=deid_code_for(uid, prefix, hash_bits),
+        user_id=uid,
+        sortable_name=user.get("sortable_name") or user.get("name") or "",
+        withdrawn=is_withdrawn(user.get("enrollments") or []),
+    )
+
+
+def detect_collisions(rows: list[StudentRow]) -> list[tuple[str, list[int]]]:
+    """Return [(deid_code, [user_id, user_id, ...])] for every code that
+    appears more than once. Empty list = no collisions.
+    """
+    by_code: dict[str, list[int]] = {}
+    for r in rows:
+        by_code.setdefault(r.deid_code, []).append(r.user_id)
+    return [(code, uids) for code, uids in by_code.items() if len(uids) > 1]
+
+
+def render_csv_rows(rows: list[StudentRow]) -> list[list[str]]:
+    """Build the CSV body (header + rows). Sorted by sortable_name for
+    deterministic output across runs."""
+    header = ["deid_code", "user_id", "sortable_name", "withdrawn"]
+    sorted_rows = sorted(rows, key=lambda r: r.sortable_name.lower())
+    return [header] + [
+        [r.deid_code, str(r.user_id), r.sortable_name, str(r.withdrawn)]
+        for r in sorted_rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Canvas API
+# ---------------------------------------------------------------------------
+
+def fetch_all_students(base_url: str, course_id: str, token: str) -> list[dict]:
+    """GET /courses/:id/users?enrollment_type[]=student with ALL enrollment
+    states so withdrawn students are NOT silently dropped.
+
+    Paginates over all pages (per_page=100).
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    out: list[dict] = []
+    page = 1
+    while True:
+        r = requests.get(
+            f"{base_url}/api/v1/courses/{course_id}/users",
+            headers=headers,
+            params={
+                "per_page": 100,
+                "page": page,
+                "enrollment_type[]": "student",
+                "enrollment_state[]": [
+                    "active", "invited", "inactive", "completed",
+                ],
+                "include[]": ["enrollments"],
+            },
+            timeout=_TIMEOUT,
+        )
+        r.raise_for_status()
+        batch = r.json()
+        if not batch:
+            break
+        out.extend(batch)
+        page += 1
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Filesystem helpers
+# ---------------------------------------------------------------------------
+
+def ensure_grading_gitignore(grading_dir: Path) -> None:
+    """Make sure `<grading_dir>/.gitignore` exists with `*` content so the
+    directory's contents are git-ignored even if the operator forgot to add
+    `grading/` to their main .gitignore. Defense-in-depth for FERPA tier 2.
+    """
+    grading_dir.mkdir(parents=True, exist_ok=True)
+    gi = grading_dir / ".gitignore"
+    if not gi.exists():
+        gi.write_text("# Auto-written by build_deid_master.py — FERPA tier 2\n"
+                      "# Every file in this directory is gitignored EXCEPT\n"
+                      "# this .gitignore itself. Commit only this file.\n"
+                      "*\n!.gitignore\n", encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    ap.add_argument("--prefix", default=_DEFAULT_PREFIX,
+                    help=f"deid_code prefix (default {_DEFAULT_PREFIX!r})")
+    ap.add_argument("--hash-bits", type=int, default=_DEFAULT_HASH_BITS,
+                    help=f"hex chars from sha256 (default {_DEFAULT_HASH_BITS}; "
+                         "increase if a collision is detected)")
+    ap.add_argument("--out", type=Path, default=_DEFAULT_OUT,
+                    help=f"output path (default {str(_DEFAULT_OUT)!r}, relative to cwd)")
+    ap.add_argument("--force", action="store_true",
+                    help="overwrite an existing master without prompting")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="print rows that would be written, don't touch the file")
+    args = ap.parse_args()
+
+    base_url = os.environ.get("CANVAS_BASE_URL", "").rstrip("/")
+    if base_url and not base_url.startswith("http"):
+        base_url = "https://" + base_url
+    course_id = os.environ.get("CANVAS_COURSE_ID", "")
+    token = os.environ.get("CANVAS_API_TOKEN", "")
+    if not (base_url and course_id and token):
+        print("ERROR: CANVAS_BASE_URL / CANVAS_COURSE_ID / CANVAS_API_TOKEN "
+              "must be set in .env or the environment.", file=sys.stderr)
+        return 2
+
+    if args.out.exists() and not args.force and not args.dry_run:
+        print(f"ERROR: {args.out} already exists. Re-run with --force to overwrite.",
+              file=sys.stderr)
+        return 2
+
+    print(f"Fetching all students (active + invited + inactive + completed)...")
+    users = fetch_all_students(base_url, course_id, token)
+    print(f"  {len(users)} student records returned")
+
+    rows = [student_to_row(u, args.prefix, args.hash_bits) for u in users]
+    collisions = detect_collisions(rows)
+    if collisions:
+        print("\nERROR: deid_code collision detected:", file=sys.stderr)
+        for code, uids in collisions:
+            print(f"  {code} ← user_ids {uids}", file=sys.stderr)
+        print(f"\nRe-run with --hash-bits {args.hash_bits + 2} (or higher).",
+              file=sys.stderr)
+        return 2
+
+    n_active = sum(1 for r in rows if r.withdrawn == 0)
+    n_withdrawn = sum(1 for r in rows if r.withdrawn == 1)
+    print(f"  {n_active} active, {n_withdrawn} withdrawn")
+
+    csv_rows = render_csv_rows(rows)
+
+    if args.dry_run:
+        print("\n--- DRY RUN — would write the following rows ---")
+        for row in csv_rows[:5]:
+            print("  " + ",".join(row))
+        if len(csv_rows) > 5:
+            print(f"  ... and {len(csv_rows) - 5} more rows")
+        print(f"\nWould write to: {args.out}")
+        return 0
+
+    ensure_grading_gitignore(args.out.parent)
+    with args.out.open("w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerows(csv_rows)
+    print(f"\nWrote {len(rows)} rows to {args.out}")
+    print("FERPA tier 2: this file is gitignored. Never commit it.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/tools/student_late_accommodation.py
+++ b/lib/tools/student_late_accommodation.py
@@ -1,0 +1,382 @@
+#!/usr/bin/env python3
+"""
+student_late_accommodation.py — Per-student "submit anything late"
+accommodation via Canvas assignment overrides.
+
+A routine faculty accommodation: ONE student gets permission to submit
+late on some (or all) assignments. The class is unaffected.
+
+HOW THE OVERRIDE IS BUILT
+  For each target assignment, write a per-student assignment override that:
+    - keeps the assignment's normal `unlock_at` (open date)
+    - keeps the assignment's normal `due_at`    (due date)
+    - omits `lock_at` (no close date) → student can submit after the due
+      date; submission shows up marked "late" but is still accepted
+
+The student STILL sees the original due date in their student-view (no
+artificial deadline extension shown); they just don't get locked out
+when the due date passes.
+
+PII-FREE LOOKUP
+  Resolve the target student with EITHER:
+    --user-id 123456        the bare Canvas user_id
+    --deid-code S-95DBB6    looked up in grading/.deid_master.csv
+                            (built by build_deid_master.py)
+  The deid_code lookup reads ONLY the user_id column of the master —
+  the student's name is never read, printed, or sent to the agent.
+
+CAVEAT WE LEARNED (DS 460 pilot, 2026-06-26)
+  Canvas's GET /assignments/:id/overrides endpoint can hang / be very
+  slow on some courses. The --apply path therefore POSTs the override
+  directly (after fetching ONE assignment's dates) and does NOT pre-list
+  existing overrides. Only the --remove path needs to read overrides,
+  and that's an explicit operator choice.
+
+SCOPE — pick ONE of these (mutually exclusive)
+  --assignment-id <id>      ONE specific assignment
+  --all                     ALL published assignments (whole semester,
+                            backdated — students get override on past-due
+                            items too)
+  --from YYYY-MM-DD         Assignments with due_at >= YYYY-MM-DD (rest
+                            of semester from a specific date forward)
+  --from-days-ago N         Assignments with due_at >= today - N days
+                            (rolling window; e.g. --from-days-ago 14
+                            covers the last two weeks through the end
+                            of the term — the recommended default for
+                            "give them grace from when they hit the
+                            wall through the end of the semester")
+
+USAGE — dry-run by default (use --apply to actually write)
+  # Preview adding accommodation to ONE assignment
+  uv run python lib/tools/student_late_accommodation.py \\
+    --deid-code S-95DBB6 --assignment-id 123
+
+  # Apply to ONE assignment
+  uv run python lib/tools/student_late_accommodation.py \\
+    --user-id 173819 --assignment-id 123 --apply
+
+  # Apply across ALL published assignments (whole semester, backdated)
+  uv run python lib/tools/student_late_accommodation.py \\
+    --deid-code S-95DBB6 --all --apply
+
+  # From a specific date forward (rest of semester)
+  uv run python lib/tools/student_late_accommodation.py \\
+    --deid-code S-95DBB6 --from 2026-04-01 --apply
+
+  # Rolling window: last 2 weeks through end of semester
+  uv run python lib/tools/student_late_accommodation.py \\
+    --deid-code S-95DBB6 --from-days-ago 14 --apply
+
+  # Remove the accommodation (cleanly undo) — scope flags work for
+  # remove too, so you can undo across the same window you applied
+  uv run python lib/tools/student_late_accommodation.py \\
+    --deid-code S-95DBB6 --all --remove --apply
+
+REQUIRES in .env: CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID
+REQUIRES: a deid master built by lib/tools/build_deid_master.py (only
+if you use --deid-code; --user-id works without it).
+
+Resolves issue #109 — course-wide de-id master + per-student
+accommodation primitives. Lifted from the DS 460 pilot and generalized.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import os
+import sys
+from datetime import date, timedelta
+from pathlib import Path
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+_DEFAULT_MASTER = Path("grading/.deid_master.csv")
+_OVERRIDE_TITLE = "Late-work accommodation (no close date)"
+_TIMEOUT = 30
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no I/O — easy to unit-test)
+# ---------------------------------------------------------------------------
+
+def resolve_user_id_from_master(master_path: Path, deid_code: str) -> int:
+    """Look up a deid_code in the master CSV and return the user_id.
+
+    Reads ONLY the user_id column (the sortable_name column is never read
+    or printed). Raises FileNotFoundError if the master doesn't exist;
+    raises KeyError if the deid_code isn't present.
+    """
+    if not master_path.exists():
+        raise FileNotFoundError(
+            f"deid master not found at {master_path}. "
+            f"Build it first with: "
+            f"uv run python lib/tools/build_deid_master.py"
+        )
+    target = deid_code.strip().upper()
+    with master_path.open(encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            if row["deid_code"].strip().upper() == target:
+                return int(row["user_id"])
+    raise KeyError(
+        f"deid_code {deid_code!r} not found in {master_path}. "
+        f"Did you rebuild the master after a roster change?"
+    )
+
+
+def build_override_payload(assignment: dict, user_id: int,
+                           title: str = _OVERRIDE_TITLE) -> dict:
+    """Build the POST body for a late-work accommodation override.
+
+    Keeps `unlock_at` + `due_at` from the assignment; omits `lock_at`
+    so Canvas treats it as null (no close date). Returns form-encoded
+    field/value pairs (the Canvas API quirk: array fields use [] suffix).
+    """
+    data: dict[str, str | int] = {
+        "assignment_override[student_ids][]": user_id,
+        "assignment_override[title]": title,
+    }
+    if assignment.get("due_at"):
+        data["assignment_override[due_at]"] = assignment["due_at"]
+    if assignment.get("unlock_at"):
+        data["assignment_override[unlock_at]"] = assignment["unlock_at"]
+    # lock_at intentionally OMITTED → null → no close date
+    return data
+
+
+def filter_my_overrides(overrides: list[dict], user_id: int) -> list[dict]:
+    """From the assignment's overrides list, return only the ones
+    targeted at this specific user_id."""
+    return [o for o in (overrides or [])
+            if user_id in (o.get("student_ids") or [])]
+
+
+def cutoff_from_days_ago(days: int, today: date | None = None) -> str:
+    """Return YYYY-MM-DD for (today - days). The `today` parameter
+    exists for testability — defaults to actual today."""
+    if today is None:
+        today = date.today()
+    return (today - timedelta(days=int(days))).isoformat()
+
+
+def filter_assignments_by_due_from(assignments: list[dict],
+                                   cutoff_date_str: str) -> list[dict]:
+    """Return assignments whose due_at >= cutoff_date_str (YYYY-MM-DD).
+
+    Compares the date-prefix of due_at (first 10 chars) against the cutoff,
+    which lets us avoid timezone parsing — close enough for accommodation
+    scoping (the operator picking "from April 1" doesn't care whether
+    an assignment due at 1am UTC on April 1 counts).
+
+    Assignments with null/missing due_at are EXCLUDED — undated
+    assignments aren't typically what "from a date" means.
+    """
+    out = []
+    for a in assignments:
+        due_at = a.get("due_at")
+        if not due_at:
+            continue
+        if due_at[:10] >= cutoff_date_str:
+            out.append(a)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Canvas API
+# ---------------------------------------------------------------------------
+
+def fetch_published_assignments(base_url: str, course_id: str,
+                                token: str) -> list[dict]:
+    """GET /courses/:id/assignments and return ONLY the published ones
+    as full dicts (so callers can filter by due_at).
+
+    Paginates over all pages.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    out: list[dict] = []
+    page = 1
+    while True:
+        r = requests.get(
+            f"{base_url}/api/v1/courses/{course_id}/assignments",
+            headers=headers,
+            params={"per_page": 100, "page": page},
+            timeout=_TIMEOUT,
+        )
+        r.raise_for_status()
+        batch = r.json()
+        if not batch:
+            break
+        for a in batch:
+            if a.get("published"):
+                out.append(a)
+        page += 1
+    return out
+
+
+def fetch_assignment(base_url: str, course_id: str, assignment_id: int,
+                     token: str) -> dict:
+    headers = {"Authorization": f"Bearer {token}"}
+    r = requests.get(
+        f"{base_url}/api/v1/courses/{course_id}/assignments/{assignment_id}",
+        headers=headers, timeout=_TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def post_override(base_url: str, course_id: str, assignment_id: int,
+                  payload: dict, token: str) -> tuple[int, dict]:
+    headers = {"Authorization": f"Bearer {token}"}
+    r = requests.post(
+        f"{base_url}/api/v1/courses/{course_id}/assignments/{assignment_id}/overrides",
+        headers=headers, data=payload, timeout=_TIMEOUT,
+    )
+    try:
+        body = r.json()
+    except ValueError:
+        body = {}
+    return r.status_code, body
+
+
+def list_overrides(base_url: str, course_id: str, assignment_id: int,
+                   token: str) -> list[dict]:
+    """SLOW on some courses — only used by the --remove path."""
+    headers = {"Authorization": f"Bearer {token}"}
+    r = requests.get(
+        f"{base_url}/api/v1/courses/{course_id}/assignments/{assignment_id}/overrides",
+        headers=headers, params={"per_page": 100}, timeout=_TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json() or []
+
+
+def delete_override(base_url: str, course_id: str, assignment_id: int,
+                    override_id: int, token: str) -> int:
+    headers = {"Authorization": f"Bearer {token}"}
+    r = requests.delete(
+        f"{base_url}/api/v1/courses/{course_id}/assignments/{assignment_id}/overrides/{override_id}",
+        headers=headers, timeout=_TIMEOUT,
+    )
+    return r.status_code
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    who = ap.add_mutually_exclusive_group(required=True)
+    who.add_argument("--user-id", help="bare Canvas user_id (no PII surface)")
+    who.add_argument("--deid-code", help="deid_code from grading/.deid_master.csv")
+    scope = ap.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--assignment-id", type=int, help="ONE assignment id")
+    scope.add_argument("--all", action="store_true",
+                       help="ALL published assignments (whole semester, "
+                            "backdated)")
+    scope.add_argument("--from", dest="from_date", metavar="YYYY-MM-DD",
+                       help="published assignments with due_at >= this date "
+                            "(rest of semester from a specific date forward)")
+    scope.add_argument("--from-days-ago", type=int, metavar="N",
+                       help="published assignments due in the last N days "
+                            "and onward (e.g. --from-days-ago 14 covers "
+                            "the last two weeks through end of term)")
+    ap.add_argument("--master", type=Path, default=_DEFAULT_MASTER,
+                    help=f"deid master path (default {str(_DEFAULT_MASTER)!r})")
+    ap.add_argument("--remove", action="store_true",
+                    help="undo: delete this student's accommodation overrides")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually write the change (without this, dry-run)")
+    args = ap.parse_args()
+
+    base_url = os.environ.get("CANVAS_BASE_URL", "").rstrip("/")
+    if base_url and not base_url.startswith("http"):
+        base_url = "https://" + base_url
+    course_id = os.environ.get("CANVAS_COURSE_ID", "")
+    token = os.environ.get("CANVAS_API_TOKEN", "")
+    if not (base_url and course_id and token):
+        print("ERROR: CANVAS_BASE_URL / CANVAS_COURSE_ID / CANVAS_API_TOKEN "
+              "must be set in .env or the environment.", file=sys.stderr)
+        return 2
+
+    if args.user_id:
+        uid = int(args.user_id)
+    else:
+        try:
+            uid = resolve_user_id_from_master(args.master, args.deid_code)
+        except (FileNotFoundError, KeyError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    if args.assignment_id:
+        assignment_ids = [args.assignment_id]
+        scope_label = f"assignment {args.assignment_id}"
+    elif args.all:
+        assignments = fetch_published_assignments(base_url, course_id, token)
+        assignment_ids = [a["id"] for a in assignments]
+        scope_label = f"ALL {len(assignment_ids)} published"
+    elif args.from_date:
+        assignments = fetch_published_assignments(base_url, course_id, token)
+        filtered = filter_assignments_by_due_from(assignments, args.from_date)
+        assignment_ids = [a["id"] for a in filtered]
+        scope_label = f"{len(assignment_ids)} due on/after {args.from_date}"
+    else:  # --from-days-ago
+        cutoff = cutoff_from_days_ago(args.from_days_ago)
+        assignments = fetch_published_assignments(base_url, course_id, token)
+        filtered = filter_assignments_by_due_from(assignments, cutoff)
+        assignment_ids = [a["id"] for a in filtered]
+        scope_label = (f"{len(assignment_ids)} due in the last "
+                       f"{args.from_days_ago} days + future (cutoff {cutoff})")
+
+    mode = "REMOVE" if args.remove else "ADD"
+    apply_ = "APPLY" if args.apply else "DRY-RUN"
+    print(f"student user_id={uid} | scope: {scope_label} "
+          f"| {mode} accommodation | {apply_}")
+
+    if not assignment_ids:
+        print("No assignments matched the scope. Nothing to do.")
+        return 0
+
+    fails = 0
+    for aid in assignment_ids:
+        if args.remove:
+            overrides = list_overrides(base_url, course_id, aid, token)
+            mine = filter_my_overrides(overrides, uid)
+            if not args.apply:
+                print(f"  [DRY] {aid}: would remove {len(mine)} override(s)")
+                continue
+            for o in mine:
+                code = delete_override(base_url, course_id, aid, o["id"], token)
+                ok = "OK " if code == 200 else "FAIL"
+                if code != 200:
+                    fails += 1
+                print(f"  [{ok}] {aid}: removed override {o['id']} (HTTP {code})")
+        else:
+            if not args.apply:
+                print(f"  [DRY] {aid}: would add override — keep open/due, "
+                      "remove close (lock=null)")
+                continue
+            assignment = fetch_assignment(base_url, course_id, aid, token)
+            payload = build_override_payload(assignment, uid)
+            code, body = post_override(base_url, course_id, aid, payload, token)
+            ok = "OK " if code in (200, 201) else "FAIL"
+            if code not in (200, 201):
+                fails += 1
+            print(f"  [{ok}] {aid}: override id={body.get('id')} "
+                  f"due={body.get('due_at')} unlock={body.get('unlock_at')} "
+                  f"lock={body.get('lock_at')}")
+
+    if fails:
+        print(f"\n{fails} operation(s) failed. Re-run to retry.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "0.69.1"
+version = "0.70.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "0.69.1"
+version = "0.70.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #109.

## Summary

Two related primitives that field-validated faculty workflows have been wanting:

- **`build_deid_master.py`** — fetches Canvas People with all enrollment states, hashes `user_id` → `S-XXXXXX`, writes `grading/.deid_master.csv` (FERPA tier 2 gitignored). Includes a `withdrawn` flag derived from enrollment state — surfaces students the default People view silently hides (DS 460 pilot: 30 active → 37 total → 7 withdrawn). Auto-writes `grading/.gitignore` to make tier 2 bulletproof. Collision detection at write-time with clear recovery path.
- **`student_late_accommodation.py`** — lifted from the DS 460 pilot. Per-student Canvas assignment overrides keeping `unlock_at` + `due_at` but omitting `lock_at` (no close date). **4 scoping modes**: one assignment, whole semester (backdated), from a specific date forward, or rolling window (e.g. `--from-days-ago 14`). Resolves student via `--user-id` OR `--deid-code` (PII-free).

Plus 4 README cleanups Chaz flagged mid-build:
- Step 3 prompt now explicitly invokes `cb-init` (uses our purpose-built idempotent bootstrap, not the agent's ad-hoc sequence)
- `byui.instructure.com` → `your-institution.instructure.com` (generic)
- "Who uses it" section dropped
- "Sharing back with the project" simplified from a technical PATH/fallback wall to a 3-row agent-prompt table

## What changed

```
 lib/tools/build_deid_master.py                            (NEW, 240L)
 lib/tools/student_late_accommodation.py                   (NEW, 285L)
 lib/agents/knowledge/deid_master_knowledge.md             (NEW)
 lib/tests/test_build_deid_master_helpers.py               (NEW, 25 tests)
 lib/tests/test_student_late_accommodation_helpers.py      (NEW, 29 tests)
 README.md                                                 (11th workflow row + dedicated section + 4 tweaks)
 AGENTS.md                                                 (Active Context entry)
 pyproject.toml, plugin.json, marketplace.json, uv.lock    (version triple-sync 0.69.1 → 0.70.0)
```

## Test plan

- [x] 543 passing tests (up from 489 in v0.69.1; the 7 sprint failures are pre-existing and require a live Canvas token)
- [x] 54 new tests across hash determinism, withdrawn-flag logic, collision detection, CSV rendering, lock_at-omission invariant, code lookup case/whitespace handling, date-cutoff edge cases
- [x] Pre-commit hooks (ruff/actionlint/shellcheck) all pass
- [ ] Manual smoke test on a real course (post-merge):
  - [ ] `uv run python lib/tools/build_deid_master.py --dry-run` shows expected rows
  - [ ] `uv run python lib/tools/build_deid_master.py` writes `grading/.deid_master.csv` + `grading/.gitignore`
  - [ ] `uv run python lib/tools/student_late_accommodation.py --deid-code S-XXXXXX --from-days-ago 14` dry-runs cleanly
  - [ ] Apply on a Test Student in a sandbox course; verify Canvas UI shows the override with the original due date + no close date

🤖 Generated with [Claude Code](https://claude.com/claude-code)
