### PR TITLE
fix: Add https:// prepending to engagement audit base URL

### DIFF
--- a/lib/tools/course_engagement_audit.py
+++ b/lib/tools/course_engagement_audit.py
@@ -345,6 +345,8 @@ def _env_canvas(course_id_override: str | None = None) -> tuple[str, str, str]:
     """Read CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID from env."""
     tok = os.environ.get("CANVAS_API_TOKEN", "")
     base = (os.environ.get("CANVAS_BASE_URL", "") or "").rstrip("/")
+    if base and not base.startswith(("http://", "https://")):
+        base = f"https://{base}"
     cid = course_id_override or os.environ.get("CANVAS_COURSE_ID", "")
     return tok, base, cid
 


### PR DESCRIPTION
Fixes bug where engagement audit fails when CANVAS_BASE_URL in .env doesn't include https:// scheme.

## Bug
When .env contains:
```
CANVAS_BASE_URL=byui.instructure.com
```

Engagement audit failed with:
```
MissingSchema: Invalid URL 'byui.instructure.com/api/v1/courses/...'
```

## Fix
Prepend https:// if base URL doesn't start with http:// or https://

Matches the pattern already used in fix_group_override_recalc.py

## Testing
✅ Tested on ITM 220 Sandbox (317348) - successfully fetched course metadata
✅ Both Rust tools now work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)