### PR TITLE
feat: Path A — .known_names.txt auto-derived from deid master (v0.71.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "canvas-toolbox",
       "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Includes agent specs (8) and pedagogical knowledge files (20+) covering course design audits, FERPA-safe LLM grading, Canvas sync, and the BYU-I Learning Model.",
-      "version": "0.70.0",
+      "version": "0.71.0",
       "source": "./",
       "author": {
         "name": "Chaz Clark",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "canvas-toolbox",
   "displayName": "canvas-toolbox",
   "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Agent specs cover course audits (rubric coverage / quality, syllabus, CLO quality, alignment chain, accessibility, workload, grading structure / load, formative variety, learning model), Canvas sync paths (course / blueprint / Page-level orphan cleanup), and a generic LLM-grading pipeline (de-identify → consensus → reconcile → push). Knowledge files cover Canvas API + lessons learned, rubrics, assessments, backwards design, cognitive load theory, Hattie 3-phase, Merrill's First Principles, BYU-I Learning Model, BYUI Course Design Standards, and 14+ other pedagogical frameworks. Brain-agnostic by design: the LLM provider is your choice.",
-  "version": "0.70.0",
+  "version": "0.71.0",
   "author": {
     "name": "Chaz Clark",
     "url": "https://github.com/chaz-clark"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,41 @@ private channel is for security.
 
 _Last updated: 2026-06-26_
 
-### Recent: Course-wide de-id master + per-student late-work accommodation primitives (v0.70.0, 2026-06-26)
+### Recent: Path A migration — `.known_names.txt` auto-derived from the de-id master (v0.71.0, 2026-06-26)
+
+**v0.71.0** — Path A of the de-id master consolidation. Mid-build
+operator question after v0.70.0 shipped: *"Do all de-id scripts run
+off the new master? Anything re-id'ed goes to Downloads?"* — surfaced
+that the master was purely additive (only 2 tools used it); the
+scrub-pass roster `.known_names.txt` was still populated separately
+by `grader_fetch.py`.
+
+**What landed:**
+
+1. **`build_deid_master.py` now auto-derives `.known_names.txt`** —
+   single new helper `render_known_names_lines()` emits BOTH sortable
+   ("Lastname, Firstname") and display ("Firstname Lastname") forms
+   per student so the scrub matches whichever literal appears in
+   submission text. Case-insensitive dedup; sorted; header comments
+   so a future reader doesn't hand-edit it.
+
+2. **7 new tests** (550 passing total, up from 543). Covers both-forms
+   emission, header comments, dedup, empty-name skip, single-word
+   names (no comma → no display-form duplicate), determinism, sort
+   order.
+
+**Unchanged (deliberate):**
+- `grader_fetch.py`'s `update_known_names()` still works as before
+  (append-mode dedup; appends submitters who weren't in the People
+  view yet). Path A is additive, not replacement.
+- Per-assignment keymaps untouched. Grader pipeline hot path unchanged.
+
+**Path B deferred** — full migration where the master replaces
+per-assignment keymaps for the grader pipeline — approved in principle
+but deferred to a future session per operator direction. Path B becomes
+harder over time; the deferral is intentional and credit-aware.
+
+### Earlier: Course-wide de-id master + per-student late-work accommodation primitives (v0.70.0, 2026-06-26)
 
 **v0.70.0** — closes issue #109 (agent-submitted ~10 min after v0.69.1
 shipped, from the DS 460 pilot). Two related primitives + four-mode

--- a/README.md
+++ b/README.md
@@ -445,6 +445,6 @@ The architecture (FERPA two-zone, voice-preservation contract, consensus-based g
 
 ---
 
-**Current version:** v0.70.0 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 543 unit tests · 20+ pedagogical knowledge files for AI-architected course design · course-wide de-id master + per-student accommodation primitives · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
+**Current version:** v0.71.0 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 550 unit tests · 20+ pedagogical knowledge files for AI-architected course design · course-wide de-id master is now authoritative for the scrub-pass roster · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
 
 For help, see the doc tree above or file a `cb-report-bug` (~1 second roundtrip; no GitHub account needed).

--- a/lib/agents/knowledge/deid_master_knowledge.md
+++ b/lib/agents/knowledge/deid_master_knowledge.md
@@ -145,6 +145,25 @@ but `--dry-run` previews changes).
 
 ---
 
+## Path A — `.known_names.txt` is now derived from the master (v0.71.0)
+
+As of v0.71.0, every `build_deid_master.py` run **also writes
+`grading/.known_names.txt`** (the scrub-pass roster used by every
+`grader_deidentify_*` tool). Each enrolled student contributes BOTH
+forms of their name (sortable "Lastname, Firstname" + display
+"Firstname Lastname") so the scrub matches whichever shape appears
+in a submission's raw text.
+
+This makes the master the single source of truth for the scrub
+roster — one rebuild keeps both files in sync. `grader_fetch.py`
+continues to APPEND submitters not yet in the roster (it preserves
+its `update_known_names()` append-dedup), so a workflow that runs
+grader_fetch first still works without a master rebuild.
+
+**Path B** (full migration where the master replaces per-assignment
+keymaps for the grader pipeline) is approved in principle and
+deferred to a future session.
+
 ## Related knowledge
 
 - `grader_knowledge.md §1` — the three FERPA tiers + zone discipline

--- a/lib/tests/test_build_deid_master_helpers.py
+++ b/lib/tests/test_build_deid_master_helpers.py
@@ -22,6 +22,7 @@ from build_deid_master import (  # noqa: E402
     detect_collisions,
     is_withdrawn,
     render_csv_rows,
+    render_known_names_lines,
     student_to_row,
 )
 
@@ -244,3 +245,85 @@ def test_render_csv_rows_deterministic():
         StudentRow("S-BBB", 2, "B", 1),
     ]
     assert render_csv_rows(rows) == render_csv_rows(rows)
+
+
+# ---------------------------------------------------------------------------
+# render_known_names_lines — Path A: auto-derive .known_names.txt
+# ---------------------------------------------------------------------------
+
+def test_known_names_emits_both_forms():
+    """Each student contributes BOTH sortable AND display forms — the
+    scrub matches whichever shape appears in document text."""
+    rows = [StudentRow("S-AAA", 1, "Ahlstrom, Sydney", 0)]
+    lines = render_known_names_lines(rows)
+    assert "Ahlstrom, Sydney" in lines
+    assert "Sydney Ahlstrom" in lines
+
+
+def test_known_names_includes_header_comments():
+    """File leads with explanatory comments so a future reader knows
+    not to hand-edit + that it's auto-derived."""
+    rows = [StudentRow("S-AAA", 1, "Ahlstrom, Sydney", 0)]
+    lines = render_known_names_lines(rows)
+    assert lines[0].startswith("#")
+    assert any("Auto-derived" in ln for ln in lines[:3])
+    assert any("Do NOT hand-edit" in ln for ln in lines[:3])
+
+
+def test_known_names_dedups_case_insensitively():
+    """If two students have the same name, emit it once. Matches the
+    case-insensitive dedup in grader_fetch's update_known_names."""
+    rows = [
+        StudentRow("S-AAA", 1, "Smith, John", 0),
+        StudentRow("S-BBB", 2, "smith, john", 0),  # same name, different case
+    ]
+    lines = render_known_names_lines(rows)
+    body = [ln for ln in lines if not ln.startswith("#")]
+    # 2 forms × 1 unique name = 2 entries, not 4
+    assert len(body) == 2
+
+
+def test_known_names_skips_empty_sortable_name():
+    """A student without a sortable_name (e.g. service account) is
+    silently skipped, not crashed on."""
+    rows = [
+        StudentRow("S-AAA", 1, "", 0),
+        StudentRow("S-BBB", 2, "Real, Student", 0),
+    ]
+    lines = render_known_names_lines(rows)
+    body = [ln for ln in lines if not ln.startswith("#")]
+    assert "Real, Student" in body
+    assert "Student Real" in body
+    assert "" not in body
+
+
+def test_known_names_handles_single_word_name():
+    """A name without a comma (e.g. 'Cher', 'Madonna', or single-word
+    service-account name) emits as-is, no display-form duplicate."""
+    rows = [StudentRow("S-AAA", 1, "Madonna", 0)]
+    lines = render_known_names_lines(rows)
+    body = [ln for ln in lines if not ln.startswith("#")]
+    assert body == ["Madonna"]
+
+
+def test_known_names_deterministic():
+    """Same input → identical output (sha256-stable when scrub-validates)."""
+    rows = [
+        StudentRow("S-AAA", 1, "Ahlstrom, Sydney", 0),
+        StudentRow("S-BBB", 2, "Smith, John", 0),
+    ]
+    assert render_known_names_lines(rows) == render_known_names_lines(rows)
+
+
+def test_known_names_sorted_by_sortable_name():
+    """Output sorted by sortable_name (case-insensitive) for stable diffs."""
+    rows = [
+        StudentRow("S-CCC", 3, "Zeta, Z", 0),
+        StudentRow("S-AAA", 1, "Alpha, A", 0),
+        StudentRow("S-BBB", 2, "beta, B", 0),
+    ]
+    lines = render_known_names_lines(rows)
+    body = [ln for ln in lines if not ln.startswith("#")]
+    # First non-comment line should be Alpha (sortable, since
+    # sorted by sortable_name → 'alpha, a' < 'beta, b' < 'zeta, z')
+    assert body[0] == "Alpha, A"

--- a/lib/tools/build_deid_master.py
+++ b/lib/tools/build_deid_master.py
@@ -164,6 +164,44 @@ def render_csv_rows(rows: list[StudentRow]) -> list[list[str]]:
     ]
 
 
