### PR TITLE
release: v0.72.3 — lib/agents link fixes + CHANGELOG completion

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,7 @@
     {
       "name": "canvas-toolbox",
       "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Includes agent specs (8) and pedagogical knowledge files (20+) covering course design audits, FERPA-safe LLM grading, Canvas sync, and the BYU-I Learning Model.",
-      "version": "0.72.2",
+      "version": "0.72.3",
       "source": "./",
       "author": {
         "name": "Chaz Clark",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "canvas-toolbox",
   "displayName": "canvas-toolbox",
   "description": "FERPA-safe AI-assisted Canvas LMS toolkit. Agent specs cover course audits (rubric coverage / quality, syllabus, CLO quality, alignment chain, accessibility, workload, grading structure / load, formative variety, learning model), Canvas sync paths (course / blueprint / Page-level orphan cleanup), and a generic LLM-grading pipeline (de-identify → consensus → reconcile → push). Knowledge files cover Canvas API + lessons learned, rubrics, assessments, backwards design, cognitive load theory, Hattie 3-phase, Merrill's First Principles, BYU-I Learning Model, BYUI Course Design Standards, and 14+ other pedagogical frameworks. Brain-agnostic by design: the LLM provider is your choice.",
-  "version": "0.72.2",
+  "version": "0.72.3",
   "author": {
     "name": "Chaz Clark",
     "url": "https://github.com/chaz-clark"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,17 @@ private channel is for security.
 
 _Last updated: 2026-06-29_
 
-### Recent: README marketing restructure + repo-root declutter (v0.72.2, 2026-06-29)
+### Recent: AGENTS.md trimmed to rotating latest-5 + CI guard (v0.72.3, 2026-06-29)
+
+**v0.72.3** — Active Context had become an append-only release log (182 KB /
+~32k tokens, past host-tool read limits). Trimmed to the 5 most-recent entries
+(~570 lines / ~10k tokens); full history relocated to `CHANGELOG.md`, filling
+the prior 0.51–0.71 gap. New CI guard `lib/tests/test_agents_active_context.py`
+enforces ≤5 entries (local impl of Make-AI-Agents#17) — on each release, add the
+new entry on top and rotate the oldest into CHANGELOG. Also repaired 17 doc-move
+links (v0.72.2) + 8 pre-existing `lib/agents/` links. No production code change.
+
+### Earlier: README marketing restructure + repo-root declutter (v0.72.2, 2026-06-29)
 
 **v0.72.2** — docs/structure patch to make the landing experience
 marketing-ready. No code or test changes (605 tests unchanged).
@@ -408,74 +418,7 @@ per-assignment keymaps for the grader pipeline — approved in principle
 but deferred to a future session per operator direction. Path B becomes
 harder over time; the deferral is intentional and credit-aware.
 
-### Earlier: Course-wide de-id master + per-student late-work accommodation primitives (v0.70.0, 2026-06-26)
-
-**v0.70.0** — closes issue #109 (agent-submitted ~10 min after v0.69.1
-shipped, from the DS 460 pilot). Two related primitives + four-mode
-scoping + the README cleanups Chaz flagged mid-build.
-
-**The missing primitive** — until v0.70.0, the toolkit could de-identify
-within a single grading workflow (per-assignment keymaps) and could
-scrub names (.known_names.txt) but had NO course-wide stable
-`code ↔ user_id ↔ name` surface. That's the primitive every keyed /
-FERPA workflow actually wants — and it's what enables the accommodation
-tool to take `--deid-code S-95DBB6` instead of `--user-id 173819`
-(so the operator never speaks the student's name to the agent).
-
-**What landed:**
-
-1. **`lib/tools/build_deid_master.py`** — fetches Canvas People with
-   ALL enrollment states (active + invited + inactive + completed),
-   hashes user_id → `S-XXXXXX` (6 hex from sha256, configurable
-   prefix + hash-bits), writes `grading/.deid_master.csv` (FERPA
-   tier 2). Auto-writes `grading/.gitignore` to make tier 2 bulletproof.
-   Detects collisions at write-time with clear recovery message
-   (`--hash-bits 8`). Default prefix `S-`; opt out via `--prefix`.
-
-2. **`lib/tools/student_late_accommodation.py`** — lifted from DS 460
-   pilot + generalized. Writes per-student assignment overrides that
-   keep `unlock_at` + `due_at` but omit `lock_at` (no close date).
-   **Four scoping modes** (the v0.70.0 mid-build operator ask):
-   - `--assignment-id` — ONE assignment
-   - `--all` — every published, backdated
-   - `--from YYYY-MM-DD` — due on/after a specific date
-   - `--from-days-ago N` — rolling window (recommended default; e.g.
-     `--from-days-ago 14` = last 2 weeks through end of term)
-   Resolves student via `--user-id` OR `--deid-code` (PII-free).
-   `--remove` flag works with any scope.
-
-3. **`lib/agents/knowledge/deid_master_knowledge.md`** — the
-   4-column contract, collision math, FERPA tier 2 explanation,
-   how downstream tools should consume the master (never read
-   `sortable_name` unless explicit).
-
-4. **54 new tests passing** (543 passing total, up from 489;
-   Title IV pure-helper pattern continued — function in/out, no
-   Canvas API mocking).
-
-5. **README mid-build tweaks** (Chaz-flagged):
-   - Step 3 prompt now explicitly invokes `cb-init` (so the agent
-     uses our purpose-built idempotent bootstrap, not its own ad-hoc
-     sequence)
-   - `byui.instructure.com` → `your-institution.instructure.com`
-     (generic across institutions)
-   - "Who uses it" section DROPPED (was leading with BYUI specifics)
-   - "Sharing back with the project" SIMPLIFIED from a technical
-     PATH/fallback wall to a 3-row agent-prompt table
-   - 11th workflow row added: "Give one student late-work accommodation"
-   - NEW dedicated section "Per-student late-work accommodation"
-     with the 4-mode scope table
-   - Trailing version line names the new primitives
-
-**Field validation** (from issue #109 author):
-- DS 460 pilot: 1 real student, 36 assignments, `--all` applied
-  cleanly — every override kept original open/due with lock=null
-- 30 active → 37 total → 7 withdrawn surfaced (the `withdrawn` flag's
-  value, hidden by the active-only People view)
-- Canvas GET overrides slow-path caveat baked into the tool: APPLY
-  POSTs directly without listing existing overrides; only REMOVE reads
-
-_Earlier releases (v0.69.1 and back) live in the [CHANGELOG](CHANGELOG.md) — Active Context keeps only the latest 5 (enforced in CI)._
+_Earlier releases (v0.70.0 and back) live in the [CHANGELOG](CHANGELOG.md) — Active Context keeps only the latest 5 (enforced in CI)._
 
 ## Domain Terms
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ## [Unreleased]
 
+(Nothing yet.)
+
+---
+
+## [0.72.3] — 2026-06-29
+
 ### Changed
 - **AGENTS.md trimmed to the rotating latest-5 rule.** Active Context had grown
   into an append-only release log (182 KB / ~32k tokens — past host-tool read
@@ -27,6 +33,7 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 - 17 outbound links in `docs/grading_readme.md`, `docs/UPGRADING.md`, and
   `.github/CONTRIBUTING.md` that broke in v0.72.2 when those files moved out of
   the repo root (their root-relative links were not re-pathed at the time).
+- 8 pre-existing broken relative links in `lib/agents/` (wrong relative depth / missing `knowledge/` prefix; two `forthcoming` references de-linked).
 
 ---
 
@@ -50,6 +57,214 @@ changes (605 tests unchanged).
   `docs/`. All internal links repointed; 0 broken links repo-wide.
 
 ---
+
+## [0.72.1] — 2026-06-26
+
+**README polish — surface quiz time extension + fix late-work intro**
+
+
+**v0.72.1** — docs-only patch addressing three gaps Chaz flagged
+after a post-v0.72.0 README review:
+
+1. `student_quiz_time_extension.py` had no standalone surface — only
+   appeared as a dispatcher target. A faculty member with an informal
+   "give Sydney 1.5x time" couldn't find it. Added a **13th workflow
+   row** + a dedicated README section between the late-work and SAS
+   dispatcher sections.
+
+2. Late-work intro paragraph still said overrides "drop the close
+   date" as if that were the only behavior — but v0.72.0 added the
+   `--shift-by-days` flavor. Rewrote the intro to mention both
+   flavors so the "Two flavors" table that follows doesn't feel
+   contradictory.
+
+3. Workflow row for "Give one student late-work accommodation" was
+   ~3x wider than its neighbors because of inline `--shift-by-days`
+   detail. Tightened by moving specifics to the dedicated section
+   and linking out.
+
+Test count unchanged (605). No code change.
+
+## [0.72.0] — 2026-06-26
+
+**BYUI SAS accommodation sprint — quiz time extension + test_reschedule + apply dispatcher**
+
+
+**v0.72.0** — three-item sprint closing out the BYUI Accessibility
+Services catalog dispatch chain. Triggered by the life-pm handoff at
+`handoffs/2026-06-26-accessibility-accommodations-catalog.md`.
+
+**S1 — `lib/tools/student_quiz_time_extension.py`** (~265 lines).
+Per-student quiz time multiplier (1.5x, 2.0x, or any > 1.0). Targets
+CLASSIC Canvas quizzes only (New Quizzes documented as a follow-up).
+Pulls quiz `time_limit` from API; computes `extra_time` minutes via
+`ceil(time_limit * (multiplier - 1))`; POSTs to `/quizzes/<id>/extensions`
+with `quiz_extensions[][user_id]` + `quiz_extensions[][extra_time]`.
+Scopes: `--quiz-id` (one) or `--all-timed` (every timed quiz in
+course). PII-free via `--user-id` or `--deid-code` lookup. Auto-skips
+untimed quizzes. Pure-helper `compute_extra_minutes` uses `math.ceil`
+so partial minutes always round UP — the student never gets less time
+than the multiplier promises.
+
+**S2 — `--shift-by-days N` mode on `student_late_accommodation.py`**.
+For SAS `test_reschedule` (distinct from `occasional_extensions`):
+shift unlock/due/lock forward by N days instead of dropping lock_at.
+New pure helper `shift_iso_timestamp(ts, days)` advances the date
+prefix of an ISO 8601 string while preserving the time-of-day and
+timezone suffix (no full tz parser needed — string-prefix arithmetic
+is sufficient for accommodation-grade precision). New
+`build_shift_payload(assignment, user_id, days)` is the
+analog of `build_override_payload` but emits all three dates shifted.
+
+**S3 — `lib/tools/apply_sas_accommodations.py`** (~280 lines). YAML
+dispatcher. Reads `grading/.sas_accommodations.yml`, walks each
+student × accommodation, classifies each `key` into one of 4 tiers
+(`canvas` / `proctoring` / `policy` / `unknown`). Canvas-tier
+accommodations are invoked as subprocess calls to the matching tool
+(so each tool stays standalone, no cross-tool imports). Proctoring +
+policy tiers surface as a one-line operator checklist. Audit trail
+written to `grading/.sas_accommodations_applied.log` (FERPA tier 2,
+gitignored). Catalog hard-coded in three frozen sets at the top of
+the module — single source of truth, easy to extend when life-pm
+surfaces new accommodation types.
+
+**Knowledge file — `lib/agents/knowledge/sas_accommodations_knowledge.md`**
+vendors the life-pm catalog into the canvas-toolbox knowledge surface
+so future agents can reason about SAS dispatch without re-reading the
+handoff each time. Maps every catalog key → tier → tool invocation;
+documents the YAML handoff schema; explains the
+"how to add a new key" extension process.
+
+**README — 12th workflow row + dedicated SAS section** between
+the de-id master section and "Sharing your grader." Late-work
+accommodation section now distinguishes the two flavors (drop lock_at
+for `occasional_extensions` vs `--shift-by-days N` for
+`test_reschedule`) in addition to the four scoping modes.
+
+**55 new tests passing** (605 passing total, up from 550):
+- 21 tests for quiz time extension (compute_extra_minutes ceil
+  behavior, filter_timed_quizzes, payload shape, master lookup edge
+  cases)
+- 12 new tests for shift-by-days mode (shift_iso_timestamp edge
+  cases: month/year boundaries, timezone preservation, null
+  passthrough, negative-days defensive; build_shift_payload all-three-
+  dates invariant)
+- 22 tests for SAS dispatcher (classify_key for all catalog members,
+  plan_one_accommodation for each canvas-tier key with default + YAML
+  overrides, plan_entries flatten/skip/order behavior, audit-line
+  format invariants)
+
+**What's NOT yet done (deferred):**
+- New Quizzes (LTI) support — they use a different endpoint
+- `apply_sas_accommodations.py` is invoked manually; future work
+  could wire it into a daily/weekly cron or post-fetch hook
+
+## [0.71.0] — 2026-06-26
+
+**Path A migration — `.known_names.txt` auto-derived from the de-id master**
+
+
+**v0.71.0** — Path A of the de-id master consolidation. Mid-build
+operator question after v0.70.0 shipped: *"Do all de-id scripts run
+off the new master? Anything re-id'ed goes to Downloads?"* — surfaced
+that the master was purely additive (only 2 tools used it); the
+scrub-pass roster `.known_names.txt` was still populated separately
+by `grader_fetch.py`.
+
+**What landed:**
+
+1. **`build_deid_master.py` now auto-derives `.known_names.txt`** —
+   single new helper `render_known_names_lines()` emits BOTH sortable
+   ("Lastname, Firstname") and display ("Firstname Lastname") forms
+   per student so the scrub matches whichever literal appears in
+   submission text. Case-insensitive dedup; sorted; header comments
+   so a future reader doesn't hand-edit it.
+
+2. **7 new tests** (550 passing total, up from 543). Covers both-forms
+   emission, header comments, dedup, empty-name skip, single-word
+   names (no comma → no display-form duplicate), determinism, sort
+   order.
+
+**Unchanged (deliberate):**
+- `grader_fetch.py`'s `update_known_names()` still works as before
+  (append-mode dedup; appends submitters who weren't in the People
+  view yet). Path A is additive, not replacement.
+- Per-assignment keymaps untouched. Grader pipeline hot path unchanged.
+
+**Path B deferred** — full migration where the master replaces
+per-assignment keymaps for the grader pipeline — approved in principle
+but deferred to a future session per operator direction. Path B becomes
+harder over time; the deferral is intentional and credit-aware.
+
+## [0.70.0] — 2026-06-26
+
+**Course-wide de-id master + per-student late-work accommodation primitives**
+
+
+**v0.70.0** — closes issue #109 (agent-submitted ~10 min after v0.69.1
+shipped, from the DS 460 pilot). Two related primitives + four-mode
+scoping + the README cleanups Chaz flagged mid-build.
+
+**The missing primitive** — until v0.70.0, the toolkit could de-identify
+within a single grading workflow (per-assignment keymaps) and could
+scrub names (.known_names.txt) but had NO course-wide stable
+`code ↔ user_id ↔ name` surface. That's the primitive every keyed /
+FERPA workflow actually wants — and it's what enables the accommodation
+tool to take `--deid-code S-95DBB6` instead of `--user-id 173819`
+(so the operator never speaks the student's name to the agent).
+
+**What landed:**
+
+1. **`lib/tools/build_deid_master.py`** — fetches Canvas People with
+   ALL enrollment states (active + invited + inactive + completed),
+   hashes user_id → `S-XXXXXX` (6 hex from sha256, configurable
+   prefix + hash-bits), writes `grading/.deid_master.csv` (FERPA
+   tier 2). Auto-writes `grading/.gitignore` to make tier 2 bulletproof.
+   Detects collisions at write-time with clear recovery message
+   (`--hash-bits 8`). Default prefix `S-`; opt out via `--prefix`.
+
+2. **`lib/tools/student_late_accommodation.py`** — lifted from DS 460
+   pilot + generalized. Writes per-student assignment overrides that
+   keep `unlock_at` + `due_at` but omit `lock_at` (no close date).
+   **Four scoping modes** (the v0.70.0 mid-build operator ask):
+   - `--assignment-id` — ONE assignment
+   - `--all` — every published, backdated
+   - `--from YYYY-MM-DD` — due on/after a specific date
+   - `--from-days-ago N` — rolling window (recommended default; e.g.
+     `--from-days-ago 14` = last 2 weeks through end of term)
+   Resolves student via `--user-id` OR `--deid-code` (PII-free).
+   `--remove` flag works with any scope.
+
+3. **`lib/agents/knowledge/deid_master_knowledge.md`** — the
+   4-column contract, collision math, FERPA tier 2 explanation,
+   how downstream tools should consume the master (never read
+   `sortable_name` unless explicit).
+
+4. **54 new tests passing** (543 passing total, up from 489;
+   Title IV pure-helper pattern continued — function in/out, no
+   Canvas API mocking).
+
+5. **README mid-build tweaks** (Chaz-flagged):
+   - Step 3 prompt now explicitly invokes `cb-init` (so the agent
+     uses our purpose-built idempotent bootstrap, not its own ad-hoc
+     sequence)
+   - `byui.instructure.com` → `your-institution.instructure.com`
+     (generic across institutions)
+   - "Who uses it" section DROPPED (was leading with BYUI specifics)
+   - "Sharing back with the project" SIMPLIFIED from a technical
+     PATH/fallback wall to a 3-row agent-prompt table
+   - 11th workflow row added: "Give one student late-work accommodation"
+   - NEW dedicated section "Per-student late-work accommodation"
+     with the 4-mode scope table
+   - Trailing version line names the new primitives
+
+**Field validation** (from issue #109 author):
+- DS 460 pilot: 1 real student, 36 assignments, `--all` applied
+  cleanly — every override kept original open/due with lock=null
+- 30 active → 37 total → 7 withdrawn surfaced (the `withdrawn` flag's
+  value, hidden by the active-only People view)
+- Canvas GET overrides slow-path caveat baked into the tool: APPLY
+  POSTs directly without listing existing overrides; only REMOVE reads
 
 ## [0.69.1] — 2026-06-26
 

--- a/README.md
+++ b/README.md
@@ -513,6 +513,6 @@ The architecture (FERPA two-zone, voice-preservation contract, consensus-based g
 
 ---
 
-**Current version:** v0.72.2 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 605 unit tests · 20+ pedagogical knowledge files for AI-architected course design · BYUI SAS accommodation dispatcher (quiz time extension + late-work + test reschedule) · ~70 versioned releases since v0.1. Full release history in [`CHANGELOG.md`](CHANGELOG.md); recent highlights + rationale in [`AGENTS.md`](AGENTS.md) Active Context.
+**Current version:** v0.72.3 · 11 grading safety gates · Title IV definitions verified 2026-06-26 (next review 2027-06-26) · 605 unit tests · 20+ pedagogical knowledge files for AI-architected course design · BYUI SAS accommodation dispatcher (quiz time extension + late-work + test reschedule) · ~70 versioned releases since v0.1. Full release history in [`CHANGELOG.md`](CHANGELOG.md); recent highlights + rationale in [`AGENTS.md`](AGENTS.md) Active Context.
 
 For help, see the doc tree above or file a `cb-report-bug` (~1 second roundtrip; no GitHub account needed).

--- a/lib/agents/AGENT_LAYERS.md
+++ b/lib/agents/AGENT_LAYERS.md
@@ -172,7 +172,7 @@ When you (in Claude Code) run the Canvas course audit in this repo right now, al
 | **Specification** | `lib/agents/canvas_course_expert.md` + `.json` — load these and Claude becomes the audit agent |
 | **Tool / function** | `parse_course_export()`, `analyze_cognitive_load()`, `canvas_api()` etc. — invoked from the runtime |
 
-The Roadmap in [`AGENTS.md`](../AGENTS.md#roadmap) describes the migration: extract the audit capability from the Python CLI tools layer up into a deployable Skill (Layer 2), so any runtime — not just Claude Code — can invoke it.
+The Roadmap in [`AGENTS.md`](../../AGENTS.md#roadmap) describes the migration: extract the audit capability from the Python CLI tools layer up into a deployable Skill (Layer 2), so any runtime — not just Claude Code — can invoke it.
 
 ---
 

--- a/lib/agents/canvas_course_expert.md
+++ b/lib/agents/canvas_course_expert.md
@@ -210,7 +210,7 @@ The Inverted Bloom's tag: `ai_agency` ∈ `{ai_dependent, scaffolded, student_ow
 
 ## Toyota Gap Analysis
 
-> Full reference: [`toyota_gap_analysis_knowledge.md`](toyota_gap_analysis_knowledge.md)
+> Full reference: [`toyota_gap_analysis_knowledge.md`](knowledge/toyota_gap_analysis_knowledge.md)
 
 Every finding in the change plan is framed as a Toyota A3 gap: **Current State → Target State → Gap → Root Cause → Countermeasure → Verification**. This replaces flat recommendation lists with root-cause thinking.
 

--- a/lib/agents/knowledge/README.md
+++ b/lib/agents/knowledge/README.md
@@ -227,7 +227,7 @@ The twelve files cover overlapping but distinct ground. Quick routing:
 **When to use:** When grading any criterion that names critical thinking, when authoring/auditing a rubric criterion meant to capture it, or when auditing whether an assignment's design *prompts* the skill (vs. recall).
 **Audit tag:** none yet (reference-shape, dual-consumer; consumed via fact lookup by grader + audit).
 **Status:** ⚠️ **v0.1** — dual-consumer file built ahead of a real critical-thinking criterion landing in a graded cohort; calibration pending.
-**Consumed by:** [`canvas_grader.md`](canvas_grader.md) (when a rubric criterion targets critical thinking), `canvas_course_expert.md`. **Pairs with:** [`rubrics_knowledge.md`](rubrics_knowledge.md), [`outcomes_quality_knowledge.md`](outcomes_quality_knowledge.md), [`grader_knowledge.md`](grader_knowledge.md), [`assessments_knowledge.md`](assessments_knowledge.md).
+**Consumed by:** [`canvas_grader.md`](../canvas_grader.md) (when a rubric criterion targets critical thinking), `canvas_course_expert.md`. **Pairs with:** [`rubrics_knowledge.md`](rubrics_knowledge.md), [`outcomes_quality_knowledge.md`](outcomes_quality_knowledge.md), [`grader_knowledge.md`](grader_knowledge.md), [`assessments_knowledge.md`](assessments_knowledge.md).
 
 ---
 
@@ -271,7 +271,7 @@ The twelve files cover overlapping but distinct ground. Quick routing:
 **When to use:** Anywhere a faculty member is being coached on grading-comment voice — first-time setup (before the edit roundtrip can refine), conflicts between voice habits and research-grounded effectiveness, or when articulating the WHAT/HOW boundary for an adopter who's confused about what the AI does and doesn't change.
 **Audit tag:** none (coaching reference; consumed via fact lookup).
 **Status:** ✅ **v1.0** — research-grounded across 8 pedagogical frameworks; validated against DS 250 + DS 460 voice artifacts. The voice-preservation contract honors the operator-set constraint that the AI must add value in PHRASING without losing the faculty's voice.
-**Consumed by:** [`canvas_grader.md`](canvas_grader.md), the agent grading any LLM-comment cohort. **Pairs with:** [`grader_voice_knowledge.md`](grader_voice_knowledge.md) (structure + per-instructor file contract + edit roundtrip — the downstream operational layer), [`grader_setup_knowledge.md`](grader_setup_knowledge.md) (per-assignment config interview), [`grader_knowledge.md`](grader_knowledge.md) (push pipeline + safety gates the voice rides on top of).
+**Consumed by:** [`canvas_grader.md`](../canvas_grader.md), the agent grading any LLM-comment cohort. **Pairs with:** [`grader_voice_knowledge.md`](grader_voice_knowledge.md) (structure + per-instructor file contract + edit roundtrip — the downstream operational layer), [`grader_setup_knowledge.md`](grader_setup_knowledge.md) (per-assignment config interview), [`grader_knowledge.md`](grader_knowledge.md) (push pipeline + safety gates the voice rides on top of).
 
 ---
 
@@ -282,7 +282,7 @@ The twelve files cover overlapping but distinct ground. Quick routing:
 **When to use:** Term-end (or any time the institution needs an R2T4 candidate list). Faculty provides a UF cutoff date; the audit produces a Markdown + PDF report in the user's Downloads folder with each student classified + the documented last-engagement timestamp.
 **Audit tag:** `engagement_classification` ∈ {`active`, `uw`, `uf`, `never_participated`}.
 **Status:** ✅ **v1.0** — Title IV definitions verified 2026-06-26 against the 6 cached canonical sources. **Next review:** 2027-06-26 (or sooner if DOE issues new R2T4 / distance-ed guidance). The Distance Ed + R2T4 final rules effective 2026-07-01 are the latest material rule change.
-**Consumed by:** [`canvas_grader.md`](canvas_grader.md), `canvas_course_expert.md`. **Pairs with:** [`grader_knowledge.md`](grader_knowledge.md) §1 (FERPA tier 3 — Downloads-folder named report), the cached Title IV sources in [`sources/title_iv/`](sources/title_iv/).
+**Consumed by:** [`canvas_grader.md`](../canvas_grader.md), `canvas_course_expert.md`. **Pairs with:** [`grader_knowledge.md`](grader_knowledge.md) §1 (FERPA tier 3 — Downloads-folder named report), the cached Title IV sources in [`sources/title_iv/`](sources/title_iv/).
 
 ---
 

--- a/lib/agents/knowledge/three_domains_knowledge.md
+++ b/lib/agents/knowledge/three_domains_knowledge.md
@@ -8,7 +8,7 @@ Companions:
 - [`taxonomy_explorer_knowledge.md`](taxonomy_explorer_knowledge.md) — BYUI's institutional tool view of the same three domains. **Faculty preferring the BYUI Taxonomy Explorer → that file. Faculty preferring the academic-research framing → this file.** Main divergence: BYUI uses Simpson's 7-level psychomotor; this file uses Harrow's 6-level.
 - [`hattie_3phase_knowledge.md`](hattie_3phase_knowledge.md) — sequencing within any domain (Surface → Deep → Transfer)
 - [`cognitive_load_theory_knowledge.md`](cognitive_load_theory_knowledge.md) — working-memory mechanics; affective load and embodied learning connect here
-- [`blooms_taxonomy_knowledge.md`](blooms_taxonomy_knowledge.md) — deeper cognitive-domain reference (forthcoming; until it exists, Bloom verb lists live in [`taxonomy_explorer_knowledge.md`](taxonomy_explorer_knowledge.md) + [`outcomes_quality_knowledge.md`](outcomes_quality_knowledge.md))
+- `blooms_taxonomy_knowledge.md` — deeper cognitive-domain reference (forthcoming; until it exists, Bloom verb lists live in [`taxonomy_explorer_knowledge.md`](taxonomy_explorer_knowledge.md) + [`outcomes_quality_knowledge.md`](outcomes_quality_knowledge.md))
 
 ---
 
@@ -49,7 +49,7 @@ The 2001 revision changed two things: **noun → verb** and **swapped the top tw
 
 The newer version is preferred for new instructional planning.
 
-> Full taxonomy with verb lists: see [`taxonomy_explorer_knowledge.md`](taxonomy_explorer_knowledge.md) + [`outcomes_quality_knowledge.md`](outcomes_quality_knowledge.md) now; a dedicated [`blooms_taxonomy_knowledge.md`](blooms_taxonomy_knowledge.md) is forthcoming (to be built from the Taxonomy Explorer source).
+> Full taxonomy with verb lists: see [`taxonomy_explorer_knowledge.md`](taxonomy_explorer_knowledge.md) + [`outcomes_quality_knowledge.md`](outcomes_quality_knowledge.md) now; a dedicated `blooms_taxonomy_knowledge.md` is forthcoming (to be built from the Taxonomy Explorer source).
 
 ---
 

--- a/lib/agents/templates/README.md
+++ b/lib/agents/templates/README.md
@@ -8,7 +8,7 @@ Templates are the **implementation layer**: actual HTML, JSON, or text files an 
 
 The [`agents/knowledge/README.md`](../knowledge/README.md) explicitly defines knowledge files as conceptual references — theory and audit signals, not implementation. Stuffing HTML or JSON templates into a knowledge file dilutes that conceptual layer. Templates live here instead, referenced from knowledge files where appropriate.
 
-This also positions cleanly for the future deployable-skill direction: when a knowledge area becomes a `.agents/skills/<skill-name>/` package per the [Agent Skills standard](https://agentskills.io/specification), templates here map cleanly to that skill's `assets/` directory. See [`AGENTS.md`](../../AGENTS.md#roadmap) Roadmap items 1–3.
+This also positions cleanly for the future deployable-skill direction: when a knowledge area becomes a `.agents/skills/<skill-name>/` package per the [Agent Skills standard](https://agentskills.io/specification), templates here map cleanly to that skill's `assets/` directory. See [`AGENTS.md`](../../../AGENTS.md#roadmap) Roadmap items 1–3.
 
 ## Layout convention
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "0.72.2"
+version = "0.72.3"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "0.72.2"
+version = "0.72.3"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Two follow-ups bundled as the **v0.72.3** release:

1. **Fix the 8 pre-existing `lib/agents/` broken links** (flagged in #116).
2. **Cut v0.72.3** — promotes the AGENTS.md trim (merged under `[Unreleased]` in #116) to a tagged release, and completes CHANGELOG so its history is contiguous with the latest release on top.

## Link fixes (8)
- `AGENT_LAYERS.md` / `templates/README.md` → wrong relative depth to root `AGENTS.md` (`../` → `../../`, `../../` → `../../../`).
- `knowledge/README.md` → `canvas_grader.md` (×3): missing `../` (it lives one level up).
- `canvas_course_expert.md` → `toyota_gap_analysis_knowledge.md`: missing `knowledge/` prefix.
- `three_domains_knowledge.md` → `blooms_taxonomy_knowledge.md` (×2): **de-linked** — that file is an intentional *"forthcoming"* reference that doesn't exist yet; kept as a code-span so it's no longer a broken link.

## Release cut (v0.72.3)
- Version bumped `0.72.2 → 0.72.3` across `pyproject.toml`, `plugin.json`, `marketplace.json`, `uv.lock`, README footer.
- CHANGELOG `[Unreleased]` → `[0.72.3] — 2026-06-29`.
- **CHANGELOG completed**: mirrored `0.72.1 / 0.72.0 / 0.71.0` and rotated-in `0.70.0`, so it now runs contiguous **0.72.3 → 0.35.4** (was jumping 0.72.2 → 0.70.0). Matches the README footer's "full release history in CHANGELOG."
- **Active Context rotation**: added `v0.72.3` on top, rotated `v0.70.0` out → stays at exactly **5 entries**, exercising the new CI guard end-to-end.

## Flagged (not fixed here)
- The `#roadmap` anchor that `AGENT_LAYERS.md` and `templates/README.md` reference no longer exists in `AGENTS.md` (no Roadmap section). The links now resolve to the right *file* (land at top); recreating a Roadmap section is a separate content decision.

## Test plan
- [x] `pytest` — **606 passed** (incl. the ≤5 Active Context guard); 7 pre-existing live-Canvas failures unchanged
- [x] Repo-wide broken-link sweep: **0 broken**
- [x] Active Context = 5 entries (guard green)
- [x] `uv.lock` consistent at 0.72.3 (no post-run drift)
- [x] `pre-commit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
