### PR TITLE
fix(syllabus_audit): catch common grading/late-work phrasing + flag image-only content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ## [Unreleased]
 
+### Fixed
+- **syllabus_audit.py** — grading-section keyword detection missed common real-world
+  phrasing: "Grading Schemes" (vs. "grading scale") and "late assignments" / "an
+  assignment is late" (vs. "late work" / "late policy"). Added those variants to the
+  pattern list. Found auditing a live BYU-I syllabus that had both a grading policy
+  and a late-work policy but was flagged incomplete.
+- **syllabus_audit.py** — added an `embedded_images` advisory signal (does not affect
+  verdict). Some syllabi present their grading scale as an image with no text
+  equivalent (e.g. a "Grading Scheme.png" screenshot) — that content is invisible to
+  this audit's keyword scan *and* to screen readers. The report now surfaces an image
+  count so operators know to check for this pattern manually.
+
 ---
 
 ## [1.7.10] — 2026-07-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ## [Unreleased]
 
-### Fixed
-- **syllabus_audit.py** — grading-section keyword detection missed common real-world
-  phrasing: "Grading Schemes" (vs. "grading scale") and "late assignments" / "an
-  assignment is late" (vs. "late work" / "late policy"). Added those variants to the
-  pattern list. Found auditing a live BYU-I syllabus that had both a grading policy
-  and a late-work policy but was flagged incomplete.
-- **syllabus_audit.py** — added an `embedded_images` advisory signal (does not affect
-  verdict). Some syllabi present their grading scale as an image with no text
-  equivalent (e.g. a "Grading Scheme.png" screenshot) — that content is invisible to
-  this audit's keyword scan *and* to screen readers. The report now surfaces an image
-  count so operators know to check for this pattern manually.
+---
+
+## [1.7.11] — 2026-07-14
+
+**`syllabus_audit`: comprehensive late-work detection + a syllabus-vs-Canvas late-policy check.** (#140, phrasing foundation by @thiebaudr-lab)
+
+Grading/late detection missed common phrasing, so syllabi with a real policy were wrongly flagged incomplete. The detection vocabulary is now grounded in evidence — 32 live BYU-I syllabi + Canvas's own Late Policy UI — and the audit compares what the syllabus *says* against what Canvas is actually *set to enforce*.
+
+### Added
+- **Late-policy mismatch check (online)** — the audit fetches the course's actual Gradebook Late Policy (`GET /courses/:id/late_policy`) and warns when the syllabus describes a late-work policy but Canvas isn't configured to enforce it (no auto missing/late deduction). Real signal: this fired on **7 of 32** live courses with a syllabus. Skipped offline (`--local`) — the setting isn't in a mirror.
+- **Scoped image-only grade-scale warning** — when a grading section is present, the body has images, but no *plain-text* grade scale (letter→number mapping; a lone late-penalty "%" doesn't count), the audit flags that the scale may be image-only (invisible to screen readers and this audit). No longer fires on every decorative image.
+
+### Changed
+- **Comprehensive late-work detection** — added the real vocabulary (`late work`, `late assignment`, `late submission`, `submitted late`, `grace period`, `make-up work`, `grade/grading scheme`, …). Faculty write "late work", Canvas's feature says "late submission" — both are valid, so the audit just detects them all. No "conventional term" nagging.
+- Dropped `"points possible"` — too generic (an assignment point value is not a grading policy; it risked false "present" verdicts, the audit's worst error).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,19 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
-## [1.7.11] — 2026-07-14
+## [1.7.11] — 2026-07-15
 
-**`syllabus_audit`: comprehensive late-work detection + a syllabus-vs-Canvas late-policy check.** (#140, phrasing foundation by @thiebaudr-lab)
+**`syllabus_audit`: comprehensive, evidence-grounded late-work detection.** (#140, by @thiebaudr-lab)
 
-Grading/late detection missed common phrasing, so syllabi with a real policy were wrongly flagged incomplete. The detection vocabulary is now grounded in evidence — 32 live BYU-I syllabi + Canvas's own Late Policy UI — and the audit compares what the syllabus *says* against what Canvas is actually *set to enforce*.
-
-### Added
-- **Late-policy mismatch check (online)** — the audit fetches the course's actual Gradebook Late Policy (`GET /courses/:id/late_policy`) and warns when the syllabus describes a late-work policy but Canvas isn't configured to enforce it (no auto missing/late deduction). Real signal: this fired on **7 of 32** live courses with a syllabus. Skipped offline (`--local`) — the setting isn't in a mirror.
-- **Scoped image-only grade-scale warning** — when a grading section is present, the body has images, but no *plain-text* grade scale (letter→number mapping; a lone late-penalty "%" doesn't count), the audit flags that the scale may be image-only (invisible to screen readers and this audit). No longer fires on every decorative image.
+Grading/late detection missed common phrasing, so syllabi with a real policy were wrongly flagged incomplete. The detection vocabulary is now grounded in evidence — 32 live BYU-I syllabi + Canvas's own Late Policy UI ("late/missing submission").
 
 ### Changed
 - **Comprehensive late-work detection** — added the real vocabulary (`late work`, `late assignment`, `late submission`, `submitted late`, `grace period`, `make-up work`, `grade/grading scheme`, …). Faculty write "late work", Canvas's feature says "late submission" — both are valid, so the audit just detects them all. No "conventional term" nagging.
 - Dropped `"points possible"` — too generic (an assignment point value is not a grading policy; it risked false "present" verdicts, the audit's worst error).
+
+### Added
+- **Scoped image-only grade-scale warning** — when a grading section is present, the body has images, but no *plain-text* grade scale (letter→number mapping; a lone late-penalty "%" doesn't count), the audit flags that the scale may be image-only (invisible to screen readers and this audit). No longer fires on every decorative image.
+
+_The syllabus-vs-Canvas late-policy mismatch check explored here is deferred to its own PR — it needs guards (skip template/master courses; require penalty-grade language) and an honest reframe that accounts for per-student / manual late-work enforcement._
 
 ---
 

--- a/lib/tests/test_syllabus_audit.py
+++ b/lib/tests/test_syllabus_audit.py
@@ -169,22 +169,6 @@ def test_has_text_grade_scale():
     assert not S.has_text_grade_scale("final grades are posted in Canvas")
 
 
-# --- late-policy: syllabus statement vs the course's actual Canvas setting ----
-
-def test_mentions_late_policy():
-    assert S.mentions_late_policy("there is a 10% penalty for late work per day")
-    assert S.mentions_late_policy("no grace period after the due date")
-    assert not S.mentions_late_policy("this course covers data analysis in python")
-
-
-def test_late_policy_enabled():
-    assert S.late_policy_enabled({"late_submission_deduction_enabled": True})
-    assert S.late_policy_enabled({"missing_submission_deduction_enabled": True})
-    assert not S.late_policy_enabled({"late_submission_deduction_enabled": False,
-                                      "missing_submission_deduction_enabled": False})
-    assert not S.late_policy_enabled(None)  # course has no late policy configured
-
-
 def _render_output(sections, advisory):
     return "\n".join(S._render(
         "1", "Course", S.COMPLETE, [], sections,
@@ -193,24 +177,7 @@ def _render_output(sections, advisory):
 
 _BASE_ADVISORY = {"word_count": 500, "bloat": False, "outcomes_present": True,
                   "learning_model_present": False, "embedded_images": 0,
-                  "grade_scale_in_text": True, "syllabus_states_late_policy": False,
-                  "late_policy_configured": None}
-
-
-def test_render_flags_late_policy_mismatch():
-    """Syllabus states a late policy but Canvas isn't set to enforce it -> warn."""
-    secs = detect_sections("late work loses 10% per day")
-    out = _render_output(secs, {**_BASE_ADVISORY, "syllabus_states_late_policy": True,
-                                "late_policy_configured": False})
-    assert "NOT set to enforce it" in out
-
-
-def test_render_no_mismatch_when_canvas_policy_configured():
-    secs = detect_sections("late work loses 10% per day")
-    out = _render_output(secs, {**_BASE_ADVISORY, "syllabus_states_late_policy": True,
-                                "late_policy_configured": True})
-    assert "NOT set to enforce it" not in out
-    assert "configured to enforce it" in out
+                  "grade_scale_in_text": True}
 
 
 def test_render_image_warning_only_when_grade_scale_missing():

--- a/lib/tests/test_syllabus_audit.py
+++ b/lib/tests/test_syllabus_audit.py
@@ -1,10 +1,14 @@
-"""Tier 1 unit tests — syllabus_audit institution profile (college-agnostic).
+"""Tier 1 unit tests — syllabus_audit.py.
 
-Source: lib/tools/syllabus_audit.py — compute_verdict + default_institution.
-The BYUI profile REQUIRES a generative-AI policy for a 'complete' verdict; other
-institutions treat it as advisory (the AI policy is reported but doesn't drive
-the verdict). Institution is inferred from the Canvas host, overridable by
-CANVAS_INSTITUTION / --institution.
+Institution profile (compute_verdict + default_institution): the BYUI profile
+REQUIRES a generative-AI policy for a 'complete' verdict; other institutions
+treat it as advisory (reported but not verdict-driving). Institution is inferred
+from the Canvas host, overridable by CANVAS_INSTITUTION / --institution.
+
+Phrasing coverage (detect_sections + count_images): a "Grading Schemes" heading
+(not "grading scale") over an image-only grade table, and late-work phrased as
+"late assignments" / "an assignment is late" — real phrasings the original
+pattern list missed.
 """
 import sys
 from pathlib import Path
@@ -14,7 +18,16 @@ if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
 import syllabus_audit as S  # noqa: E402
+from syllabus_audit import (  # noqa: E402
+    count_images,
+    detect_sections,
+    html_to_text,
+)
 
+
+# ---------------------------------------------------------------------------
+# institution profile — compute_verdict + default_institution
+# ---------------------------------------------------------------------------
 
 def _all_detected():
     return [{"label": s["label"], "detected": True} for s in S.REQUIRED_SECTIONS]
@@ -54,3 +67,73 @@ def test_env_overrides_inference(monkeypatch):
     monkeypatch.setenv("CANVAS_INSTITUTION", "acme")
     monkeypatch.setattr(S, "CANVAS_BASE_URL", "https://byui.instructure.com")
     assert S.default_institution() == "acme"
+
+
+# ---------------------------------------------------------------------------
+# grading section — phrasing variants that previously false-negatived
+# ---------------------------------------------------------------------------
+
+def _grading_detected(text: str) -> bool:
+    sections = detect_sections(text)
+    return next(s["detected"] for s in sections if s["key"] == "grading")
+
+
+def test_grading_scheme_heading_detected():
+    """"Grading Schemes" (not "grading scale") must now match."""
+    assert _grading_detected("see the grading schemes section below")
+
+
+def test_late_assignments_phrasing_detected():
+    """"Late assignments" / "an assignment is late" must now match
+    ("late work" / "late policy" alone missed this real phrasing)."""
+    assert _grading_detected("late assignments: 10% is deducted "
+                             "for every day an assignment is late")
+
+
+def test_original_grading_patterns_still_detected():
+    """Regression guard — the original pattern set must keep working."""
+    assert _grading_detected("see the grading scale for letter grades")
+    assert _grading_detected("our late policy allows one free extension")
+
+
+def test_grading_not_detected_when_absent():
+    assert not _grading_detected("this syllabus discusses the course overview only")
+
+
+# ---------------------------------------------------------------------------
+# count_images — advisory signal for image-only policy content
+# ---------------------------------------------------------------------------
+
+def test_count_images_zero_for_text_only_body():
+    assert count_images("<p>No images here, just text.</p>") == 0
+
+
+def test_count_images_counts_multiple():
+    body = '<img src="a.png"><p>text</p><img src="b.png">'
+    assert count_images(body) == 2
+
+
+def test_count_images_empty_body():
+    assert count_images("") == 0
+    assert count_images(None) == 0  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# html_to_text — sanity check the real-world case end-to-end
+# ---------------------------------------------------------------------------
+
+def test_grading_scheme_image_only_html_flagged_by_advisory_not_text():
+    """The exact shape from the real syllabus: a "Grading Schemes" heading
+    over an <img> with no textual grade cutoffs. Section detection passes
+    on the heading; count_images flags the image so the advisory can warn
+    that the actual scale is unreadable to both this audit and a screen
+    reader."""
+    body = (
+        "<h2>Grading Schemes</h2>"
+        '<img src="grading-scheme.png" alt="Grading Scheme.png">'
+        "<h2>Late assignments</h2>"
+        "<p>Every day an assignment is late, 10% is deducted.</p>"
+    )
+    text = html_to_text(body)
+    assert _grading_detected(text)
+    assert count_images(body) == 1

--- a/lib/tests/test_syllabus_audit.py
+++ b/lib/tests/test_syllabus_audit.py
@@ -137,3 +137,87 @@ def test_grading_scheme_image_only_html_flagged_by_advisory_not_text():
     text = html_to_text(body)
     assert _grading_detected(text)
     assert count_images(body) == 1
+
+
+# ---------------------------------------------------------------------------
+# clarity advisory — call out non-standard phrasing (student cognitive load)
+# ---------------------------------------------------------------------------
+
+def _grading(text):
+    return next(s for s in detect_sections(text) if s["key"] == "grading")
+
+
+def test_points_possible_no_longer_marks_grading_present():
+    """Dropped as too generic — an assignment point value is not a grading policy."""
+    assert not _grading("quiz 1 is worth 10 points possible")["detected"]
+
+
+def test_comprehensive_late_vocabulary_detected():
+    """Real faculty + Canvas vocabulary all detect the grading/late section
+    (no false-negatives) — grounded in 32 live syllabi + Canvas's Late Policy UI."""
+    for phrase in ("late work policy", "late assignments lose 10%",
+                   "late submission deduction", "work submitted late",
+                   "a grace period after the due date", "make-up work is allowed"):
+        assert _grading(phrase)["detected"], phrase
+
+
+def test_has_text_grade_scale():
+    assert S.has_text_grade_scale("A = 93, B = 83")            # letter = number
+    assert S.has_text_grade_scale("90-100% = A, 80-89% = B")   # percent range = letter
+    # a lone percentage is a late penalty, NOT a grade scale — must not count
+    assert not S.has_text_grade_scale("10% off per day an assignment is late")
+    assert not S.has_text_grade_scale("final grades are posted in Canvas")
+
+
+# --- late-policy: syllabus statement vs the course's actual Canvas setting ----
+
+def test_mentions_late_policy():
+    assert S.mentions_late_policy("there is a 10% penalty for late work per day")
+    assert S.mentions_late_policy("no grace period after the due date")
+    assert not S.mentions_late_policy("this course covers data analysis in python")
+
+
+def test_late_policy_enabled():
+    assert S.late_policy_enabled({"late_submission_deduction_enabled": True})
+    assert S.late_policy_enabled({"missing_submission_deduction_enabled": True})
+    assert not S.late_policy_enabled({"late_submission_deduction_enabled": False,
+                                      "missing_submission_deduction_enabled": False})
+    assert not S.late_policy_enabled(None)  # course has no late policy configured
+
+
+def _render_output(sections, advisory):
+    return "\n".join(S._render(
+        "1", "Course", S.COMPLETE, [], sections,
+        {"present": True, "frameworks": []}, advisory, False, "ts"))
+
+
+_BASE_ADVISORY = {"word_count": 500, "bloat": False, "outcomes_present": True,
+                  "learning_model_present": False, "embedded_images": 0,
+                  "grade_scale_in_text": True, "syllabus_states_late_policy": False,
+                  "late_policy_configured": None}
+
+
+def test_render_flags_late_policy_mismatch():
+    """Syllabus states a late policy but Canvas isn't set to enforce it -> warn."""
+    secs = detect_sections("late work loses 10% per day")
+    out = _render_output(secs, {**_BASE_ADVISORY, "syllabus_states_late_policy": True,
+                                "late_policy_configured": False})
+    assert "NOT set to enforce it" in out
+
+
+def test_render_no_mismatch_when_canvas_policy_configured():
+    secs = detect_sections("late work loses 10% per day")
+    out = _render_output(secs, {**_BASE_ADVISORY, "syllabus_states_late_policy": True,
+                                "late_policy_configured": True})
+    assert "NOT set to enforce it" not in out
+    assert "configured to enforce it" in out
+
+
+def test_render_image_warning_only_when_grade_scale_missing():
+    secs = detect_sections("grading scale: refer to the chart")  # grading present
+    warn = _render_output(secs, {**_BASE_ADVISORY, "embedded_images": 2,
+                                 "grade_scale_in_text": False})
+    assert "invisible to screen readers" in warn          # image-only risk -> warn
+    ok = _render_output(secs, {**_BASE_ADVISORY, "embedded_images": 2,
+                               "grade_scale_in_text": True})
+    assert "invisible to screen readers" not in ok        # text scale present -> quiet

--- a/lib/tools/syllabus_audit.py
+++ b/lib/tools/syllabus_audit.py
@@ -167,6 +167,26 @@ def fetch_syllabus(course_id: str) -> tuple[str, str | None]:
     return name, ("" if body is None else str(body))
 
 
+def fetch_late_policy(course_id: str) -> dict | None:
+    """The course's Gradebook Late Policy (GET /courses/:id/late_policy) — the
+    missing/late submission deduction settings from Gradebook → Settings → Late
+    Policies. None if the course has none set or the request fails. Online only;
+    this setting is not part of a `.imscc` export or a --pull mirror."""
+    try:
+        resp = _get(f"/courses/{course_id}/late_policy")
+    except Exception:
+        return None
+    if isinstance(resp, dict):
+        return resp.get("late_policy", resp)  # API nests under "late_policy"
+    return None
+
+
+def late_policy_enabled(lp: dict | None) -> bool:
+    """True if Canvas is set to auto-enforce a late/missing deduction."""
+    return bool(lp and (lp.get("late_submission_deduction_enabled")
+                        or lp.get("missing_submission_deduction_enabled")))
+
+
 # ---------------------------------------------------------------------------
 # HTML → text
 # ---------------------------------------------------------------------------
@@ -230,10 +250,15 @@ REQUIRED_SECTIONS: list[dict] = [
      "patterns": ["feedback", "workload", "time commitment", "hours per week",
                   "expect to spend", "expectations"], "byui": False},
     {"key": "grading", "label": "Grading (Grading Scale / Late Work)",
-     "patterns": ["grading scale", "grade scale", "grading scheme", "grade scheme",
-                  "grading policy", "grade breakdown", "letter grade",
+     # Detection vocabulary grounded in real syllabi (32 live BYU-I courses) AND
+     # Canvas's own Late Policy UI ("late/missing submission"). No "conventional
+     # term" nagging: faculty overwhelmingly write "late work", Canvas's feature
+     # says "late submission" — both are valid, so we just detect them all.
+     "patterns": ["grading scale", "grade scale", "grading policy", "grade breakdown",
+                  "letter grade", "grading scheme", "grade scheme",
                   "late work", "late policy", "late assignment", "late submission",
-                  "assignment is late", "points possible"], "byui": False},
+                  "submitted late", "grace period", "make-up work", "makeup work"],
+     "byui": False},
     {"key": "disabilities", "label": "Students with Disabilities",
      "patterns": ["disabilit", "accommodation", "accessibility", "section 504",
                   "ada ", "americans with disabilities"], "byui": False},
@@ -280,15 +305,28 @@ def _any(text: str, patterns: list[str]) -> bool:
 
 def detect_sections(text: str) -> list[dict]:
     """Return each required section with a `detected` bool."""
-    out = []
-    for spec in REQUIRED_SECTIONS:
-        out.append({
-            "key": spec["key"],
-            "label": spec["label"],
-            "byui": spec["byui"],
-            "detected": _any(text, spec["patterns"]),
-        })
-    return out
+    return [{
+        "key": spec["key"],
+        "label": spec["label"],
+        "byui": spec["byui"],
+        "detected": _any(text, spec["patterns"]),
+    } for spec in REQUIRED_SECTIONS]
+
+
+# A syllabus "states a late-work policy" if it uses any of this vocabulary. Kept
+# focused (clear late-policy language only, not generic "penalty"/"deduct") so
+# the late_policy mismatch check below doesn't false-positive.
+_LATE_POLICY_PATTERNS = [
+    "late work", "late policy", "late assignment", "late submission",
+    "submitted late", "turned in late", "accept late", "accepted late",
+    "not accepted late", "grace period", "make-up work", "makeup work",
+    "late penalty", "penalty for late",
+]
+
+
+def mentions_late_policy(text: str) -> bool:
+    """True if the syllabus text describes a late-work policy."""
+    return _any(text, _LATE_POLICY_PATTERNS)
 
 
 # ---------------------------------------------------------------------------
@@ -552,12 +590,31 @@ def detect_ai_policy(text: str) -> dict:
     return {"present": present, "frameworks": frameworks}
 
 
+# A textual grade scale maps LETTER grades to numbers — "A = 93", "B: 83", or a
+# range like "90-100% = A". A lone percentage ("10% off per day") is a late
+# penalty, not a scale, so it must NOT count (else it would suppress the
+# image-only warning below). If a grading section is present but none of this
+# appears AND the body has images, the scale may live only in an image.
+_GRADE_SCALE_RE = re.compile(
+    r"\b[a-df][+-]?\s*[=:]\s*\d{2}"                            # A = 93 / B: 83
+    r"|\d{2,3}\s*%?\s*[-–]\s*\d{2,3}\s*%?\s*[=:]?\s*[a-df]\b",  # 90-100% = A
+    re.IGNORECASE)
+
+
+def has_text_grade_scale(text: str) -> bool:
+    return bool(_GRADE_SCALE_RE.search(text))
+
+
 def detect_advisory(text: str, body: str) -> dict:
     wc = word_count(text)
     return {
         "word_count": wc,
         "bloat": wc > _BLOAT_WORDS,
         "embedded_images": count_images(body),
+        "grade_scale_in_text": has_text_grade_scale(text),
+        "syllabus_states_late_policy": mentions_late_policy(text),
+        # set online in main() to True/False; stays None when not checked (offline)
+        "late_policy_configured": None,
         # DOM-aware, shared with rubric_quality_audit / rubric_recommender (#31):
         # detects the outcomes SECTION (heading/stem), not a bare keyword hit.
         "outcomes_present": detect_outcomes_section(body) is not None,
@@ -657,10 +714,31 @@ def _render(course_id: str, course_name: str, verdict: str, missing: list[str],
                  f"{'yes' if advisory['learning_model_present'] else 'not detected'}"
                  "  [BYUI]")
     img_n = advisory["embedded_images"]
+    # Only warn when there's a real image-only-policy risk: a grading section is
+    # present, images exist, but no textual grade scale was found — so the scale
+    # may be a graphic (invisible to screen readers and this audit). A decorative
+    # banner/logo on a syllabus with a text scale is not flagged.
+    grading_present = any(s["key"] == "grading" and s["detected"] for s in sections)
+    image_only_risk = img_n and grading_present and not advisory["grade_scale_in_text"]
     lines.append(f"  • Images embedded in body: {img_n}"
-                 + (f"  ⚠️ policy content shown only as an image (e.g. a grading-scale "
-                    f"graphic) is invisible to this audit's keyword scan AND to screen "
-                    f"readers — add a plain-text equivalent" if img_n else ""))
+                 + ("  ⚠️ a grading section is present but no plain-text grade scale "
+                    "was found — if the scale is shown only as an image it's invisible "
+                    "to screen readers AND to this audit; add a text equivalent"
+                    if image_only_risk else ""))
+    # Does the course's ACTUAL Canvas Late Policy match what the syllabus states?
+    states_late = advisory.get("syllabus_states_late_policy")
+    configured = advisory.get("late_policy_configured")  # True/False, or None (offline)
+    if states_late and configured is False:
+        lines.append("  • ⚠️ Late-work policy: the syllabus describes one, but Canvas's "
+                     "Late Policy (Gradebook → Settings → Late Policies) is NOT set to "
+                     "enforce it — students can't tell what actually happens, and "
+                     "deductions fall to manual grading")
+    elif states_late and configured is True:
+        lines.append("  • Late-work policy: stated in the syllabus and Canvas's Late "
+                     "Policy is configured to enforce it ✅")
+    elif states_late:  # None — offline, not checked
+        lines.append("  • Late-work policy: stated in the syllabus "
+                     "(Canvas Late Policy setting not checked offline)")
     lines.append("")
 
     if missing:
@@ -811,12 +889,15 @@ def main() -> None:
             print(f"\nCould not fetch course {course_id} (or the request failed).",
                   file=sys.stderr)
             sys.exit(2)
+        late_policy = fetch_late_policy(course_id)
 
     text = html_to_text(body)
     body_words = word_count(text)
     sections = detect_sections(text)
     ai_policy = detect_ai_policy(text)
     advisory = detect_advisory(text, body)
+    if not use_local:  # online: compare the syllabus's late policy to Canvas's setting
+        advisory["late_policy_configured"] = late_policy_enabled(late_policy)
     verdict, missing = compute_verdict(sections, ai_policy, body_words,
                                        ai_policy_required=(institution == "byui"))
 

--- a/lib/tools/syllabus_audit.py
+++ b/lib/tools/syllabus_audit.py
@@ -173,6 +173,15 @@ def fetch_syllabus(course_id: str) -> tuple[str, str | None]:
 
 _TAG_RE = re.compile(r"<[^>]+>")
 _WS_RE = re.compile(r"\s+")
+_IMG_RE = re.compile(r"<img\b", re.IGNORECASE)
+
+
+def count_images(body: str) -> int:
+    """Count <img> tags in the raw (untagged-stripped) syllabus body.
+    Used as an advisory signal: policy content (e.g. a grading-scale
+    graphic) embedded only as an image is invisible to this audit's
+    keyword scan AND to screen readers — same blind spot, two audiences."""
+    return len(_IMG_RE.findall(body)) if body else 0
 
 
 def html_to_text(body: str) -> str:
@@ -221,9 +230,10 @@ REQUIRED_SECTIONS: list[dict] = [
      "patterns": ["feedback", "workload", "time commitment", "hours per week",
                   "expect to spend", "expectations"], "byui": False},
     {"key": "grading", "label": "Grading (Grading Scale / Late Work)",
-     "patterns": ["grading scale", "grade scale", "grading policy",
-                  "grade breakdown", "letter grade", "late work", "late policy",
-                  "points possible"], "byui": False},
+     "patterns": ["grading scale", "grade scale", "grading scheme", "grade scheme",
+                  "grading policy", "grade breakdown", "letter grade",
+                  "late work", "late policy", "late assignment", "late submission",
+                  "assignment is late", "points possible"], "byui": False},
     {"key": "disabilities", "label": "Students with Disabilities",
      "patterns": ["disabilit", "accommodation", "accessibility", "section 504",
                   "ada ", "americans with disabilities"], "byui": False},
@@ -547,6 +557,7 @@ def detect_advisory(text: str, body: str) -> dict:
     return {
         "word_count": wc,
         "bloat": wc > _BLOAT_WORDS,
+        "embedded_images": count_images(body),
         # DOM-aware, shared with rubric_quality_audit / rubric_recommender (#31):
         # detects the outcomes SECTION (heading/stem), not a bare keyword hit.
         "outcomes_present": detect_outcomes_section(body) is not None,
@@ -645,6 +656,11 @@ def _render(course_id: str, course_name: str, verdict: str, missing: list[str],
     lines.append(f"  • BYU-I Learning Model introduced: "
                  f"{'yes' if advisory['learning_model_present'] else 'not detected'}"
                  "  [BYUI]")
+    img_n = advisory["embedded_images"]
+    lines.append(f"  • Images embedded in body: {img_n}"
+                 + (f"  ⚠️ policy content shown only as an image (e.g. a grading-scale "
+                    f"graphic) is invisible to this audit's keyword scan AND to screen "
+                    f"readers — add a plain-text equivalent" if img_n else ""))
     lines.append("")
 
     if missing:

--- a/lib/tools/syllabus_audit.py
+++ b/lib/tools/syllabus_audit.py
@@ -167,26 +167,6 @@ def fetch_syllabus(course_id: str) -> tuple[str, str | None]:
     return name, ("" if body is None else str(body))
 
 
-def fetch_late_policy(course_id: str) -> dict | None:
-    """The course's Gradebook Late Policy (GET /courses/:id/late_policy) — the
-    missing/late submission deduction settings from Gradebook → Settings → Late
-    Policies. None if the course has none set or the request fails. Online only;
-    this setting is not part of a `.imscc` export or a --pull mirror."""
-    try:
-        resp = _get(f"/courses/{course_id}/late_policy")
-    except Exception:
-        return None
-    if isinstance(resp, dict):
-        return resp.get("late_policy", resp)  # API nests under "late_policy"
-    return None
-
-
-def late_policy_enabled(lp: dict | None) -> bool:
-    """True if Canvas is set to auto-enforce a late/missing deduction."""
-    return bool(lp and (lp.get("late_submission_deduction_enabled")
-                        or lp.get("missing_submission_deduction_enabled")))
-
-
 # ---------------------------------------------------------------------------
 # HTML → text
 # ---------------------------------------------------------------------------
@@ -311,22 +291,6 @@ def detect_sections(text: str) -> list[dict]:
         "byui": spec["byui"],
         "detected": _any(text, spec["patterns"]),
     } for spec in REQUIRED_SECTIONS]
-
-
-# A syllabus "states a late-work policy" if it uses any of this vocabulary. Kept
-# focused (clear late-policy language only, not generic "penalty"/"deduct") so
-# the late_policy mismatch check below doesn't false-positive.
-_LATE_POLICY_PATTERNS = [
-    "late work", "late policy", "late assignment", "late submission",
-    "submitted late", "turned in late", "accept late", "accepted late",
-    "not accepted late", "grace period", "make-up work", "makeup work",
-    "late penalty", "penalty for late",
-]
-
-
-def mentions_late_policy(text: str) -> bool:
-    """True if the syllabus text describes a late-work policy."""
-    return _any(text, _LATE_POLICY_PATTERNS)
 
 
 # ---------------------------------------------------------------------------
@@ -612,9 +576,6 @@ def detect_advisory(text: str, body: str) -> dict:
         "bloat": wc > _BLOAT_WORDS,
         "embedded_images": count_images(body),
         "grade_scale_in_text": has_text_grade_scale(text),
-        "syllabus_states_late_policy": mentions_late_policy(text),
-        # set online in main() to True/False; stays None when not checked (offline)
-        "late_policy_configured": None,
         # DOM-aware, shared with rubric_quality_audit / rubric_recommender (#31):
         # detects the outcomes SECTION (heading/stem), not a bare keyword hit.
         "outcomes_present": detect_outcomes_section(body) is not None,
@@ -725,20 +686,6 @@ def _render(course_id: str, course_name: str, verdict: str, missing: list[str],
                     "was found — if the scale is shown only as an image it's invisible "
                     "to screen readers AND to this audit; add a text equivalent"
                     if image_only_risk else ""))
-    # Does the course's ACTUAL Canvas Late Policy match what the syllabus states?
-    states_late = advisory.get("syllabus_states_late_policy")
-    configured = advisory.get("late_policy_configured")  # True/False, or None (offline)
-    if states_late and configured is False:
-        lines.append("  • ⚠️ Late-work policy: the syllabus describes one, but Canvas's "
-                     "Late Policy (Gradebook → Settings → Late Policies) is NOT set to "
-                     "enforce it — students can't tell what actually happens, and "
-                     "deductions fall to manual grading")
-    elif states_late and configured is True:
-        lines.append("  • Late-work policy: stated in the syllabus and Canvas's Late "
-                     "Policy is configured to enforce it ✅")
-    elif states_late:  # None — offline, not checked
-        lines.append("  • Late-work policy: stated in the syllabus "
-                     "(Canvas Late Policy setting not checked offline)")
     lines.append("")
 
     if missing:
@@ -889,15 +836,12 @@ def main() -> None:
             print(f"\nCould not fetch course {course_id} (or the request failed).",
                   file=sys.stderr)
             sys.exit(2)
-        late_policy = fetch_late_policy(course_id)
 
     text = html_to_text(body)
     body_words = word_count(text)
     sections = detect_sections(text)
     ai_policy = detect_ai_policy(text)
     advisory = detect_advisory(text, body)
-    if not use_local:  # online: compare the syllabus's late policy to Canvas's setting
-        advisory["late_policy_configured"] = late_policy_enabled(late_policy)
     verdict, missing = compute_verdict(sections, ai_policy, body_words,
                                        ai_policy_required=(institution == "byui"))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.10"
+version = "1.7.11"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

Ran the full course health sweep on a live BYU-I course syllabus that has both a grading policy and a late-work policy — the audit flagged the Grading section as missing. Root cause: two real-world phrasing variants weren't in the keyword list, plus the grading scale itself was shipped as an image with no text fallback.

- The syllabus uses a **"Grading Schemes"** heading (not "grading scale"/"grade scale"/etc.)
- The late-work policy is phrased **"late assignments" / "an assignment is late"** (not "late work"/"late policy")
- The actual letter-grade cutoffs are shown as an **embedded image** (`Grading Scheme.png`) with no plain-text equivalent — invisible to this audit's keyword scan, and (same root cause) invisible to a screen reader

## Changes

- Added `"grading scheme"`, `"grade scheme"`, `"late assignment"`, `"late submission"`, `"assignment is late"` to the `grading` section's pattern list in `REQUIRED_SECTIONS`
- Added a new `count_images()` pure-logic helper + `embedded_images` advisory signal (does **not** affect verdict) — surfaces how many `<img>` tags are in the syllabus body so operators get a nudge to manually check for image-only policy content. This felt more honest than trying to OCR/guess at image contents, and it doubles as a lightweight accessibility signal since the same blind spot affects screen readers.
- Added `lib/tests/test_syllabus_audit.py` — 8 pure-logic tests covering the new patterns, `count_images`, and a regression guard on the original patterns.

## Ideas for further follow-up (not implemented here — wanted your read before scoping further)

- The `embedded_images` count is body-wide, not scoped to the grading section specifically — a syllabus with an unrelated decorative image would also get flagged. Could tighten this to only fire when an image appears within/near a detected (or expected-but-missing) grading heading, but that needs heading-proximity parsing on the raw DOM rather than the flattened text, which felt like a bigger architectural change than this PR should carry.
- Might be worth applying the same "advisory: content might be image-only" pattern to other sections prone to graphic-only policies (e.g. a weekly schedule shown as a screenshot/table image) — happy to open a follow-up `share:` issue with a design sketch if that's useful, rather than scope-creep this PR.
- No changes made to the accessibility audit itself, even though it already flags missing alt-text — this PR is scoped to syllabus_audit.py only.

## Test plan

- `uv run pytest lib/tests/test_syllabus_audit.py -v` — 8/8 passing (new tests)
- `uv run pytest lib/tests/ -k "not sprint"` — ran full pure-logic suite; only pre-existing Windows-environment failures unrelated to this change (NTFS has no `chmod +x` bit for `test_install_script.py`'s executable-bit check, and a `sh`-dependent subprocess test in `test_cb_init.py`/`test_grader_share_helpers.py`) — none touch `syllabus_audit.py`
- `uv run ruff check lib/tools/syllabus_audit.py lib/tests/test_syllabus_audit.py` — clean
- Manual: ran `course_audit.py --full` against the live course before and after — Grading section correctly flips from 🔴 not-detected to ✅ detected; `embedded_images: 1` now shows up in the advisory block for that course

## Pre-merge checklist

- [x] Pre-commit hooks pass locally (`uv run pre-commit run --all-files` via commit hook)
- [x] Pure-logic tests added/updated for new code (`lib/tests/test_syllabus_audit.py`)
- [ ] AGENTS.md Active Context updated if behavior changed (didn't touch — happy to add if you want an entry)
- [ ] Triple-version-sync — no version bump in this PR
- [x] FERPA two-zone architecture preserved — no student data touched, syllabus_body is instructor-authored content

## Related issue / context

Found while running `course_audit.py --full` for an ESS 465 course adopter — no existing issue number, opening the PR directly per CONTRIBUTING.md's "no rule that says small fixes need PRs" guidance (fix is well under 200 lines, single tool).