+def render_known_names_lines(rows: list[StudentRow]) -> list[str]:
+    """Render the auto-derived `.known_names.txt` content from the master.
+
+    Path A (v0.71.0) — making the de-id master the source of truth for
+    the scrub-pass name roster. Previously, grader_fetch.py populated
+    .known_names.txt with display names per submitter; now the file is
+    derived from the course-wide master so a single rebuild keeps the
+    scrub roster in sync with the People view.
+
+    Emits BOTH sortable ('Lastname, Firstname') and display ('Firstname
+    Lastname') forms per student — submission text might say either,
+    and the scrub matches whichever appears literally.
+
+    Sorted + deduped (case-insensitive) for deterministic output.
+    """
+    out = [
+        "# Auto-derived by build_deid_master.py from .deid_master.csv.",
+        "# Do NOT hand-edit — changes will be overwritten on next build.",
+        "# Peer-mention scrub roster. Gitignored. Never read by the AI.",
+    ]
+    seen: set[str] = set()
+    for row in sorted(rows, key=lambda r: r.sortable_name.lower()):
+        sortable = row.sortable_name.strip()
+        if not sortable:
+            continue
+        if "," in sortable:
+            last, first = (s.strip() for s in sortable.split(",", 1))
+            display = f"{first} {last}".strip()
+        else:
+            display = sortable
+        for form in (sortable, display):
+            key = form.lower()
+            if form and key not in seen:
+                seen.add(key)
+                out.append(form)
+    return out
+
+
 # ---------------------------------------------------------------------------
 # Canvas API
 # ---------------------------------------------------------------------------
