### PR TITLE
feat: BYUI SAS accommodation sprint — quiz time + test_reschedule + dispatcher (v0.72.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "canvas-toolbox",
       "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Includes agent specs (8) and pedagogical knowledge files (20+) covering course design audits, FERPA-safe LLM grading, Canvas sync, and the BYU-I Learning Model.",
-      "version": "0.71.0",
+      "version": "0.72.0",
       "source": "./",
       "author": {
         "name": "Chaz Clark",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "canvas-toolbox",
   "displayName": "canvas-toolbox",
   "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Agent specs cover course audits (rubric coverage / quality, syllabus, CLO quality, alignment chain, accessibility, workload, grading structure / load, formative variety, learning model), Canvas sync paths (course / blueprint / Page-level orphan cleanup), and a generic LLM-grading pipeline (de-identify → consensus → reconcile → push). Knowledge files cover Canvas API + lessons learned, rubrics, assessments, backwards design, cognitive load theory, Hattie 3-phase, Merrill's First Principles, BYU-I Learning Model, BYUI Course Design Standards, and 14+ other pedagogical frameworks. Brain-agnostic by design: the LLM provider is your choice.",
-  "version": "0.71.0",
+  "version": "0.72.0",
   "author": {
     "name": "Chaz Clark",
     "url": "https://github.com/chaz-clark"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,78 @@ private channel is for security.
 
 _Last updated: 2026-06-26_
 
-### Recent: Path A migration — `.known_names.txt` auto-derived from the de-id master (v0.71.0, 2026-06-26)
+### Recent: BYUI SAS accommodation sprint — quiz time extension + test_reschedule + apply dispatcher (v0.72.0, 2026-06-26)
+
+**v0.72.0** — three-item sprint closing out the BYUI Accessibility
+Services catalog dispatch chain. Triggered by the life-pm handoff at
+`handoffs/2026-06-26-accessibility-accommodations-catalog.md`.
+
+**S1 — `lib/tools/student_quiz_time_extension.py`** (~265 lines).
+Per-student quiz time multiplier (1.5x, 2.0x, or any > 1.0). Targets
+CLASSIC Canvas quizzes only (New Quizzes documented as a follow-up).
+Pulls quiz `time_limit` from API; computes `extra_time` minutes via
+`ceil(time_limit * (multiplier - 1))`; POSTs to `/quizzes/<id>/extensions`
+with `quiz_extensions[][user_id]` + `quiz_extensions[][extra_time]`.
+Scopes: `--quiz-id` (one) or `--all-timed` (every timed quiz in
+course). PII-free via `--user-id` or `--deid-code` lookup. Auto-skips
+untimed quizzes. Pure-helper `compute_extra_minutes` uses `math.ceil`
+so partial minutes always round UP — the student never gets less time
+than the multiplier promises.
+
+**S2 — `--shift-by-days N` mode on `student_late_accommodation.py`**.
+For SAS `test_reschedule` (distinct from `occasional_extensions`):
+shift unlock/due/lock forward by N days instead of dropping lock_at.
+New pure helper `shift_iso_timestamp(ts, days)` advances the date
+prefix of an ISO 8601 string while preserving the time-of-day and
+timezone suffix (no full tz parser needed — string-prefix arithmetic
+is sufficient for accommodation-grade precision). New
+`build_shift_payload(assignment, user_id, days)` is the
+analog of `build_override_payload` but emits all three dates shifted.
+
+**S3 — `lib/tools/apply_sas_accommodations.py`** (~280 lines). YAML
+dispatcher. Reads `grading/.sas_accommodations.yml`, walks each
+student × accommodation, classifies each `key` into one of 4 tiers
+(`canvas` / `proctoring` / `policy` / `unknown`). Canvas-tier
+accommodations are invoked as subprocess calls to the matching tool
+(so each tool stays standalone, no cross-tool imports). Proctoring +
+policy tiers surface as a one-line operator checklist. Audit trail
+written to `grading/.sas_accommodations_applied.log` (FERPA tier 2,
+gitignored). Catalog hard-coded in three frozen sets at the top of
+the module — single source of truth, easy to extend when life-pm
+surfaces new accommodation types.
+
+**Knowledge file — `lib/agents/knowledge/sas_accommodations_knowledge.md`**
+vendors the life-pm catalog into the canvas-toolbox knowledge surface
+so future agents can reason about SAS dispatch without re-reading the
+handoff each time. Maps every catalog key → tier → tool invocation;
+documents the YAML handoff schema; explains the
+"how to add a new key" extension process.
+
+**README — 12th workflow row + dedicated SAS section** between
+the de-id master section and "Sharing your grader." Late-work
+accommodation section now distinguishes the two flavors (drop lock_at
+for `occasional_extensions` vs `--shift-by-days N` for
+`test_reschedule`) in addition to the four scoping modes.
+
+**55 new tests passing** (605 passing total, up from 550):
+- 21 tests for quiz time extension (compute_extra_minutes ceil
+  behavior, filter_timed_quizzes, payload shape, master lookup edge
+  cases)
+- 12 new tests for shift-by-days mode (shift_iso_timestamp edge
+  cases: month/year boundaries, timezone preservation, null
+  passthrough, negative-days defensive; build_shift_payload all-three-
+  dates invariant)
+- 22 tests for SAS dispatcher (classify_key for all catalog members,
+  plan_one_accommodation for each canvas-tier key with default + YAML
+  overrides, plan_entries flatten/skip/order behavior, audit-line
+  format invariants)
+
+**What's NOT yet done (deferred):**
+- New Quizzes (LTI) support — they use a different endpoint
+- `apply_sas_accommodations.py` is invoked manually; future work
+  could wire it into a daily/weekly cron or post-fetch hook
+
+### Earlier: Path A migration — `.known_names.txt` auto-derived from the de-id master (v0.71.0, 2026-06-26)
 
 **v0.71.0** — Path A of the de-id master consolidation. Mid-build
 operator question after v0.70.0 shipped: *"Do all de-id scripts run

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ That's the grading workflow. The toolbox does more — audits, sync, sharing, se
 
 ## What you can ask your AI agent to do
 
-Eleven workflows. Each one is a prompt your agent can act on.
+Twelve workflows. Each one is a prompt your agent can act on.
 
 | You want to… | Ask your agent | What happens |
 |---|---|---|
@@ -52,7 +52,8 @@ Eleven workflows. Each one is a prompt your agent can act on.
 | **Pull New Quiz response data** | *"Pull the per-student responses from quiz <id>"* | The New Quizzes API doesn't expose responses directly; the toolkit reads them via the student-analysis report. FERPA-safe by default (uid-keyed; names opt-in). |
 | **Grade an assignment end-to-end** | *"Grade the KC1 assignment"* | Fetch → de-identify → 3-pass consensus → review surface (`_all_comments.md`) → push gated behind `--mark-reviewed`. You approve every grade. |
 | **Run a UW / UF check (Title IV)** | *"Run a UW check with UF date 2026-04-15"* or *"Last participation report"* | Classifies each enrolled student as ACTIVE / UW / UF / NEVER_PARTICIPATED by their last academically related activity vs your UF cutoff. PDF + MD report drops in **~/Downloads/** (outside the repo — FERPA tier 3). Compliant with 34 CFR 668.22 + the 2025-2026 FSA Handbook (verified 2026-06-26). |
-| **Give one student late-work accommodation** | *"Give student S-95DBB6 late-work grace for the rest of the semester"* / *"…starting from the last 2 weeks"* / *"…on assignment 1234 only"* | Writes per-student assignment overrides that keep the original open + due dates but **drop the close date** — so the student can submit after the deadline (marked late, still accepted) without affecting the class. **4 scoping modes**: one assignment, whole semester, from a date forward, or rolling window (e.g. last 14 days through end of term). Resolves the target student PII-free via the [de-id master](#the-de-id-master--the-primitive-under-everything). |
+| **Give one student late-work accommodation** | *"Give student S-95DBB6 late-work grace for the rest of the semester"* / *"…starting from the last 2 weeks"* / *"…on assignment 1234 only"* | Writes per-student assignment overrides that keep the original open + due dates but **drop the close date** — so the student can submit after the deadline (marked late, still accepted) without affecting the class. **4 scoping modes**: one assignment, whole semester, from a date forward, or rolling window. **Also**: `--shift-by-days N` mode for *test_reschedule* accommodations (moves unlock/due/lock forward by N days). Resolves the target student PII-free via the [de-id master](#the-de-id-master--the-primitive-under-everything). |
+| **Apply a BYUI Accessibility Services letter** | *"Apply the SAS accommodations for this student"* / *"Run my .sas_accommodations.yml"* | Reads `grading/.sas_accommodations.yml` (produced by life-pm from your BYUI Outlook inbox), dispatches per accommodation key. **Canvas-tier** (quiz time extension 1.5x/2.0x, occasional extensions, test reschedule) auto-runs; **proctoring-tier** (Proctorio breaks, private testing room) + **policy-tier** (spelling/grammar, attendance, recording, etc.) surface as an instructor checklist. Audit log at `grading/.sas_accommodations_applied.log`. |
 | **Share your grader with another faculty teaching the same course** | *"Bundle this course's rubrics and configs to share with another faculty"* | Exports a ZIP with rubrics, task specs, configs, course-level pitfalls. Your personal voice file is REFUSED by the export — by design. They build their own voice. |
 | **Roll out a new semester** | *"Sync my master course to the spring section"* | Master → Blueprint; Canvas handles section distribution. Safety gates keep section edits from leaking back to master. |
 
@@ -344,9 +345,16 @@ Full audit documentation: [`course_engagement_audit_knowledge.md`](lib/agents/kn
 
 When ONE student needs permission to submit late — for any reason, on some or all assignments — the toolkit writes Canvas **assignment overrides** that keep the original open and due dates but **drop the close date**. The student still sees the original due date (no artificial deadline extension shown), but submitting after it stays accepted, marked "late." The class is unaffected.
 
-## Four scoping modes
+## Two flavors of accommodation + four scoping modes
 
-Pick the one that matches the accommodation you're granting:
+**Flavors** (which Canvas dates to change):
+
+| Flavor | What happens | When you'd use it | SAS catalog key |
+|---|---|---|---|
+| Default (drop `lock_at`) | Keep original open/due; remove the close date | *"Allow late submission without penalty"* — student still sees the original deadline, can submit after | `occasional_extensions` |
+| `--shift-by-days N` | Shift open + due + close forward by N days | *"Reschedule the exam for this student"* — student gets a moved window with a real hard close | `test_reschedule` |
+
+**Scopes** (which assignments to apply to):
 
 | Scope flag | What it covers | When you'd use it |
 |---|---|---|
@@ -392,6 +400,30 @@ One row per enrolled student, four columns: `deid_code, user_id, sortable_name, 
 **You** look up "Sydney" in the local CSV → see `S-95DBB6` → hand the agent only that code. The tool reads only the `user_id` column. Names never cross the LLM boundary.
 
 Full knowledge file: [`deid_master_knowledge.md`](lib/agents/knowledge/deid_master_knowledge.md).
+
+---
+
+# BYUI Accessibility Services accommodations (SAS dispatcher)
+
+If you're at BYU-Idaho and you get accommodation letters from `byui.as@accessiblelearning.com`, the `apply_sas_accommodations.py` dispatcher closes the loop. Your **life-pm** repo reads your Outlook for the letters, extracts the catalog keys (PII-free), and drops a structured YAML at `grading/.sas_accommodations.yml`. Canvas-toolbox reads the YAML and dispatches each accommodation to the right tool.
+
+```bash
+# Dry-run — see what the dispatcher plans to do
+uv run python lib/tools/apply_sas_accommodations.py
+
+# Apply
+uv run python lib/tools/apply_sas_accommodations.py --apply
+```
+
+Three tiers:
+
+| Tier | Count | Behavior |
+|---|---|---|
+| **Canvas** | 4 keys (`extra_time_1.5x`, `extra_time_2.0x`, `occasional_extensions`, `test_reschedule`) | Dispatcher invokes the matching tool (quiz time extension or late-work override) |
+| **Proctoring** | 2 keys (`proctorio_breaks`, `private_room_exams`) | Surface as a checklist line for the operator — out of Canvas API scope |
+| **Policy** | 11 keys (`spelling_grammar`, `attendance_notification`, `recording_device`, etc.) | Surface as instructor-practice checklist — no LMS change |
+
+Every action lands in an audit log at `grading/.sas_accommodations_applied.log` (FERPA tier 2, gitignored). Full catalog + handoff schema: [`sas_accommodations_knowledge.md`](lib/agents/knowledge/sas_accommodations_knowledge.md).
 
 ---
 
@@ -445,6 +477,6 @@ The architecture (FERPA two-zone, voice-preservation contract, consensus-based g
 
 ---
 
-**Current version:** v0.71.0 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 550 unit tests · 20+ pedagogical knowledge files for AI-architected course design · course-wide de-id master is now authoritative for the scrub-pass roster · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
+**Current version:** v0.72.0 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 605 unit tests · 20+ pedagogical knowledge files for AI-architected course design · BYUI SAS accommodation dispatcher (quiz time extension + late-work + test reschedule) · ~70 versioned releases since v0.1. Running release log + per-feature rationale in [`AGENTS.md`](AGENTS.md) Active Context.
 
 For help, see the doc tree above or file a `cb-report-bug` (~1 second roundtrip; no GitHub account needed).

--- a/lib/agents/knowledge/sas_accommodations_knowledge.md
+++ b/lib/agents/knowledge/sas_accommodations_knowledge.md
@@ -1,0 +1,113 @@
+# SAS accommodations — catalog + dispatch knowledge
+
+**Source:** life-pm produces SAS accommodation handoffs from BYUI
+Accessibility Services notification letters (sender:
+`byui.as@accessiblelearning.com`, subject pattern: `[AS] <student> -
+<COURSE> - … - Notification of Disability Accommodations <Term>`).
+
+**Consumed by:** `lib/tools/apply_sas_accommodations.py` (v0.72.0).
+
+**Why this file exists:** the catalog of accommodation types is
+stable boilerplate — the AS office issues the same set of standardized
+asks letter-to-letter. Codifying them once here lets the dispatcher
+classify every observed key without LLM judgment, and lets future
+agents reason about what's automatable vs. instructor-discretion.
+
+---
+
+## Three tiers — what gets automated, what's a flag
+
+| Tier | Count | Examples | Dispatcher behavior |
+|---|---|---|---|
+| `canvas` | 4 | `extra_time_1.5x`, `extra_time_2.0x`, `occasional_extensions`, `test_reschedule` | Invoke the matching canvas-toolbox tool |
+| `proctoring` | 2 | `proctorio_breaks`, `private_room_exams` | Flag for operator — out of Canvas API scope |
+| `policy` | 11 | `spelling_grammar`, `attendance_notification`, `recording_device`, `assignment_clarification`, etc. | Flag for operator — instructor-practice, no LMS toggle |
+
+---
+
+## Canvas-tier key → tool dispatch
+
+| Catalog key | Faculty ask | Dispatched tool | Notes |
+|---|---|---|---|
+| `extra_time_1.5x` | "Please allow 50% extra time on all timed exams and quizzes." | `student_quiz_time_extension --multiplier 1.5 --all-timed` | Classic Quizzes only. New Quizzes follow-up. |
+| `extra_time_2.0x` | "Please allow 100% extra time (double time) on all exams and quizzes." | `student_quiz_time_extension --multiplier 2.0 --all-timed` | Same scope as 1.5x. |
+| `occasional_extensions` | "Students are expected to meet assignment deadlines. However, occasional extensions may be appropriate…" | `student_late_accommodation --all` (or scoped by YAML `scope`) | Dropped `lock_at` (no close date). Scope flags: `from_days_ago`, `from`. |
+| `test_reschedule` | "This student has health issues that may warrant a need to reschedule their exam date…" | `student_late_accommodation --shift-by-days N` | Shifts unlock/due/lock forward by N days. Distinct from `occasional_extensions`. |
+
+---
+
+## Proctoring-tier flags (faculty handle outside Canvas)
+
+| Catalog key | Faculty ask | What operator does |
+|---|---|---|
+| `proctorio_breaks` | "This student may need to look away from the computer screen or take a break…" | Whitelist behavior in the course's Proctorio config so monitoring doesn't flag it. |
+| `private_room_exams` | "The student needs access to a private room with reduced distraction…" | Coordinate with the BYUI Testing Center; student reserves a private room in advance. |
+
+---
+
+## Policy-tier flags (instructor practice, no LMS change)
+
+All 11 policy-tier keys surface as a one-line note in the dispatcher
+output. Faculty add them to their personal accommodation checklist for
+that student. None of these have a Canvas API counterpart.
+
+| Catalog key | Faculty ask |
+|---|---|
+| `assignment_clarification` | Allow student to communicate with you / TA for clarification. |
+| `recording_device` | Permission to record lectures for personal educational use. |
+| `breaks_during_class` | Permission to leave class briefly for short breaks. |
+| `spelling_grammar` | Consider not penalizing spelling/grammar errors (subject to fundamental-alteration clause). |
+| `food_drink_medication` | Permission to have food/drink/medication accessible during class & exams. |
+| `class_participation_mod` | Advance notice when called on; provide questions in advance; consider alternate assignments (subject to fundamental-alteration clause). |
+| `attendance_notification` | Flexibility for cyclical acute episodes affecting attendance. |
+| `hat_in_class` / `hat_in_class_testing` | Permission to wear a hat (dress-standard exception). |
+| `tinted_glasses` | Permission to wear tinted glasses in class/testing. |
+| `service_animal` | Refer to BYUI Animal Policy. |
+
+---
+
+## Handoff schema (YAML — `grading/.sas_accommodations.yml`)
+
+FERPA tier 2 (gitignored). The de-id master sits next to it
+(`grading/.deid_master.csv`) so the dispatcher resolves `deid_code` →
+`user_id` without ever reading sortable_name.
+
+```yaml
+- deid_code: S-95DBB6           # required, looked up in de-id master
+  letter_date: 2026-06-22       # optional, audit trail
+  accommodations:
+    - key: extra_time_1.5x
+    - key: occasional_extensions
+      scope: from_days_ago      # optional: all (default) | from_days_ago | from
+      days: 14
+    - key: test_reschedule
+      shift_by_days: 7          # optional, defaults to 7
+      assignment_id: 12345      # optional, applies to all if absent
+    - key: spelling_grammar     # policy tier → emit checklist line
+    - key: proctorio_breaks     # proctoring tier → emit checklist line
+```
+
+---
+
+## Updating the catalog
+
+When life-pm surfaces a new accommodation type not in the v0.72.0 list:
+
+1. The dispatcher will print `UNKNOWN key '<name>'` and skip it.
+2. Add the key to the right tier set in
+   `apply_sas_accommodations.py` (`_CANVAS_KEYS`, `_PROCTORING_KEYS`,
+   or `_POLICY_KEYS`).
+3. If it's `canvas`-tier, add a branch in `_build_canvas_command()`
+   mapping the key to a tool invocation.
+4. Update the tables in this knowledge file.
+5. Bump the catalog version date in the next handoff.
+
+---
+
+## Related
+
+- `deid_master_knowledge.md` — the de-id master this dispatcher consumes
+- `course_engagement_audit_knowledge.md` — Title IV pattern; same FERPA tier discipline
+- `handoffs/2026-06-26-accessibility-accommodations-catalog.md` — the
+  original life-pm catalog this knowledge file vendors from
+- Cross-repo: `[[project-sas-accommodations-handoff]]` user memory

--- a/lib/tests/test_apply_sas_accommodations_helpers.py
+++ b/lib/tests/test_apply_sas_accommodations_helpers.py
@@ -1,0 +1,227 @@
+"""Tier 1 unit tests — apply_sas_accommodations pure-logic helpers.
+
+Source: lib/tools/apply_sas_accommodations.py
+  - classify_key            (key → tier)
+  - plan_one_accommodation  (single accommodation → DispatchPlan)
+  - plan_entries            (full YAML structure → flat plan list)
+  - render_audit_line       (audit-log format)
+
+No subprocess calls. No file I/O. Pure dispatch logic.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from apply_sas_accommodations import (  # noqa: E402
+    DispatchPlan,
+    classify_key,
+    plan_entries,
+    plan_one_accommodation,
+    render_audit_line,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_key — the 3-tier classification (+ unknown)
+# ---------------------------------------------------------------------------
+
+def test_classify_canvas_keys():
+    assert classify_key("extra_time_1.5x") == "canvas"
+    assert classify_key("extra_time_2.0x") == "canvas"
+    assert classify_key("occasional_extensions") == "canvas"
+    assert classify_key("test_reschedule") == "canvas"
+
+
+def test_classify_proctoring_keys():
+    assert classify_key("proctorio_breaks") == "proctoring"
+    assert classify_key("private_room_exams") == "proctoring"
+
+
+def test_classify_policy_keys():
+    assert classify_key("spelling_grammar") == "policy"
+    assert classify_key("attendance_notification") == "policy"
+    assert classify_key("recording_device") == "policy"
+    assert classify_key("service_animal") == "policy"
+
+
+def test_classify_unknown_key():
+    assert classify_key("not_a_real_key") == "unknown"
+    assert classify_key("") == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# plan_one_accommodation — single accommodation dispatch
+# ---------------------------------------------------------------------------
+
+def test_plan_extra_time_15x():
+    plan = plan_one_accommodation("S-95DBB6", {"key": "extra_time_1.5x"})
+    assert plan.tier == "canvas"
+    assert plan.command is not None
+    assert "student_quiz_time_extension.py" in " ".join(plan.command)
+    assert "--multiplier" in plan.command
+    assert "1.5" in plan.command
+    assert "--all-timed" in plan.command
+    assert "--deid-code" in plan.command
+    assert "S-95DBB6" in plan.command
+
+
+def test_plan_extra_time_20x():
+    plan = plan_one_accommodation("S-95DBB6", {"key": "extra_time_2.0x"})
+    assert "2.0" in plan.command
+
+
+def test_plan_occasional_extensions_defaults_to_all():
+    """No scope key → --all."""
+    plan = plan_one_accommodation("S-X", {"key": "occasional_extensions"})
+    assert plan.tier == "canvas"
+    assert "student_late_accommodation.py" in " ".join(plan.command)
+    assert "--all" in plan.command
+
+
+def test_plan_occasional_extensions_from_days_ago():
+    plan = plan_one_accommodation("S-X", {
+        "key": "occasional_extensions",
+        "scope": "from_days_ago",
+        "days": 14,
+    })
+    assert "--from-days-ago" in plan.command
+    assert "14" in plan.command
+    assert "--all" not in plan.command
+
+
+def test_plan_occasional_extensions_from_date():
+    plan = plan_one_accommodation("S-X", {
+        "key": "occasional_extensions",
+        "scope": "from",
+        "from": "2026-04-01",
+    })
+    assert "--from" in plan.command
+    assert "2026-04-01" in plan.command
+
+
+def test_plan_test_reschedule_defaults_to_7_days():
+    plan = plan_one_accommodation("S-X", {"key": "test_reschedule"})
+    assert plan.tier == "canvas"
+    assert "--shift-by-days" in plan.command
+    assert "7" in plan.command
+    assert "--all" in plan.command  # no assignment_id → all
+
+
+def test_plan_test_reschedule_custom_days_and_assignment():
+    plan = plan_one_accommodation("S-X", {
+        "key": "test_reschedule",
+        "shift_by_days": 14,
+        "assignment_id": 12345,
+    })
+    assert "--shift-by-days" in plan.command
+    assert "14" in plan.command
+    assert "--assignment-id" in plan.command
+    assert "12345" in plan.command
+
+
+def test_plan_proctoring_no_command():
+    plan = plan_one_accommodation("S-X", {"key": "proctorio_breaks"})
+    assert plan.tier == "proctoring"
+    assert plan.command is None
+    assert "PROCTORING" in plan.note
+
+
+def test_plan_policy_no_command():
+    plan = plan_one_accommodation("S-X", {"key": "spelling_grammar"})
+    assert plan.tier == "policy"
+    assert plan.command is None
+    assert "POLICY" in plan.note
+
+
+def test_plan_unknown_key():
+    plan = plan_one_accommodation("S-X", {"key": "fictional_accom"})
+    assert plan.tier == "unknown"
+    assert plan.command is None
+    assert "UNKNOWN" in plan.note
+
+
+def test_plan_missing_key_treated_as_unknown():
+    """An entry with no 'key' field (typo in YAML?) → unknown tier."""
+    plan = plan_one_accommodation("S-X", {})
+    assert plan.tier == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# plan_entries — full handoff structure
+# ---------------------------------------------------------------------------
+
+def test_plan_entries_flattens_two_students():
+    entries = [
+        {"deid_code": "S-AAA",
+         "accommodations": [{"key": "extra_time_1.5x"}]},
+        {"deid_code": "S-BBB",
+         "accommodations": [{"key": "extra_time_2.0x"},
+                            {"key": "occasional_extensions"}]},
+    ]
+    plans = plan_entries(entries)
+    assert len(plans) == 3
+    assert {p.deid_code for p in plans} == {"S-AAA", "S-BBB"}
+
+
+def test_plan_entries_skips_entry_with_no_deid_code():
+    entries = [
+        {"accommodations": [{"key": "extra_time_1.5x"}]},  # no deid_code → skip
+        {"deid_code": "S-X", "accommodations": [{"key": "extra_time_1.5x"}]},
+    ]
+    plans = plan_entries(entries)
+    assert len(plans) == 1
+    assert plans[0].deid_code == "S-X"
+
+
+def test_plan_entries_handles_no_accommodations():
+    """A student entry with no accommodations list emits no plans."""
+    entries = [{"deid_code": "S-AAA"}]
+    plans = plan_entries(entries)
+    assert plans == []
+
+
+def test_plan_entries_handles_empty_list():
+    assert plan_entries([]) == []
+
+
+def test_plan_entries_preserves_order():
+    """Plans come out in document order so the audit log matches the YAML."""
+    entries = [
+        {"deid_code": "S-ONE",
+         "accommodations": [{"key": "extra_time_1.5x"},
+                            {"key": "spelling_grammar"}]},
+    ]
+    plans = plan_entries(entries)
+    assert plans[0].key == "extra_time_1.5x"
+    assert plans[1].key == "spelling_grammar"
+
+
+# ---------------------------------------------------------------------------
+# render_audit_line — audit log format
+# ---------------------------------------------------------------------------
+
+def test_audit_line_contains_all_fields():
+    plan = DispatchPlan(
+        deid_code="S-95DBB6",
+        key="extra_time_1.5x",
+        tier="canvas",
+        command=["foo"],
+        note="Canvas: +50% extra time.",
+    )
+    line = render_audit_line(plan, "APPLIED", "2026-06-26T12:00:00+00:00")
+    assert "S-95DBB6" in line
+    assert "extra_time_1.5x" in line
+    assert "canvas" in line
+    assert "APPLIED" in line
+    assert "2026-06-26T12:00:00+00:00" in line
+
+
+def test_audit_line_tab_separated():
+    """Tab-separated so `cut -f` works on the log file."""
+    plan = DispatchPlan("S-X", "extra_time_1.5x", "canvas", None, "note")
+    line = render_audit_line(plan, "PLANNED", "ts")
+    parts = line.split("\t")
+    assert len(parts) == 6

--- a/lib/tests/test_student_late_accommodation_helpers.py
+++ b/lib/tests/test_student_late_accommodation_helpers.py
@@ -19,10 +19,12 @@ if str(_TOOLS_DIR) not in sys.path:
 
 from student_late_accommodation import (  # noqa: E402
     build_override_payload,
+    build_shift_payload,
     cutoff_from_days_ago,
     filter_assignments_by_due_from,
     filter_my_overrides,
     resolve_user_id_from_master,
+    shift_iso_timestamp,
 )
 
 
@@ -293,3 +295,96 @@ def test_filter_mixed_pre_and_post_cutoff():
     ]
     out = filter_assignments_by_due_from(assignments, "2026-04-15")
     assert [a["id"] for a in out] == [3, 4]
+
+
+# ---------------------------------------------------------------------------
+# shift_iso_timestamp — date-shift helper for test_reschedule
+# ---------------------------------------------------------------------------
+
+def test_shift_basic_forward():
+    """Shift 2026-04-15T23:59:00Z forward 7 days → 2026-04-22T23:59:00Z.
+    Time-of-day and Z suffix preserved."""
+    assert shift_iso_timestamp("2026-04-15T23:59:00Z", 7) == "2026-04-22T23:59:00Z"
+
+
+def test_shift_crosses_month_boundary():
+    """Shift Apr 28 forward 7 → May 5."""
+    assert shift_iso_timestamp("2026-04-28T12:00:00Z", 7) == "2026-05-05T12:00:00Z"
+
+
+def test_shift_crosses_year_boundary():
+    """Shift Dec 30 forward 5 → Jan 4 (next year)."""
+    assert shift_iso_timestamp("2026-12-30T09:00:00Z", 5) == "2027-01-04T09:00:00Z"
+
+
+def test_shift_preserves_timezone_suffix():
+    """Shift must preserve whatever timezone Canvas sent (e.g. -06:00)."""
+    out = shift_iso_timestamp("2026-04-15T23:59:00-06:00", 3)
+    assert out == "2026-04-18T23:59:00-06:00"
+
+
+def test_shift_none_returns_none():
+    """Null timestamps pass through unchanged so callers can chain."""
+    assert shift_iso_timestamp(None, 7) is None
+    assert shift_iso_timestamp("", 7) is None
+
+
+def test_shift_zero_days_returns_same():
+    """Zero days = no shift."""
+    assert shift_iso_timestamp("2026-04-15T23:59:00Z", 0) == "2026-04-15T23:59:00Z"
+
+
+def test_shift_negative_days_goes_backward():
+    """Negative days = move backward. Defensive: not the primary use
+    case but the helper shouldn't crash."""
+    assert shift_iso_timestamp("2026-04-15T23:59:00Z", -2) == "2026-04-13T23:59:00Z"
+
+
+# ---------------------------------------------------------------------------
+# build_shift_payload — POST body for date-shifted overrides
+# ---------------------------------------------------------------------------
+
+def test_shift_payload_includes_lock_at_unlike_default():
+    """KEY DIFFERENCE from build_override_payload: this payload INCLUDES
+    lock_at (shifted). The default override drops lock_at entirely."""
+    assignment = {
+        "unlock_at": "2026-04-01T00:00:00Z",
+        "due_at": "2026-04-15T23:59:00Z",
+        "lock_at": "2026-04-22T23:59:00Z",
+    }
+    payload = build_shift_payload(assignment, user_id=1, days=7)
+    assert "assignment_override[lock_at]" in payload
+    assert payload["assignment_override[lock_at]"] == "2026-04-29T23:59:00Z"
+
+
+def test_shift_payload_shifts_all_three_dates():
+    assignment = {
+        "unlock_at": "2026-04-01T00:00:00Z",
+        "due_at": "2026-04-15T23:59:00Z",
+        "lock_at": "2026-04-22T23:59:00Z",
+    }
+    payload = build_shift_payload(assignment, user_id=1, days=7)
+    assert payload["assignment_override[unlock_at]"] == "2026-04-08T00:00:00Z"
+    assert payload["assignment_override[due_at]"] == "2026-04-22T23:59:00Z"
+    assert payload["assignment_override[lock_at]"] == "2026-04-29T23:59:00Z"
+
+
+def test_shift_payload_includes_student_id_and_title():
+    payload = build_shift_payload({}, user_id=173819, days=7)
+    assert payload["assignment_override[student_ids][]"] == 173819
+    assert "reschedule" in payload["assignment_override[title]"].lower()
+
+
+def test_shift_payload_omits_missing_dates():
+    """If due_at is null, the payload just omits it — doesn't crash."""
+    assignment = {"due_at": None, "unlock_at": None, "lock_at": None}
+    payload = build_shift_payload(assignment, user_id=1, days=7)
+    assert "assignment_override[due_at]" not in payload
+    assert "assignment_override[unlock_at]" not in payload
+    assert "assignment_override[lock_at]" not in payload
+
+
+def test_shift_payload_custom_title():
+    payload = build_shift_payload({}, user_id=1, days=7,
+                                  title="Bereavement reschedule")
+    assert payload["assignment_override[title]"] == "Bereavement reschedule"

--- a/lib/tests/test_student_quiz_time_extension_helpers.py
+++ b/lib/tests/test_student_quiz_time_extension_helpers.py
@@ -1,0 +1,177 @@
+"""Tier 1 unit tests — student_quiz_time_extension pure-logic helpers.
+
+Source: lib/tools/student_quiz_time_extension.py
+  - compute_extra_minutes   (multiplier → extra minutes, ceil)
+  - filter_timed_quizzes    (skip untimed quizzes)
+  - resolve_user_id_from_master  (CSV lookup, PII-aware)
+  - build_extension_payload (POST body construction)
+
+No Canvas API calls. Pure functions in/out.
+"""
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from student_quiz_time_extension import (  # noqa: E402
+    build_extension_payload,
+    compute_extra_minutes,
+    filter_timed_quizzes,
+    resolve_user_id_from_master,
+)
+
+
+# ---------------------------------------------------------------------------
+# compute_extra_minutes — multiplier to extra minutes
+# ---------------------------------------------------------------------------
+
+def test_extra_minutes_15x_on_60min_quiz():
+    """1.5x on a 60-minute quiz → 30 extra minutes (50% of 60)."""
+    assert compute_extra_minutes(60, 1.5) == 30
+
+
+def test_extra_minutes_20x_on_60min_quiz():
+    """2.0x on a 60-minute quiz → 60 extra minutes (double time)."""
+    assert compute_extra_minutes(60, 2.0) == 60
+
+
+def test_extra_minutes_125x_on_60min_quiz():
+    """1.25x on a 60-minute quiz → 15 extra minutes."""
+    assert compute_extra_minutes(60, 1.25) == 15
+
+
+def test_extra_minutes_ceils_partial_minute():
+    """1.5x on a 45-minute quiz → 22.5 → ceil → 23 minutes.
+    Always round UP so the student never gets less than promised."""
+    assert compute_extra_minutes(45, 1.5) == 23
+
+
+def test_extra_minutes_ceils_one_third():
+    """1.33x on a 60-minute quiz → 19.8 → 20 minutes."""
+    assert compute_extra_minutes(60, 1.33) == 20
+
+
+def test_extra_minutes_none_for_untimed_quiz():
+    """time_limit is None (untimed quiz) → return None so caller skips."""
+    assert compute_extra_minutes(None, 1.5) is None
+
+
+def test_extra_minutes_none_for_zero_time_limit():
+    """A time_limit of 0 (or negative) is meaningless → return None."""
+    assert compute_extra_minutes(0, 1.5) is None
+    assert compute_extra_minutes(-5, 1.5) is None
+
+
+def test_extra_minutes_zero_at_multiplier_1():
+    """1.0x = no extension → 0 extra minutes (caller may skip)."""
+    assert compute_extra_minutes(60, 1.0) == 0
+
+
+def test_extra_minutes_zero_at_multiplier_less_than_1():
+    """Multiplier < 1 doesn't make sense for accommodations; return 0
+    rather than negative. (CLI validates > 1.0 before getting here, but
+    the helper is defensive.)"""
+    assert compute_extra_minutes(60, 0.5) == 0
+
+
+# ---------------------------------------------------------------------------
+# filter_timed_quizzes — skip untimed quizzes
+# ---------------------------------------------------------------------------
+
+def test_filter_keeps_quiz_with_time_limit():
+    quizzes = [{"id": 1, "time_limit": 60}]
+    assert len(filter_timed_quizzes(quizzes)) == 1
+
+
+def test_filter_drops_quiz_with_null_time_limit():
+    """Untimed quizzes don't need an extension."""
+    quizzes = [{"id": 1, "time_limit": None}]
+    assert filter_timed_quizzes(quizzes) == []
+
+
+def test_filter_drops_quiz_with_missing_time_limit_key():
+    """Defensive: time_limit key absent entirely."""
+    quizzes = [{"id": 1}]
+    assert filter_timed_quizzes(quizzes) == []
+
+
+def test_filter_drops_quiz_with_zero_time_limit():
+    quizzes = [{"id": 1, "time_limit": 0}]
+    assert filter_timed_quizzes(quizzes) == []
+
+
+def test_filter_mixed_set():
+    quizzes = [
+        {"id": 1, "time_limit": 60},   # keep
+        {"id": 2, "time_limit": None}, # drop
+        {"id": 3, "time_limit": 30},   # keep
+        {"id": 4},                      # drop
+        {"id": 5, "time_limit": 0},    # drop
+    ]
+    out = filter_timed_quizzes(quizzes)
+    assert sorted(q["id"] for q in out) == [1, 3]
+
+
+# ---------------------------------------------------------------------------
+# resolve_user_id_from_master — CSV lookup (duplicated helper)
+# ---------------------------------------------------------------------------
+
+def _write_master(tmp_path: Path) -> Path:
+    p = tmp_path / ".deid_master.csv"
+    with p.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.DictWriter(fh, fieldnames=["deid_code", "user_id",
+                                            "sortable_name", "withdrawn"])
+        w.writeheader()
+        w.writerow({"deid_code": "S-95DBB6", "user_id": "173819",
+                    "sortable_name": "Ahlstrom, Sydney", "withdrawn": "0"})
+    return p
+
+
+def test_resolve_basic(tmp_path):
+    p = _write_master(tmp_path)
+    assert resolve_user_id_from_master(p, "S-95DBB6") == 173819
+
+
+def test_resolve_case_insensitive(tmp_path):
+    p = _write_master(tmp_path)
+    assert resolve_user_id_from_master(p, "s-95dbb6") == 173819
+
+
+def test_resolve_missing_master_points_at_builder(tmp_path):
+    nope = tmp_path / "absent.csv"
+    with pytest.raises(FileNotFoundError) as exc_info:
+        resolve_user_id_from_master(nope, "S-X")
+    assert "build_deid_master" in str(exc_info.value)
+
+
+def test_resolve_missing_code(tmp_path):
+    p = _write_master(tmp_path)
+    with pytest.raises(KeyError):
+        resolve_user_id_from_master(p, "S-NOTHERE")
+
+
+# ---------------------------------------------------------------------------
+# build_extension_payload — POST body
+# ---------------------------------------------------------------------------
+
+def test_payload_includes_user_id():
+    payload = build_extension_payload(user_id=173819, extra_time_minutes=30)
+    assert payload["quiz_extensions[][user_id]"] == 173819
+
+
+def test_payload_includes_extra_time():
+    payload = build_extension_payload(user_id=1, extra_time_minutes=30)
+    assert payload["quiz_extensions[][extra_time]"] == 30
+
+
+def test_payload_canvas_array_syntax():
+    """Canvas requires array-suffix keys ([]) for quiz_extensions.
+    If we ever drop them, the API silently ignores the extension."""
+    payload = build_extension_payload(user_id=1, extra_time_minutes=30)
+    for key in payload:
+        assert "[]" in key, f"missing array syntax in key: {key}"

--- a/lib/tools/apply_sas_accommodations.py
+++ b/lib/tools/apply_sas_accommodations.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+apply_sas_accommodations.py — Dispatcher for BYUI Accessibility Services
+accommodation letters.
+
+Reads a structured SAS handoff (YAML), dispatches each accommodation
+to the right Canvas tool per the catalog at
+`lib/agents/knowledge/sas_accommodations_knowledge.md`. Three tiers:
+
+  canvas      — calls a canvas-toolbox tool (per-student override / extension)
+  proctoring  — flags for the operator (Proctorio / Testing Center setup)
+  policy      — flags for the operator (instructor-practice checklist;
+                no Canvas API change)
+
+PII-FREE END TO END
+  The YAML carries `deid_code`, never names. The dispatcher resolves
+  code → user_id via the de-id master only when needed by a downstream
+  tool, and never reads the sortable_name column.
+
+HANDOFF SCHEMA (life-pm produces; canvas-toolbox consumes)
+
+  Default path: grading/.sas_accommodations.yml (FERPA tier 2 gitignored)
+
+  - deid_code: S-95DBB6
+    letter_date: 2026-06-22
+    accommodations:
+      - key: extra_time_1.5x       # required
+      - key: occasional_extensions
+        scope: from_days_ago       # optional, defaults to all
+        days: 14
+      - key: test_reschedule
+        shift_by_days: 7           # optional, defaults to 7
+        assignment_id: 12345       # optional; if absent, applies to all
+      - key: spelling_grammar      # policy tier → emit checklist line
+      - key: proctorio_breaks      # proctoring tier → emit checklist line
+
+KEY → TOOL MAPPING (only the canvas tier is dispatched here;
+proctoring + policy are surfaced as a checklist)
+
+  extra_time_1.5x       → student_quiz_time_extension --multiplier 1.5 --all-timed
+  extra_time_2.0x       → student_quiz_time_extension --multiplier 2.0 --all-timed
+  occasional_extensions → student_late_accommodation --all
+                          (with optional scope flags from YAML)
+  test_reschedule       → student_late_accommodation --shift-by-days N
+
+USAGE — dry-run by default
+  uv run python lib/tools/apply_sas_accommodations.py
+  uv run python lib/tools/apply_sas_accommodations.py --apply
+  uv run python lib/tools/apply_sas_accommodations.py \\
+    --file /path/to/.sas_accommodations.yml --apply
+
+REQUIRES in .env: CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID
+REQUIRES: grading/.deid_master.csv (build with build_deid_master.py)
+REQUIRES (Python deps): pyyaml (already in canvas-toolbox dependencies)
+
+Resolves: the rest of the SAS catalog dispatch path. Audit log is
+written to grading/.sas_accommodations_applied.log (tier 2, gitignored)
+so faculty have a per-semester record of what was applied.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("ERROR: pyyaml is required. Install with: uv sync", file=sys.stderr)
+    sys.exit(2)
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+_DEFAULT_HANDOFF = Path("grading/.sas_accommodations.yml")
+_DEFAULT_AUDIT_LOG = Path("grading/.sas_accommodations_applied.log")
+
+
+# ---------------------------------------------------------------------------
+# Catalog — the single source of truth for what each key dispatches to
+# ---------------------------------------------------------------------------
+
+# Tier classification per the catalog handoff
+# (handoffs/2026-06-26-accessibility-accommodations-catalog.md).
+_CANVAS_KEYS = {
+    "extra_time_1.5x",
+    "extra_time_2.0x",
+    "occasional_extensions",
+    "test_reschedule",
+}
+_PROCTORING_KEYS = {
+    "proctorio_breaks",
+    "private_room_exams",
+}
+_POLICY_KEYS = {
+    "assignment_clarification",
+    "recording_device",
+    "breaks_during_class",
+    "spelling_grammar",
+    "food_drink_medication",
+    "class_participation_mod",
+    "attendance_notification",
+    "hat_in_class",
+    "tinted_glasses",
+    "service_animal",
+}
+_ALL_KEYS = _CANVAS_KEYS | _PROCTORING_KEYS | _POLICY_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no I/O, no subprocess — easy to unit-test)
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DispatchPlan:
+    """One planned action for one student × one accommodation key."""
+    deid_code: str
+    key: str
+    tier: str               # "canvas" | "proctoring" | "policy" | "unknown"
+    command: list[str] | None  # CLI argv for canvas tier; None otherwise
+    note: str               # human-readable explanation (always set)
+
+
+def classify_key(key: str) -> str:
+    """Return 'canvas' | 'proctoring' | 'policy' | 'unknown' for a key."""
+    if key in _CANVAS_KEYS:
+        return "canvas"
+    if key in _PROCTORING_KEYS:
+        return "proctoring"
+    if key in _POLICY_KEYS:
+        return "policy"
+    return "unknown"
+
+
+def plan_one_accommodation(deid_code: str, acc: dict) -> DispatchPlan:
+    """Build one DispatchPlan from a single accommodation dict.
+
+    Doesn't run anything — just decides what WOULD run. The CLI walks
+    a list of these and executes the `canvas` tier ones when --apply
+    is set.
+    """
+    key = (acc.get("key") or "").strip()
+    tier = classify_key(key)
+
+    if tier == "canvas":
+        cmd, note = _build_canvas_command(deid_code, key, acc)
+        return DispatchPlan(deid_code, key, "canvas", cmd, note)
+
+    if tier == "proctoring":
+        return DispatchPlan(
+            deid_code, key, "proctoring", None,
+            f"PROCTORING: faculty action required outside Canvas "
+            f"(Proctorio config or Testing Center reservation).",
+        )
+
+    if tier == "policy":
+        return DispatchPlan(
+            deid_code, key, "policy", None,
+            f"POLICY: instructor-practice flag — no LMS change. "
+            f"Add to your accommodation checklist for this student.",
+        )
+
+    return DispatchPlan(
+        deid_code, key, "unknown", None,
+        f"UNKNOWN key {key!r} — not in the v0.72.0 catalog. Skipping. "
+        f"Either typo in the YAML or a new SAS accommodation type that "
+        f"needs adding to lib/agents/knowledge/sas_accommodations_knowledge.md.",
+    )
+
+
+def _build_canvas_command(deid_code: str, key: str,
+                          acc: dict) -> tuple[list[str], str]:
+    """Build the CLI argv for one canvas-tier accommodation.
+
+    Returns (argv, note). Note is a human-readable summary the CLI prints.
+
+    Tools are invoked as subprocess so they each enforce their own
+    env-validation + .env loading + de-id master lookup. We do NOT
+    cross-import them — each tool stays standalone.
+    """
+    common = ["uv", "run", "python", "lib/tools/"]
+
+    if key == "extra_time_1.5x":
+        cmd = common + ["student_quiz_time_extension.py",
+                        "--deid-code", deid_code,
+                        "--multiplier", "1.5",
+                        "--all-timed"]
+        note = "Canvas: +50% extra time on all timed classic quizzes."
+        return cmd, note
+
+    if key == "extra_time_2.0x":
+        cmd = common + ["student_quiz_time_extension.py",
+                        "--deid-code", deid_code,
+                        "--multiplier", "2.0",
+                        "--all-timed"]
+        note = "Canvas: +100% (double time) on all timed classic quizzes."
+        return cmd, note
+
+    if key == "occasional_extensions":
+        # Default: --all (whole-semester backdated lock_at=null grant).
+        # YAML may override scope: 'from_days_ago' or 'from' for a tighter window.
+        cmd = common + ["student_late_accommodation.py",
+                        "--deid-code", deid_code]
+        scope = (acc.get("scope") or "").strip()
+        if scope == "from_days_ago":
+            days = int(acc.get("days", 14))
+            cmd += ["--from-days-ago", str(days)]
+            note = f"Canvas: lock_at=null on assignments due in the last {days} days + future."
+        elif scope == "from":
+            cutoff = str(acc.get("from") or "").strip()
+            cmd += ["--from", cutoff]
+            note = f"Canvas: lock_at=null on assignments due on/after {cutoff}."
+        else:
+            cmd += ["--all"]
+            note = "Canvas: lock_at=null on ALL published assignments (backdated)."
+        return cmd, note
+
+    if key == "test_reschedule":
+        days = int(acc.get("shift_by_days", 7))
+        cmd = common + ["student_late_accommodation.py",
+                        "--deid-code", deid_code,
+                        "--shift-by-days", str(days)]
+        if acc.get("assignment_id"):
+            cmd += ["--assignment-id", str(int(acc["assignment_id"]))]
+            scope_text = f"assignment {acc['assignment_id']}"
+        else:
+            cmd += ["--all"]
+            scope_text = "ALL published assignments"
+        note = f"Canvas: shift unlock+due+lock forward {days} days on {scope_text}."
+        return cmd, note
+
+    # Should never reach (classify_key filtered to canvas already)
+    raise AssertionError(f"unhandled canvas-tier key: {key}")
+
+
+def plan_entries(entries: list[dict]) -> list[DispatchPlan]:
+    """Walk an entire SAS handoff YAML and produce a flat list of
+    DispatchPlan objects — one per (student, accommodation key) pair."""
+    out: list[DispatchPlan] = []
+    for entry in entries:
+        deid = (entry.get("deid_code") or "").strip()
+        if not deid:
+            continue
+        for acc in entry.get("accommodations") or []:
+            out.append(plan_one_accommodation(deid, acc))
+    return out
+
+
+def render_audit_line(plan: DispatchPlan, status: str,
+                      timestamp: str) -> str:
+    """One line for the applied-audit log. Single-line CSV-ish format
+    so it's easy to grep / tail later."""
+    return (f"{timestamp}\t{status}\t{plan.deid_code}\t{plan.key}\t"
+            f"{plan.tier}\t{plan.note}")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    ap.add_argument("--file", type=Path, default=_DEFAULT_HANDOFF,
+                    help=f"SAS handoff YAML (default {str(_DEFAULT_HANDOFF)!r})")
+    ap.add_argument("--audit-log", type=Path, default=_DEFAULT_AUDIT_LOG,
+                    help=f"audit log path (default {str(_DEFAULT_AUDIT_LOG)!r})")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually invoke the downstream tools "
+                         "(without this, dry-run prints planned commands)")
+    args = ap.parse_args()
+
+    if not args.file.exists():
+        print(f"ERROR: SAS handoff not found at {args.file}.", file=sys.stderr)
+        print(f"Expected schema documented in: "
+              f"lib/agents/knowledge/sas_accommodations_knowledge.md",
+              file=sys.stderr)
+        return 2
+
+    entries = yaml.safe_load(args.file.read_text(encoding="utf-8")) or []
+    if not isinstance(entries, list):
+        print(f"ERROR: top-level of {args.file} must be a YAML list.",
+              file=sys.stderr)
+        return 2
+
+    plans = plan_entries(entries)
+    apply_ = "APPLY" if args.apply else "DRY-RUN"
+    print(f"Loaded {len(plans)} planned action(s) from {args.file} | {apply_}\n")
+
+    # Print plans grouped by tier so the operator sees the checklist
+    # they need to handle manually for proctoring + policy tiers.
+    fails = 0
+    audit_lines: list[str] = []
+    timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    for plan in plans:
+        prefix = f"[{plan.deid_code} {plan.key:24s}]"
+        if plan.tier in {"proctoring", "policy", "unknown"}:
+            print(f"{prefix} {plan.note}")
+            audit_lines.append(render_audit_line(plan, "FLAGGED", timestamp))
+            continue
+
+        # canvas tier
+        print(f"{prefix} {plan.note}")
+        print(f"    cmd: {' '.join(plan.command)}")
+
+        if not args.apply:
+            audit_lines.append(render_audit_line(plan, "PLANNED", timestamp))
+            continue
+
+        result = subprocess.run(plan.command, capture_output=True, text=True)
+        if result.returncode == 0:
+            print("    OK")
+            audit_lines.append(render_audit_line(plan, "APPLIED", timestamp))
+        else:
+            print(f"    FAIL (exit {result.returncode})")
+            print(f"    stderr: {result.stderr.strip()[:300]}")
+            fails += 1
+            audit_lines.append(render_audit_line(plan, "FAILED", timestamp))
+
+    # Audit log append (tier 2 gitignored)
+    if audit_lines:
+        args.audit_log.parent.mkdir(parents=True, exist_ok=True)
+        with args.audit_log.open("a", encoding="utf-8") as fh:
+            fh.write("\n".join(audit_lines) + "\n")
+        print(f"\nAudit log appended: {args.audit_log}")
+
+    if fails:
+        print(f"\n{fails} action(s) failed.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/tools/student_late_accommodation.py
+++ b/lib/tools/student_late_accommodation.py
@@ -67,6 +67,11 @@ USAGE — dry-run by default (use --apply to actually write)
   uv run python lib/tools/student_late_accommodation.py \\
     --deid-code S-95DBB6 --from-days-ago 14 --apply
 
+  # SAS test_reschedule: shift dates forward 7 days (vs the default
+  # "drop lock_at" mode used for occasional_extensions)
+  uv run python lib/tools/student_late_accommodation.py \\
+    --deid-code S-95DBB6 --assignment-id 123 --shift-by-days 7 --apply
+
   # Remove the accommodation (cleanly undo) — scope flags work for
   # remove too, so you can undo across the same window you applied
   uv run python lib/tools/student_late_accommodation.py \\
@@ -163,6 +168,53 @@ def cutoff_from_days_ago(days: int, today: date | None = None) -> str:
     if today is None:
         today = date.today()
     return (today - timedelta(days=int(days))).isoformat()
+
+
+def shift_iso_timestamp(ts: str | None, days: int) -> str | None:
+    """Shift an ISO 8601 timestamp forward by N days, preserving the
+    time-of-day and timezone suffix. Returns None if `ts` is None (so
+    callers can pass through null dates).
+
+    Canvas's due_at / unlock_at / lock_at are ISO strings like
+    '2026-04-15T23:59:00Z'. We split at 'T', advance the date part by N
+    days using date.fromisoformat + timedelta, and re-join. This avoids
+    pulling in a full timezone-aware parser for what's a simple offset.
+    """
+    if not ts:
+        return None
+    date_part = ts[:10]   # YYYY-MM-DD
+    rest = ts[10:]        # T..HH:MM:SSZ (or whatever suffix Canvas sent)
+    shifted = (date.fromisoformat(date_part) + timedelta(days=int(days))).isoformat()
+    return shifted + rest
+
+
+def build_shift_payload(assignment: dict, user_id: int, days: int,
+                        title: str = "Test reschedule (date-shifted)") -> dict:
+    """Build the POST body for a date-shift override (test_reschedule).
+
+    Different from build_override_payload: instead of dropping lock_at,
+    this SHIFTS all three dates (unlock_at, due_at, lock_at) forward by
+    N days. The student gets a moved availability window — they still
+    have a hard close, just N days later.
+
+    Used for SAS `test_reschedule` (catalog key). Different intent from
+    `occasional_extensions` (which uses build_override_payload to drop
+    lock_at). Faculty picks per accommodation letter.
+    """
+    data: dict[str, str | int] = {
+        "assignment_override[student_ids][]": user_id,
+        "assignment_override[title]": title,
+    }
+    unlock = shift_iso_timestamp(assignment.get("unlock_at"), days)
+    due = shift_iso_timestamp(assignment.get("due_at"), days)
+    lock = shift_iso_timestamp(assignment.get("lock_at"), days)
+    if unlock:
+        data["assignment_override[unlock_at]"] = unlock
+    if due:
+        data["assignment_override[due_at]"] = due
+    if lock:
+        data["assignment_override[lock_at]"] = lock
+    return data
 
 
 def filter_assignments_by_due_from(assignments: list[dict],
@@ -289,6 +341,12 @@ def main() -> int:
                             "the last two weeks through end of term)")
     ap.add_argument("--master", type=Path, default=_DEFAULT_MASTER,
                     help=f"deid master path (default {str(_DEFAULT_MASTER)!r})")
+    ap.add_argument("--shift-by-days", type=int, metavar="N",
+                    help="(SAS test_reschedule) shift unlock_at + due_at + "
+                         "lock_at forward by N days for this student, "
+                         "instead of dropping lock_at (the default behavior). "
+                         "Use for accommodations that say 'reschedule the "
+                         "exam' rather than 'allow late submission'.")
     ap.add_argument("--remove", action="store_true",
                     help="undo: delete this student's accommodation overrides")
     ap.add_argument("--apply", action="store_true",
@@ -363,7 +421,10 @@ def main() -> int:
                       "remove close (lock=null)")
                 continue
             assignment = fetch_assignment(base_url, course_id, aid, token)
-            payload = build_override_payload(assignment, uid)
+            if args.shift_by_days:
+                payload = build_shift_payload(assignment, uid, args.shift_by_days)
+            else:
+                payload = build_override_payload(assignment, uid)
             code, body = post_override(base_url, course_id, aid, payload, token)
             ok = "OK " if code in (200, 201) else "FAIL"
             if code not in (200, 201):

--- a/lib/tools/student_quiz_time_extension.py
+++ b/lib/tools/student_quiz_time_extension.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+student_quiz_time_extension.py — Per-student "extra time on timed quizzes"
+accommodation via Canvas quiz extensions.
+
+A routine BYUI Accessibility Services accommodation: ONE student gets a
+time multiplier on all timed quizzes/exams (1.5x = 50% extra; 2.0x =
+double time). The class is unaffected.
+
+The catalog (handoffs/2026-06-26-accessibility-accommodations-catalog.md)
+identifies extra-time as the dominant SAS ask. Two flavors observed:
+  extra_time_1.5x — "Please allow 50% extra time on all timed exams
+                    and quizzes."
+  extra_time_2.0x — "Please allow 100% extra time (double time) on
+                    all exams and quizzes."
+
+HOW THE EXTENSION IS BUILT
+  For each target timed quiz, POST to
+    /api/v1/courses/:cid/quizzes/:qid/extensions
+  with `quiz_extensions[][user_id]` + `quiz_extensions[][extra_time]`
+  (in MINUTES). extra_time = ceil(quiz.time_limit * (multiplier - 1)).
+
+WHAT'S IN SCOPE
+  Classic Canvas quizzes only. New Quizzes (LTI-based) use a separate
+  API and are NOT covered by this tool — they're listed as a follow-up
+  in lib/agents/knowledge/deid_master_knowledge.md.
+
+PII-FREE LOOKUP
+  --user-id 123456        bare Canvas user_id
+  --deid-code S-95DBB6    looked up in grading/.deid_master.csv
+                          (built by build_deid_master.py; tool reads
+                          only the user_id column)
+
+USAGE — dry-run by default (use --apply to actually write)
+  # Preview: 1.5x on every timed classic quiz in the course
+  uv run python lib/tools/student_quiz_time_extension.py \\
+    --deid-code S-95DBB6 --multiplier 1.5 --all-timed
+
+  # Apply 2.0x (double time) across all timed quizzes
+  uv run python lib/tools/student_quiz_time_extension.py \\
+    --deid-code S-95DBB6 --multiplier 2.0 --all-timed --apply
+
+  # ONE specific quiz
+  uv run python lib/tools/student_quiz_time_extension.py \\
+    --deid-code S-95DBB6 --multiplier 1.5 --quiz-id 12345 --apply
+
+  # Custom multiplier (e.g. 1.25x for 25% extra time)
+  uv run python lib/tools/student_quiz_time_extension.py \\
+    --user-id 173819 --multiplier 1.25 --all-timed --apply
+
+REQUIRES in .env: CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID
+
+Resolves SAS catalog keys: extra_time_1.5x, extra_time_2.0x
+(see handoffs/2026-06-26-accessibility-accommodations-catalog.md)
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import sys
+from pathlib import Path
+
+import requests
+
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+
+_DEFAULT_MASTER = Path("grading/.deid_master.csv")
+_TIMEOUT = 30
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (no I/O — easy to unit-test)
+# ---------------------------------------------------------------------------
+
+def compute_extra_minutes(time_limit_minutes: int | None,
+                          multiplier: float) -> int | None:
+    """Compute extra minutes to add for a given multiplier.
+
+    Returns None if the quiz is untimed (no time_limit) — the caller
+    should skip the quiz silently (no need for an extension when there's
+    no time limit to extend).
+
+    Multiplier semantics:
+      1.5 → 50% extra time → extra = ceil(time_limit * 0.5)
+      2.0 → 100% extra time (double time) → extra = ceil(time_limit * 1.0)
+      1.25 → 25% extra time → extra = ceil(time_limit * 0.25)
+
+    Uses math.ceil so partial minutes round UP (giving the student the
+    full benefit of the multiplier — never less time than promised).
+    """
+    if time_limit_minutes is None or time_limit_minutes <= 0:
+        return None
+    if multiplier <= 1.0:
+        return 0  # 1.0x or less = no extension; caller may skip
+    return math.ceil(time_limit_minutes * (multiplier - 1.0))
+
+
+def filter_timed_quizzes(quizzes: list[dict]) -> list[dict]:
+    """Return only quizzes that have a non-null, positive time_limit.
+
+    Quizzes without a time limit don't need an extension — the student
+    already has unlimited time. Filtering them here means the operator
+    doesn't have to think about it.
+    """
+    out = []
+    for q in quizzes:
+        tl = q.get("time_limit")
+        if tl is None:
+            continue
+        if isinstance(tl, (int, float)) and tl > 0:
+            out.append(q)
+    return out
+
+
+def resolve_user_id_from_master(master_path: Path, deid_code: str) -> int:
+    """Look up a deid_code in the master CSV and return the user_id.
+
+    Identical signature + behavior to the helper in
+    student_late_accommodation.py — duplicated here so each tool stays
+    standalone (no cross-tool import dependency).
+
+    Reads ONLY the user_id column (sortable_name is never read).
+    """
+    if not master_path.exists():
+        raise FileNotFoundError(
+            f"deid master not found at {master_path}. "
+            f"Build it first with: "
+            f"uv run python lib/tools/build_deid_master.py"
+        )
+    target = deid_code.strip().upper()
+    with master_path.open(encoding="utf-8") as fh:
+        for row in csv.DictReader(fh):
+            if row["deid_code"].strip().upper() == target:
+                return int(row["user_id"])
+    raise KeyError(
+        f"deid_code {deid_code!r} not found in {master_path}. "
+        f"Did you rebuild the master after a roster change?"
+    )
+
+
+def build_extension_payload(user_id: int, extra_time_minutes: int) -> dict:
+    """Build the POST body for a quiz extension.
+
+    Canvas quirk: extensions are submitted as an array of objects, so
+    the form-encoded keys use [] suffix.
+    """
+    return {
+        "quiz_extensions[][user_id]": user_id,
+        "quiz_extensions[][extra_time]": extra_time_minutes,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Canvas API
+# ---------------------------------------------------------------------------
+
+def fetch_timed_quizzes(base_url: str, course_id: str, token: str) -> list[dict]:
+    """GET /courses/:id/quizzes (classic quizzes) and return only
+    the ones with a time_limit set.
+
+    Note: this endpoint returns CLASSIC quizzes only. New Quizzes (LTI)
+    aren't returned here.
+    """
+    headers = {"Authorization": f"Bearer {token}"}
+    out: list[dict] = []
+    page = 1
+    while True:
+        r = requests.get(
+            f"{base_url}/api/v1/courses/{course_id}/quizzes",
+            headers=headers,
+            params={"per_page": 100, "page": page},
+            timeout=_TIMEOUT,
+        )
+        r.raise_for_status()
+        batch = r.json()
+        if not batch:
+            break
+        out.extend(batch)
+        page += 1
+    return filter_timed_quizzes(out)
+
+
+def fetch_quiz(base_url: str, course_id: str, quiz_id: int,
+               token: str) -> dict:
+    headers = {"Authorization": f"Bearer {token}"}
+    r = requests.get(
+        f"{base_url}/api/v1/courses/{course_id}/quizzes/{quiz_id}",
+        headers=headers, timeout=_TIMEOUT,
+    )
+    r.raise_for_status()
+    return r.json()
+
+
+def post_extension(base_url: str, course_id: str, quiz_id: int,
+                   payload: dict, token: str) -> tuple[int, dict]:
+    headers = {"Authorization": f"Bearer {token}"}
+    r = requests.post(
+        f"{base_url}/api/v1/courses/{course_id}/quizzes/{quiz_id}/extensions",
+        headers=headers, data=payload, timeout=_TIMEOUT,
+    )
+    try:
+        body = r.json()
+    except ValueError:
+        body = {}
+    return r.status_code, body
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n")[1])
+    who = ap.add_mutually_exclusive_group(required=True)
+    who.add_argument("--user-id", help="bare Canvas user_id (no PII surface)")
+    who.add_argument("--deid-code", help="deid_code from grading/.deid_master.csv")
+    scope = ap.add_mutually_exclusive_group(required=True)
+    scope.add_argument("--quiz-id", type=int, help="ONE specific quiz id")
+    scope.add_argument("--all-timed", action="store_true",
+                       help="ALL classic quizzes that have a time limit")
+    ap.add_argument("--multiplier", type=float, required=True,
+                    help="time multiplier — 1.5 for 50%% extra time, "
+                         "2.0 for double time, 1.25 for 25%% extra, etc.")
+    ap.add_argument("--master", type=Path, default=_DEFAULT_MASTER,
+                    help=f"deid master path (default {str(_DEFAULT_MASTER)!r})")
+    ap.add_argument("--apply", action="store_true",
+                    help="actually write the change (without this, dry-run)")
+    args = ap.parse_args()
+
+    if args.multiplier <= 1.0:
+        print(f"ERROR: --multiplier must be > 1.0 (got {args.multiplier}). "
+              f"1.0 means no extension; use 1.5 or 2.0 for typical SAS asks.",
+              file=sys.stderr)
+        return 2
+
+    base_url = os.environ.get("CANVAS_BASE_URL", "").rstrip("/")
+    if base_url and not base_url.startswith("http"):
+        base_url = "https://" + base_url
+    course_id = os.environ.get("CANVAS_COURSE_ID", "")
+    token = os.environ.get("CANVAS_API_TOKEN", "")
+    if not (base_url and course_id and token):
+        print("ERROR: CANVAS_BASE_URL / CANVAS_COURSE_ID / CANVAS_API_TOKEN "
+              "must be set in .env or the environment.", file=sys.stderr)
+        return 2
+
+    if args.user_id:
+        uid = int(args.user_id)
+    else:
+        try:
+            uid = resolve_user_id_from_master(args.master, args.deid_code)
+        except (FileNotFoundError, KeyError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+
+    if args.all_timed:
+        quizzes = fetch_timed_quizzes(base_url, course_id, token)
+    else:
+        one = fetch_quiz(base_url, course_id, args.quiz_id, token)
+        quizzes = filter_timed_quizzes([one])
+
+    apply_ = "APPLY" if args.apply else "DRY-RUN"
+    print(f"student user_id={uid} | {len(quizzes)} timed quiz(zes) "
+          f"| multiplier {args.multiplier}x | {apply_}")
+
+    if not quizzes:
+        print("No timed quizzes matched. Nothing to do.")
+        return 0
+
+    fails = 0
+    for q in quizzes:
+        qid = q["id"]
+        tl = q.get("time_limit")
+        extra = compute_extra_minutes(tl, args.multiplier)
+        if extra is None or extra <= 0:
+            print(f"  [SKIP] quiz {qid}: no time_limit or multiplier <= 1.0")
+            continue
+        title = q.get("title", "")[:40]
+        if not args.apply:
+            print(f"  [DRY] quiz {qid} ({title}): "
+                  f"would add {extra} min (base {tl} min × {args.multiplier})")
+            continue
+        payload = build_extension_payload(uid, extra)
+        code, body = post_extension(base_url, course_id, qid, payload, token)
+        ok = "OK " if code in (200, 201) else "FAIL"
+        if code not in (200, 201):
+            fails += 1
+        print(f"  [{ok}] quiz {qid} ({title}): +{extra} min (HTTP {code})")
+
+    if fails:
+        print(f"\n{fails} operation(s) failed. Re-run to retry.", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "0.71.0"
+version = "0.72.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "0.70.0"
+version = "0.72.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Three-item sprint closing out the BYUI Accessibility Services catalog dispatch chain — triggered by the life-pm handoff at `handoffs/2026-06-26-accessibility-accommodations-catalog.md` (17 accommodation types across 3 tiers).

- **S1**: `student_quiz_time_extension.py` — per-student quiz time multiplier (1.5x, 2.0x). Pulls `time_limit` from API, computes extra minutes with `ceil()` so the student never gets less time than promised. Classic Canvas quizzes only; New Quizzes deferred.
- **S2**: `--shift-by-days N` mode on `student_late_accommodation.py` — for SAS `test_reschedule` (shifts unlock/due/lock forward instead of dropping lock_at).
- **S3**: `apply_sas_accommodations.py` — YAML dispatcher. Reads `grading/.sas_accommodations.yml`, classifies each key (canvas / proctoring / policy / unknown), invokes canvas-tier tools as subprocess (no cross-tool imports), surfaces proctoring + policy tiers as an instructor checklist. Audit log at `grading/.sas_accommodations_applied.log` (FERPA tier 2).

## What changed

```
 lib/tools/student_quiz_time_extension.py          (NEW, 265L)
 lib/tools/student_late_accommodation.py           (+--shift-by-days mode)
 lib/tools/apply_sas_accommodations.py             (NEW, 280L)
 lib/agents/knowledge/sas_accommodations_knowledge.md   (NEW)
 lib/tests/test_student_quiz_time_extension_helpers.py  (NEW, 21 tests)
 lib/tests/test_student_late_accommodation_helpers.py   (+12 tests)
 lib/tests/test_apply_sas_accommodations_helpers.py     (NEW, 22 tests)
 README.md                                         (12th workflow row + dedicated SAS section)
 AGENTS.md                                         (Active Context entry)
 pyproject.toml, plugin.json, marketplace.json     (0.71.0 → 0.72.0)
```

## Test plan

- [x] 605 passing tests (up from 550 in v0.71.0; the 7 sprint failures are pre-existing and require a live Canvas token)
- [x] 55 new tests covering: `compute_extra_minutes` ceil behavior, `filter_timed_quizzes`, `build_extension_payload` Canvas array-syntax invariant, `shift_iso_timestamp` boundary cases (month/year/timezone preservation/null/negative), `build_shift_payload` all-three-dates invariant, `classify_key` for every catalog member, `plan_one_accommodation` for each canvas-tier key with default + YAML overrides, `plan_entries` flatten/skip/order behavior, audit-line format invariants
- [x] Pre-commit hooks pass (ruff fixed one unused import on first run; re-committed clean)
- [ ] Manual smoke test on a real course (post-merge):
  - [ ] Build a `grading/.sas_accommodations.yml` with one canvas + one proctoring + one policy entry → run dry-run → confirm checklist matches
  - [ ] Run with `--apply` against a Test Student → verify quiz extension lands + override shows up in Canvas UI
  - [ ] Verify audit log accumulates

## What's NOT done (deferred)

- New Quizzes (LTI) support — different endpoint, separate sprint
- `apply_sas_accommodations.py` is operator-invoked; future work could wire it into a daily/weekly cron or post-fetch hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)
