### PR TITLE
fix: Windows hardening — reliable PDF render + cb-init console encoding

### DIFF
--- a/lib/tools/_md_to_pdf.py
+++ b/lib/tools/_md_to_pdf.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -140,19 +141,32 @@ def render_pair(md_path: Path, title: str | None = None,
               f"Brave / Edge, or render the .md manually)", file=sys.stderr)
         return None
 
-    pdf_path = md_path.with_suffix(".pdf")
-    html_path = md_path.with_suffix(".html")
+    # Resolve to ABSOLUTE: new-headless Chrome resolves a relative
+    # --print-to-pdf target against its OWN cwd (the Chrome install dir under
+    # Program Files on Windows — not writable), reporting the failure as
+    # "Access is denied". An absolute path writes exactly where intended.
+    pdf_path = md_path.resolve().with_suffix(".pdf")
+    html_path = md_path.resolve().with_suffix(".html")
 
     md_text = md_path.read_text(encoding="utf-8")
     html_doc = md_to_html(md_text, title=title or md_path.stem,
                            css=css or _DEFAULT_CSS)
     html_path.write_text(html_doc, encoding="utf-8")
 
+    # Isolated profile dir: without --user-data-dir, headless Chrome shares the
+    # operator's default profile. If a normal Chrome window is already open, the
+    # profile is locked and the new headless mode reports the collision as
+    # "Failed to write file <pdf>: Access is denied" (Windows). A throwaway
+    # profile sidesteps the lock entirely and is cleaned up after.
+    user_data_dir = tempfile.mkdtemp(prefix="cb-chrome-")
     try:
         # Run Chrome headless. Filter known-noisy stderr lines.
+        # Path.as_uri() yields a correct file:///C:/... URI on Windows (the bare
+        # f"file://{path}" form leaves backslashes and only two slashes).
         result = subprocess.run(
-            [chrome, "--headless", "--disable-gpu", "--no-pdf-header-footer",
-             f"--print-to-pdf={pdf_path}", f"file://{html_path.resolve()}"],
+            [chrome, "--headless=new", "--disable-gpu",
+             f"--user-data-dir={user_data_dir}", "--no-pdf-header-footer",
+             f"--print-to-pdf={pdf_path}", html_path.resolve().as_uri()],
             capture_output=True, text=True, timeout=60,
         )
         if not pdf_path.is_file():
@@ -169,9 +183,10 @@ def render_pair(md_path: Path, title: str | None = None,
         print(f"  (PDF render failed: {e})", file=sys.stderr)
         return None
     finally:
-        # Clean up the intermediate HTML
+        # Clean up the intermediate HTML + throwaway Chrome profile
         try:
             if html_path.is_file():
                 html_path.unlink()
         except Exception:
             pass
+        shutil.rmtree(user_data_dir, ignore_errors=True)

--- a/lib/tools/cb_init.py
+++ b/lib/tools/cb_init.py
@@ -498,6 +498,16 @@ def step_8_surface_docs(*, mode: str) -> bool:
 # ---------------------------------------------------------------------------
 
 def main() -> int:
+    # Windows consoles default to the cp1252 code page, which can't encode the
+    # ✓ / — / ⏭ glyphs this bootstrap prints — raising UnicodeEncodeError
+    # mid-run on a fresh Windows machine (exactly where cb-init runs first).
+    # Force UTF-8 on stdout/stderr so the output renders instead of crashing.
+    if sys.platform == "win32":
+        for _stream in (sys.stdout, sys.stderr):
+            try:
+                _stream.reconfigure(encoding="utf-8")
+            except (AttributeError, OSError):
+                pass
     parser = argparse.ArgumentParser(
         description=(
             "One-command bootstrap for canvas-toolbox. Detects state, "


### PR DESCRIPTION
## Problem

On Windows, the shared MD→PDF renderer (`lib/tools/_md_to_pdf.py`) fails for every audit/report whenever the report path is relative — which is the documented common case (e.g. `course_audit.py --report audit.md`). Chrome exits with:

```
ERROR:headless_command_handler.cc:266] Failed to write file audit.pdf: Access is denied. (0x5)
```

The `.md` is written, but no `.pdf` pair is produced. The PDF is the faculty-facing default, so this silently degrades the primary artifact on Windows.

## Root cause

Three issues in `render_pair`, in order of impact:

1. **Relative output path (the actual blocker).** The renderer passed `--print-to-pdf=audit.pdf` (relative). New-headless Chrome resolves a relative output path against **its own** working directory — the Chrome install dir under `C:\Program Files\...`, which isn't writable — not the calling process's cwd. Hence "Access is denied".
2. **Shared user profile.** No `--user-data-dir` was passed, so headless Chrome used the operator's default profile. If a normal Chrome window is open, that profile is locked and the new headless mode surfaces the collision as the same access-denied error.
3. **Malformed `file://` URL.** The source URL was built as `f"file://{path}"`, which on Windows leaves backslashes and only two slashes.

## Fix

- Resolve PDF/HTML paths to **absolute** before invoking Chrome.
- Launch with an isolated, throwaway `--user-data-dir` (created via `tempfile.mkdtemp`, removed in `finally`).
- Build the source URL with `Path.as_uri()` → correct `file:///C:/...`.
- Pin `--headless=new`.

On macOS/Linux these are equivalent to the prior invocation (absolute paths and `as_uri()` produce the same effective args), so there's no behavior change off Windows.

## Verification

- **Windows 11, Chrome 14x:** `course_audit.py --course-id <id> --full --report audit.md` now emits both `audit.md` **and** a ~91 KB `audit.pdf`. Confirmed both via the tool entrypoint and a direct `render_pair()` call.
- `ruff check lib/tools/_md_to_pdf.py` → clean (pre-commit ruff hook passed on commit).
- `pytest lib/tests/ -k "not sprint"`: no new failures. The 11 failures present in my environment (`test_install_script.py` bash-syntax / exec-bit checks, one subprocess `FileNotFoundError`) reproduce **identically on the unmodified baseline** — they're Windows-only environmental (no `bash` on PATH, no Unix exec bit) and unrelated to this change.

## Notes

- Scope is intentionally limited to `_md_to_pdf.py`; no public API change. `render_pair` still returns the `.pdf` path or `None` and still graceful-degrades when no Chromium-family browser is found.

---

## Second fix in this PR — cb-init console encoding (Windows)

Same Windows-hardening theme, different tool. `cb_init.py` prints `✓ / — / ⏭` status glyphs. On a fresh Windows box the console defaults to cp1252, which can't encode them — so the **first command an adopter runs** (`cb-init`) crashes mid-step with `UnicodeEncodeError: 'charmap' codec can't encode character '✓'`. Fixed by reconfiguring `sys.stdout`/`stderr` to UTF-8 at the top of `main()` on win32 (guarded no-op otherwise). Verified: with `PYTHONUTF8` unset, `cb-init --check` now exits 0 instead of crashing.

**Deliberately scoped narrow:** the same cp1252 limitation affects other glyph-printing tools (`course_audit.py`, `clo_quality_audit.py`, …), but they share no single import chokepoint (`cb_init` can't import the deps-dependent helpers pre-sync), so a toolkit-wide console-encoding retrofit is filed **separately as a bug** for a test-covered change rather than bolted onto this PR. This commit fixes the highest-impact crash site only — the first-run onboarding entry point.

The two commits are independent and can be split if you'd prefer them as separate PRs.