@@ -286,8 +324,19 @@ def main() -> int:
     with args.out.open("w", encoding="utf-8", newline="") as fh:
         writer = csv.writer(fh)
         writer.writerows(csv_rows)
+
+    # Path A (v0.71.0): auto-derive .known_names.txt from the master so
+    # the scrub-pass roster (used by every grader_deidentify_* tool)
+    # stays in sync without a separate refresh step.
+    names_path = args.out.parent / ".known_names.txt"
+    names_path.write_text(
+        "\n".join(render_known_names_lines(rows)) + "\n",
+        encoding="utf-8",
+    )
+
     print(f"\nWrote {len(rows)} rows to {args.out}")
-    print("FERPA tier 2: this file is gitignored. Never commit it.")
+    print(f"Auto-derived {names_path} for the peer-mention scrub")
+    print("FERPA tier 2: both files are gitignored. Never commit them.")
     return 0
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "0.70.0"
+version = "0.71.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Path A of the de-id master consolidation. Closes the architectural question Chaz raised after v0.70.0: *"do all de-id scripts run off the new master? anything re-id'ed goes to Downloads?"*

The v0.70.0 master was purely additive (only 2 tools used it). Path A makes it the source of truth for `.known_names.txt` (the scrub-pass roster used by every `grader_deidentify_*` tool) without disturbing the grader pipeline's hot path.

## What changed

- `build_deid_master.py` writes `.known_names.txt` alongside the master on every build — one new helper `render_known_names_lines()` emits both sortable and display forms per student
- 7 new tests (550 passing total, up from 543)

## Unchanged (deliberate)

- `grader_fetch.py`'s `update_known_names()` still appends submitters who weren't in the People view (additive, not replacement)
- Per-assignment `.keymap.json` files untouched. Grader pipeline unchanged.

**Path B** (full migration — master replaces per-assignment keymaps) approved in principle but deferred per operator direction.

## Test plan

- [x] 550 passing tests (the 7 sprint failures are pre-existing and require a live Canvas token)
- [x] 7 new tests cover both-forms emission, header comments, dedup, empty-name skip, single-word names, determinism, sort order
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
