### PR TITLE
feat(offline): Sprint 1 — CANVAS_MODE + gradebook CSV + download finder

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,13 @@ CANVAS_API_TOKEN=
 # Examples: https://byui.instructure.com  |  https://canvas.instructure.com
 CANVAS_BASE_URL=
 
+# Canvas mode — "online" (default) uses the Canvas API; "offline" works from
+# Canvas UI downloads (gradebook CSV / .imscc) for faculty without an API token.
+# online  requires CANVAS_API_TOKEN.  offline requires no token.
+# In offline mode, tools HARD-STOP if the needed download is missing from
+# ~/Downloads (they tell you exactly what to export). See docs/offline_readme.md.
+CANVAS_MODE=online
+
 # Optional: master template course and Canvas Blueprint course (for three-course architecture)
 # See README.md for details. Required only if using course_mirror.py or blueprint_sync.py.
 MASTER_COURSE_ID=

--- a/lib/agents/knowledge/imscc_format_knowledge.md
+++ b/lib/agents/knowledge/imscc_format_knowledge.md
@@ -252,12 +252,72 @@ import hashlib
 import uuid
 
 def generate_canvas_identifier(content_type: str, title: str) -> str:
-    """Generate Canvas-compatible identifier."""
+    """Generate Canvas-compatible identifier — ONLY for net-new content.
+
+    Roundtrip / date-adjust flows PRESERVE the original identifier read from the
+    source .imscc (see "Re-Import Behavior"). Regenerating an existing item's id
+    makes Canvas duplicate it instead of updating in place.
+    """
     # Use UUID5 (deterministic from namespace + name)
     namespace = uuid.UUID('00000000-0000-0000-0000-000000000000')
     identifier_uuid = uuid.uuid5(namespace, f"{content_type}:{title}")
     return "g" + identifier_uuid.hex
 ```
+
+---
+
+## Re-Import Behavior (Canvas Overwrite Semantics) — CRITICAL for offline_export.py
+
+**Finding (2026-07-12 research, verified against Canvas docs)**: When you re-import an
+`.imscc` into a course, Canvas does **not** duplicate content — it **matches by the
+original migration identifier and overwrites the matching item in place**. This applies to
+Modules, Pages, Assignments, Files, and Quizzes.
+
+### Implication: PRESERVE identifiers on roundtrip — do NOT regenerate them
+
+For the date-adjust roundtrip (export → edit → re-import to the **same** course), you MUST
+carry the **original** identifiers from the source `.imscc` through to the output
+unchanged. If `offline_export.py` mints **new** identifiers (e.g. via
+`generate_canvas_identifier()`), Canvas sees the content as brand-new and **duplicates** it
+instead of updating.
+
+- ✅ Existing content (came from the source export) → **reuse its original identifier verbatim**
+- ✅ Genuinely new content (created locally, never in Canvas) → generate a fresh `g` + 32 hex id
+- ❌ Never regenerate identifiers for content that already exists in Canvas
+
+> This corrects earlier guidance in this file: `generate_canvas_identifier()` is ONLY for
+> net-new content. The default offline workflow (import → adjust dates → export) preserves
+> every identifier it read.
+
+### ⚠️ Overwrite is DESTRUCTIVE
+
+Canvas warns that re-importing "can cause any changes made to the destination course,
+including submissions and grades, to be **lost permanently**." Same-course re-import is
+therefore only safe when:
+
+- The destination is an **empty / new** course (the semester-copy workflow — the safe default), OR
+- The course has **no student activity yet** (no submissions/grades).
+
+`offline_export.py` / `validate_imscc.py` must surface a **loud guard** before producing an
+`.imscc` aimed at a course that already has student work. Lead faculty toward the
+**new-course** copy path.
+
+### New Quizzes revert quirk
+
+Re-importing a **New Quizzes** assessment reverts it to the original — edits don't apply. To
+update a New Quiz you must duplicate it in Canvas, then import. Flag New Quizzes during
+validation so faculty aren't surprised.
+
+### Related gradebook finding (not .imscc, but shapes the offline flow)
+
+Canvas gradebook **CSV import does not carry submission comments** — scores only (open,
+unimplemented feature request). Offline comment delivery therefore can't ride the CSV;
+it needs the API (`grader_push_comments.py`) or manual SpeedGrader paste.
+
+**Sources**:
+- Overwrite/identifier-match: <https://classhelp.screenstepslive.com/a/1859694-avoiding-overwriting-course-content-when-using-the-import-tool>
+- Destructive re-import: <https://community.canvaslms.com/t5/Idea-Conversations/Import-Course-Content-should-always-be-non-destructive/idi-p/368391>
+- CSV comments unsupported: <https://community.instructure.com/en/discussion/510567/including-comments-when-importing-a-grades-csv-file>
 
 ---
 
@@ -529,7 +589,7 @@ When building `offline_import.py` and `offline_export.py`:
 - [ ] Convert `.imscc` structure → `.canvas/` JSON structure
 - [ ] Build `adjust_dates.py` tool (operate on `.canvas/` JSON)
 - [ ] Convert `.canvas/` JSON → `.imscc` structure
-- [ ] Generate valid Canvas identifiers (`g` + 32 hex)
+- [ ] Preserve original identifiers on roundtrip; generate `g` + 32 hex ONLY for net-new content
 - [ ] Preserve timezone info in all date operations
 - [ ] Validate date constraints before repacking
 - [ ] Create valid ZIP with all required files

--- a/lib/tests/fixtures/gradebook_sample.csv
+++ b/lib/tests/fixtures/gradebook_sample.csv
@@ -1,0 +1,5 @@
+Student,ID,SIS User ID,SIS Login ID,Root Account,Section,HW 1 (1001),Quiz 1 (1002),Participation (1003),Homework Current Score,Homework Unposted Current Score,Homework Final Score,Homework Unposted Final Score,Current Score,Unposted Current Score,Final Score,Unposted Final Score,Current Grade,Unposted Current Grade,Final Grade,Unposted Final Grade
+    Points Possible,,,,,,100,10,1,(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only),(read only)
+"Anon, Ada",2001,a2001,student2001@example.edu,example.edu,Section A2,95,9,1,95.00,95.00,95.00,95.00,94.00,94.00,94.00,94.00,A,A,A,A
+"Byte, Ben",2002,a2002,student2002@example.edu,example.edu,Section A2,,7,EX,70.00,70.00,70.00,70.00,70.00,70.00,70.00,70.00,C,C,C,C
+"Cole, Cid",2003,a2003,student2003@example.edu,example.edu,Section A2,80,,1,80.00,80.00,80.00,80.00,80.00,80.00,80.00,80.00,B,B,B,B

--- a/lib/tests/test_canvas_mode.py
+++ b/lib/tests/test_canvas_mode.py
@@ -1,0 +1,93 @@
+"""Tier 1 unit tests — offline-mode CANVAS_MODE flag helpers.
+
+Source: lib/tools/_canvas_mode.py (Sprint 1)
+  - get_canvas_mode          (default online; case/space insensitive; loud on typo)
+  - is_online_mode / is_offline_mode
+  - check_mode_requirements  (online requires CANVAS_API_TOKEN; offline does not)
+
+Pure logic, no Canvas access — env is injected, so these never touch the network
+and run regardless of sandbox creds.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from _canvas_mode import (  # noqa: E402
+    ONLINE,
+    OFFLINE,
+    get_canvas_mode,
+    is_online_mode,
+    is_offline_mode,
+    check_mode_requirements,
+)
+
+
+# --- get_canvas_mode -------------------------------------------------------
+
+def test_default_is_online_when_unset():
+    assert get_canvas_mode({}) == ONLINE
+
+
+def test_empty_string_is_online():
+    assert get_canvas_mode({"CANVAS_MODE": ""}) == ONLINE
+
+
+def test_explicit_offline():
+    assert get_canvas_mode({"CANVAS_MODE": "offline"}) == OFFLINE
+
+
+@pytest.mark.parametrize("raw", ["OFFLINE", " Offline ", "offline\n"])
+def test_case_and_whitespace_insensitive(raw):
+    assert get_canvas_mode({"CANVAS_MODE": raw}) == OFFLINE
+
+
+@pytest.mark.parametrize("bad", ["ofline", "local", "api", "true", "0"])
+def test_invalid_mode_raises(bad):
+    with pytest.raises(ValueError):
+        get_canvas_mode({"CANVAS_MODE": bad})
+
+
+# --- is_online_mode / is_offline_mode --------------------------------------
+
+def test_predicates_online():
+    env = {"CANVAS_MODE": "online"}
+    assert is_online_mode(env) is True
+    assert is_offline_mode(env) is False
+
+
+def test_predicates_offline():
+    env = {"CANVAS_MODE": "offline"}
+    assert is_offline_mode(env) is True
+    assert is_online_mode(env) is False
+
+
+# --- check_mode_requirements ----------------------------------------------
+
+def test_online_without_token_raises():
+    with pytest.raises(ValueError, match="CANVAS_API_TOKEN"):
+        check_mode_requirements({"CANVAS_MODE": "online"})
+
+
+def test_online_with_blank_token_raises():
+    with pytest.raises(ValueError, match="CANVAS_API_TOKEN"):
+        check_mode_requirements({"CANVAS_MODE": "online", "CANVAS_API_TOKEN": "   "})
+
+
+def test_online_with_token_ok():
+    env = {"CANVAS_MODE": "online", "CANVAS_API_TOKEN": "abc123"}
+    assert check_mode_requirements(env) == ONLINE
+
+
+def test_offline_needs_no_token():
+    assert check_mode_requirements({"CANVAS_MODE": "offline"}) == OFFLINE
+
+
+def test_default_unset_treated_as_online_and_needs_token():
+    # No CANVAS_MODE at all → online → token still required.
+    with pytest.raises(ValueError, match="CANVAS_API_TOKEN"):
+        check_mode_requirements({})

--- a/lib/tests/test_cb_init.py
+++ b/lib/tests/test_cb_init.py
@@ -199,9 +199,16 @@ def test_check_mode_against_tmp_repo(tmp_path):
     )
     out = result.stdout + result.stderr
 
-    # All 13 step labels must appear (catches the dispatch-wiring class of bugs)
-    for i in range(1, 14):
-        assert f"Step {i}/13:" in out, (
+    # Every step label must appear (catches the dispatch-wiring class of bugs).
+    # Derive the total from the output rather than hardcoding it, so adding a
+    # cb-init step never silently breaks this test again (it went 13→14 in
+    # v1.6.1 and this assertion wasn't updated).
+    import re
+    totals = set(re.findall(r"Step \d+/(\d+):", out))
+    assert len(totals) == 1, f"inconsistent step totals {totals} in output:\n{out}"
+    total = int(totals.pop())
+    for i in range(1, total + 1):
+        assert f"Step {i}/{total}:" in out, (
             f"step {i} missing from --check output. Full output:\n{out}"
         )
 

--- a/lib/tests/test_csv_utils.py
+++ b/lib/tests/test_csv_utils.py
@@ -1,0 +1,196 @@
+"""Tier 1 unit tests — Canvas gradebook CSV parsing/writing (Sprint 1).
+
+Source: lib/tools/_csv_utils.py
+Fixture: lib/tests/fixtures/gradebook_sample.csv  (synthetic, mirrors the real
+         120-col BYUI export structure at small scale — no PII).
+
+Also includes a gated INTEGRATION test that parses the real export sitting in
+~/Downloads (via _file_finder), skipped when it isn't present.
+"""
+import csv
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from _csv_utils import (  # noqa: E402
+    read_canvas_gradebook_csv,
+    write_canvas_gradebook_csv,
+    detect_csv_format,
+    is_points_possible_row,
+    IDENTITY_COLUMNS,
+)
+import _file_finder  # noqa: E402
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "gradebook_sample.csv"
+
+
+# --- detection -------------------------------------------------------------
+
+def test_detect_true_on_gradebook():
+    assert detect_csv_format(FIXTURE) is True
+
+
+def test_detect_false_on_random_csv(tmp_path):
+    p = tmp_path / "notes.csv"
+    p.write_text("a,b,c\n1,2,3\n", encoding="utf-8")
+    assert detect_csv_format(p) is False
+
+
+def test_detect_false_on_missing(tmp_path):
+    assert detect_csv_format(tmp_path / "nope.csv") is False
+
+
+def test_is_points_possible_row_handles_leading_spaces():
+    assert is_points_possible_row(["    Points Possible", "", ""]) is True
+    assert is_points_possible_row(["Anon, Ada", "2001"]) is False
+
+
+# --- parsing ---------------------------------------------------------------
+
+def test_reads_identity_and_points_possible():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    assert gb.identity_columns == IDENTITY_COLUMNS
+    assert gb.points_possible_row is not None
+    assert gb.points_possible_row[0].strip() == "Points Possible"
+
+
+def test_extracts_assignment_columns_only():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    ids = {a.assignment_id for a in gb.assignments}
+    assert ids == {"1001", "1002", "1003"}
+    hw = gb.assignment_by_id("1001")
+    assert hw.name == "HW 1"
+    assert hw.points_possible == "100"
+
+
+def test_readonly_columns_classified():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    # group-total + 8 summary columns are read-only (not assignments)
+    ro_headers = {gb.header[i] for i in gb.readonly_indices}
+    assert "Current Score" in ro_headers
+    assert "Final Grade" in ro_headers
+    assert "Homework Current Score" in ro_headers
+    # no assignment column leaked into read-only
+    assert not any(h.endswith("(1001)") for h in ro_headers)
+
+
+def test_student_rows_and_identity_access():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    assert len(gb.students) == 3
+    ada = gb.students[0]
+    assert ada.student == "Anon, Ada"      # comma preserved through CSV quoting
+    assert ada.canvas_id == "2001"
+    assert ada.section == "Section A2"
+
+
+def test_get_grade_number_blank_and_excused():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    ada, ben, cid = gb.students
+    assert ada.get_grade("1001") == "95"
+    assert ben.get_grade("1001") == ""      # missing submission
+    assert ben.get_grade("1003") == "EX"    # excused
+    assert cid.get_grade("1002") == ""
+
+
+# --- writing / round-trip --------------------------------------------------
+
+def test_set_grade_updates_only_target_cell():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    ben = gb.students[1]
+    before = list(ben.raw)
+    ben.set_grade("1001", "88")
+    assert ben.get_grade("1001") == "88"
+    # every other cell untouched
+    changed = [i for i, (a, b) in enumerate(zip(before, ben.raw)) if a != b]
+    assert changed == [gb.assignment_by_id("1001").index]
+
+
+def test_set_grade_rejects_unknown_assignment():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    with pytest.raises(KeyError):
+        gb.students[0].set_grade("9999", "50")
+
+
+def test_roundtrip_write_read_is_stable(tmp_path):
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    out = tmp_path / "out.csv"
+    write_canvas_gradebook_csv(gb, out)
+    # raw cell grid identical after a read→write→read cycle
+    gb2 = read_canvas_gradebook_csv(out)
+    assert gb.to_rows() == gb2.to_rows()
+    # and byte-identical rows to the original fixture
+    orig = list(csv.reader(FIXTURE.open(newline="", encoding="utf-8-sig")))
+    assert gb.to_rows() == orig
+
+
+def test_edit_persists_through_write(tmp_path):
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    gb.students[0].set_grade("1002", "10")
+    out = tmp_path / "edited.csv"
+    write_canvas_gradebook_csv(gb, out)
+    reloaded = read_canvas_gradebook_csv(out)
+    assert reloaded.students[0].get_grade("1002") == "10"
+
+
+def test_read_rejects_non_gradebook(tmp_path):
+    bad = tmp_path / "bad.csv"
+    bad.write_text("foo,bar\n1,2\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="does not look like a Canvas gradebook"):
+        read_canvas_gradebook_csv(bad)
+
+
+# --- adaptability: different identity layout + size (synthetic) ------------
+
+def test_adapts_to_different_identity_layout_and_size(tmp_path):
+    # 7 identity cols (incl. 'Integration ID'), 2 assignments, no group-totals,
+    # 4 students — a shape unlike the fixture. Identity is DERIVED, not hardcoded.
+    header = [
+        "Student", "ID", "SIS User ID", "SIS Login ID", "Integration ID",
+        "Root Account", "Section",
+        "Essay (500)", "Final Exam (501)",
+        "Current Score", "Final Score",
+    ]
+    pp = ["    Points Possible", "", "", "", "", "", "", "50", "100",
+          "(read only)", "(read only)"]
+    data = [
+        [f"S{n}, T", str(9000 + n), f"i{n}", f"s{n}@e.edu", f"int{n}", "e.edu",
+         "Section 1", str(40 + n), str(90 + n), "x", "x"]
+        for n in range(4)
+    ]
+    p = tmp_path / "other.csv"
+    with p.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        w.writerow(header); w.writerow(pp)
+        for r in data:
+            w.writerow(r)
+
+    gb = read_canvas_gradebook_csv(p)
+    assert gb.identity_columns == header[:7]          # includes Integration ID
+    assert "Integration ID" in gb.identity_columns
+    assert {a.assignment_id for a in gb.assignments} == {"500", "501"}
+    assert gb.assignment_by_id("501").name == "Final Exam"
+    assert len(gb.students) == 4
+    assert gb.students[0].get_grade("500") == "40"
+
+
+# --- integration: ALL real exports in ~/Downloads (gated, cross-course) -----
+
+def test_parses_all_real_exports_if_present():
+    reals = _file_finder.list_gradebook_csvs(name_hint="Grades")
+    if not reals:
+        pytest.skip("no real gradebook CSV in ~/Downloads — integration skipped")
+    for real in reals:  # e.g. DS 250 (120 cols) AND DS 460 (78 cols)
+        gb = read_canvas_gradebook_csv(real)
+        assert "Student" in gb.identity_columns and "ID" in gb.identity_columns
+        assert gb.points_possible_row is not None
+        assert len(gb.assignments) > 0
+        assert len(gb.students) > 0
+        assert all(a.assignment_id.isdigit() for a in gb.assignments)
+        # assignment and read-only columns must never overlap
+        assign_idx = {a.index for a in gb.assignments}
+        assert assign_idx.isdisjoint(gb.readonly_indices)

--- a/lib/tests/test_file_finder.py
+++ b/lib/tests/test_file_finder.py
@@ -1,0 +1,131 @@
+"""Tier 1 unit tests — Canvas download locator (Sprint 1).
+
+Source: lib/tools/_file_finder.py
+Uses a tmp Downloads dir with controlled mtimes; asserts newest-first selection,
+hint filtering, and that the globs match REAL observed export filenames.
+"""
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+import _file_finder  # noqa: E402
+
+
+def _touch(path: Path, mtime: float):
+    path.write_text("x", encoding="utf-8")
+    os.utime(path, (mtime, mtime))
+
+
+# --- gradebook CSV ---------------------------------------------------------
+
+def test_matches_real_gradebook_filename(tmp_path):
+    # exact real-world name observed from a BYUI export
+    _touch(tmp_path / "2026-07-12T1053_Grades-DS_250.csv", 1000)
+    found = _file_finder.find_latest_gradebook_csv(downloads_dir=tmp_path)
+    assert found is not None and found.name == "2026-07-12T1053_Grades-DS_250.csv"
+
+
+def test_ignores_unrelated_csv(tmp_path):
+    _touch(tmp_path / "budget.csv", 1000)
+    assert _file_finder.find_latest_gradebook_csv(downloads_dir=tmp_path) is None
+
+
+def test_returns_newest_gradebook(tmp_path):
+    _touch(tmp_path / "2026-01-01T0900_Grades-DS_250.csv", 1000)
+    _touch(tmp_path / "2026-07-12T1053_Grades-DS_250.csv", 2000)  # newer
+    found = _file_finder.find_latest_gradebook_csv(downloads_dir=tmp_path)
+    assert found.name == "2026-07-12T1053_Grades-DS_250.csv"
+
+
+def test_name_hint_filters_by_course(tmp_path):
+    _touch(tmp_path / "2026-07-12T1000_Grades-DS_250.csv", 1000)
+    _touch(tmp_path / "2026-07-12T1100_Grades-CS_142.csv", 2000)  # newer, other course
+    # without hint → newest (CS 142); with hint → DS 250
+    assert _file_finder.find_latest_gradebook_csv(downloads_dir=tmp_path).name.endswith("CS_142.csv")
+    ds = _file_finder.find_latest_gradebook_csv(downloads_dir=tmp_path, name_hint="DS_250")
+    assert ds.name.endswith("DS_250.csv")
+
+
+def test_list_gradebook_csvs_newest_first(tmp_path):
+    _touch(tmp_path / "2026-01-01T0900_Grades-A.csv", 1000)
+    _touch(tmp_path / "2026-07-01T0900_Grades-B.csv", 3000)
+    _touch(tmp_path / "2026-03-01T0900_Grades-C.csv", 2000)
+    names = [p.name for p in _file_finder.list_gradebook_csvs(downloads_dir=tmp_path)]
+    assert names == [
+        "2026-07-01T0900_Grades-B.csv",
+        "2026-03-01T0900_Grades-C.csv",
+        "2026-01-01T0900_Grades-A.csv",
+    ]
+
+
+# --- .imscc ----------------------------------------------------------------
+
+def test_matches_real_imscc_hashname(tmp_path):
+    _touch(tmp_path / "189dea1f71e04e7a9c2396b4fe4d16a6.imscc", 1000)
+    found = _file_finder.find_latest_imscc(downloads_dir=tmp_path)
+    assert found is not None and found.suffix == ".imscc"
+
+
+def test_newest_imscc(tmp_path):
+    _touch(tmp_path / "old.imscc", 1000)
+    _touch(tmp_path / "new.imscc", 2000)
+    assert _file_finder.find_latest_imscc(downloads_dir=tmp_path).name == "new.imscc"
+
+
+# --- submissions ZIP -------------------------------------------------------
+
+def test_matches_submissions_zip_variants(tmp_path):
+    _touch(tmp_path / "submissions.zip", 1000)
+    _touch(tmp_path / "assignment_123_submissions.zip", 2000)
+    found = _file_finder.find_latest_submissions_zip(downloads_dir=tmp_path)
+    assert found.name == "assignment_123_submissions.zip"
+    assert len(_file_finder.list_submissions_zips(downloads_dir=tmp_path)) == 2
+
+
+# --- edge cases ------------------------------------------------------------
+
+def test_empty_dir_returns_none(tmp_path):
+    assert _file_finder.find_latest_gradebook_csv(downloads_dir=tmp_path) is None
+    assert _file_finder.find_latest_imscc(downloads_dir=tmp_path) is None
+    assert _file_finder.find_latest_submissions_zip(downloads_dir=tmp_path) is None
+
+
+def test_nonexistent_dir_returns_empty(tmp_path):
+    missing = tmp_path / "does_not_exist"
+    assert _file_finder.list_gradebook_csvs(downloads_dir=missing) == []
+    assert _file_finder.find_latest_imscc(downloads_dir=missing) is None
+
+
+# --- hard-stop require_* (offline runtime blocking) ------------------------
+
+def test_require_returns_path_when_present(tmp_path):
+    _touch(tmp_path / "2026-07-12T1053_Grades-DS_250.csv", 1000)
+    got = _file_finder.require_gradebook_csv(downloads_dir=tmp_path)
+    assert got.name.endswith("Grades-DS_250.csv")
+
+
+def test_require_gradebook_raises_with_marker_and_guidance(tmp_path):
+    with pytest.raises(_file_finder.OfflineDownloadMissing) as exc:
+        _file_finder.require_gradebook_csv(downloads_dir=tmp_path)
+    msg = str(exc.value)
+    assert _file_finder.MISSING_MARKER in msg          # agent-legible marker
+    assert "Grades → Export" in msg                     # actionable UI step
+    assert "BLOCKED" in msg                             # signals hard stop
+
+
+def test_require_imscc_and_submissions_raise_when_absent(tmp_path):
+    with pytest.raises(_file_finder.OfflineDownloadMissing):
+        _file_finder.require_imscc(downloads_dir=tmp_path)
+    with pytest.raises(_file_finder.OfflineDownloadMissing):
+        _file_finder.require_submissions_zip(downloads_dir=tmp_path)
+
+
+def test_offline_download_missing_is_filenotfound():
+    # callers may catch either type
+    assert issubclass(_file_finder.OfflineDownloadMissing, FileNotFoundError)

--- a/lib/tools/_canvas_mode.py
+++ b/lib/tools/_canvas_mode.py
@@ -1,0 +1,80 @@
+"""
+Canvas mode helper — single source of truth for online vs offline operation.
+
+Part of offline mode (Sprint 1). Faculty who cannot obtain a Canvas API token
+(IT policy) run tools in "offline" mode: data comes from Canvas UI
+download/upload (gradebook CSV, .imscc) instead of the REST API. Every
+mode-aware tool calls get_canvas_mode() / check_mode_requirements() at startup
+and branches on the result.
+
+Design decisions (see docs/offline_mode.md):
+  - EXPLICIT flag, not auto-detection (commit 0b39cbb). CANVAS_MODE in .env
+    controls it; default "online" preserves current behavior for every existing
+    tool that never sets it.
+  - The token variable is CANVAS_API_TOKEN — matching the rest of the toolbox
+    and lib/tests/conftest.py. (The early design docs said "CANVAS_TOKEN"; that
+    was never the real variable name.)
+  - Unknown CANVAS_MODE values fail loud (ValueError) rather than silently
+    falling back to online — a typo shouldn't quietly hit the API.
+
+USAGE
+    from _canvas_mode import check_mode_requirements, is_offline_mode
+
+    def main():
+        mode = check_mode_requirements()   # raises if online without a token
+        if is_offline_mode():
+            ...  # read from local files
+        else:
+            ...  # call the Canvas API
+"""
+import os
+
+ONLINE = "online"
+OFFLINE = "offline"
+_VALID_MODES = (ONLINE, OFFLINE)
+
+
+def get_canvas_mode(env=None) -> str:
+    """Return the configured Canvas mode: "online" (default) or "offline".
+
+    Reads CANVAS_MODE from `env` (defaults to os.environ), case- and
+    whitespace-insensitive. An unset/empty value means "online" so existing
+    tools keep working unchanged. Any other value raises ValueError.
+    """
+    env = os.environ if env is None else env
+    raw = (env.get("CANVAS_MODE") or ONLINE).strip().lower()
+    if raw not in _VALID_MODES:
+        raise ValueError(
+            f"CANVAS_MODE={raw!r} is invalid; expected one of {_VALID_MODES}. "
+            f"Leave it unset for online mode."
+        )
+    return raw
+
+
+def is_online_mode(env=None) -> bool:
+    """True when operating against the Canvas API (the default)."""
+    return get_canvas_mode(env) == ONLINE
+
+
+def is_offline_mode(env=None) -> bool:
+    """True when operating from Canvas UI downloads (no API token)."""
+    return get_canvas_mode(env) == OFFLINE
+
+
+def check_mode_requirements(env=None) -> str:
+    """Validate that the environment satisfies the selected mode; return it.
+
+    online  → CANVAS_API_TOKEN must be present (API calls 401 without it).
+    offline → no token required (data comes from local files).
+
+    Raises ValueError with actionable guidance when online mode lacks a token.
+    """
+    env = os.environ if env is None else env
+    mode = get_canvas_mode(env)
+    if mode == ONLINE and not (env.get("CANVAS_API_TOKEN") or "").strip():
+        raise ValueError(
+            "CANVAS_MODE=online requires CANVAS_API_TOKEN. "
+            "Set the token in .env, or switch to CANVAS_MODE=offline to work "
+            "from Canvas UI downloads (gradebook CSV / .imscc)."
+        )
+    return mode

--- a/lib/tools/_csv_utils.py
+++ b/lib/tools/_csv_utils.py
@@ -1,0 +1,248 @@
+"""
+Canvas gradebook CSV parsing/writing for offline mode (Sprint 1).
+
+Ground truth: a real BYU-Idaho export (2026-07, DS 250) — 120 columns for 65
+assignments, because group weighting adds per-group total columns. Layout:
+
+  row 0        header
+  row 1        Points Possible — Student cell is '    Points Possible' (leading
+               spaces); read-only columns carry the literal '(read only)'
+  rows 2..n    one per student
+
+Column classes (left → right):
+  identity (6, fixed order): Student, ID, SIS User ID, SIS Login ID,
+                             Root Account, Section
+  assignment  : header ends with ' (<assignment_id>)'  → gradeable
+  read-only   : everything else (group-total columns like
+                'Checkpoints Current Score', and the trailing 8 summary columns
+                'Current Score' … 'Unposted Final Grade'). Canvas RECOMPUTES
+                these on import — never write them back.
+
+Canvas gradebook Import (Grades → Import) reads identity + assignment columns
+only. It ignores read-only columns and does NOT accept submission comments
+(scores only — see docs/offline_mode.md and imscc_format_knowledge.md).
+"""
+import csv
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Fixed identity columns, in the exact order Canvas emits them.
+IDENTITY_COLUMNS = [
+    "Student", "ID", "SIS User ID", "SIS Login ID", "Root Account", "Section",
+]
+# Some older/instance exports omit "Root Account"; accept a 5-col identity block too.
+IDENTITY_COLUMNS_LEGACY = [
+    "Student", "ID", "SIS User ID", "SIS Login ID", "Section",
+]
+
+_ASSIGNMENT_RE = re.compile(r"^(?P<name>.*?)\s*\((?P<id>\d+)\)\s*$")
+_READ_ONLY_MARKER = "(read only)"
+
+
+@dataclass
+class AssignmentColumn:
+    """A gradeable assignment column: header 'Name (assignment_id)'."""
+    index: int
+    name: str
+    assignment_id: str
+    points_possible: str  # kept as the raw CSV string (may be '' or e.g. '100')
+
+
+@dataclass
+class Gradebook:
+    """Parsed Canvas gradebook CSV.
+
+    `students` are the data rows (identity + raw cells). Read-only/group-total
+    columns are preserved verbatim in each row's `raw` and re-emitted unchanged
+    by write_canvas_gradebook_csv().
+    """
+    path: Optional[Path]
+    header: list[str]
+    points_possible_row: Optional[list[str]]
+    assignments: list[AssignmentColumn]
+    identity_columns: list[str]
+    readonly_indices: set[int]
+    students: list["StudentRow"] = field(default_factory=list)
+
+    def assignment_by_id(self, assignment_id: str) -> Optional[AssignmentColumn]:
+        for a in self.assignments:
+            if a.assignment_id == str(assignment_id):
+                return a
+        return None
+
+    def to_rows(self) -> list[list[str]]:
+        rows = [list(self.header)]
+        if self.points_possible_row is not None:
+            rows.append(list(self.points_possible_row))
+        rows.extend(s.raw for s in self.students)
+        return rows
+
+
+@dataclass
+class StudentRow:
+    """One student's row. Identity fields are convenience views onto `raw`;
+    `raw` is the full, column-aligned source of truth used for writing."""
+    raw: list[str]
+    _gradebook: "Gradebook"
+
+    def _idx(self, colname: str) -> int:
+        return self._gradebook.header.index(colname)
+
+    @property
+    def student(self) -> str:
+        return self.raw[0] if self.raw else ""
+
+    @property
+    def canvas_id(self) -> str:
+        i = self._idx("ID")
+        return self.raw[i] if i < len(self.raw) else ""
+
+    @property
+    def section(self) -> str:
+        i = self._idx("Section")
+        return self.raw[i] if i < len(self.raw) else ""
+
+    def get_grade(self, assignment_id: str) -> Optional[str]:
+        a = self._gradebook.assignment_by_id(assignment_id)
+        if a is None or a.index >= len(self.raw):
+            return None
+        return self.raw[a.index]
+
+    def set_grade(self, assignment_id: str, value: str) -> None:
+        """Set the raw cell value for an assignment. Read-only columns are never
+        addressable here (only assignment columns have ids), so this can't
+        accidentally write a computed column."""
+        a = self._gradebook.assignment_by_id(assignment_id)
+        if a is None:
+            raise KeyError(f"No assignment column with id {assignment_id!r}")
+        # Pad the row if a short export truncated trailing empties.
+        while len(self.raw) <= a.index:
+            self.raw.append("")
+        self.raw[a.index] = value
+
+
+def is_points_possible_row(row: list[str]) -> bool:
+    """The Points Possible row's Student cell is 'Points Possible' (Canvas emits
+    it with leading spaces)."""
+    return bool(row) and row[0].strip() == "Points Possible"
+
+
+def _first_assignment_index(header: list[str]) -> Optional[int]:
+    """Index of the first assignment column ('Name (id)'), or None when the
+    gradebook has no assignments."""
+    for i, h in enumerate(header):
+        if _ASSIGNMENT_RE.match(h):
+            return i
+    return None
+
+
+def _identity_block(header: list[str]) -> list[str]:
+    """The leading metadata columns — everything before the first assignment
+    column. DERIVED from the data, not a hardcoded list, so it adapts to
+    instance variation (with/without 'Root Account', 'Integration ID', extra
+    'Override' columns, etc.). Falls back to known identity names only when a
+    gradebook has no assignment columns at all."""
+    fa = _first_assignment_index(header)
+    if fa is not None:
+        return header[:fa]
+    known = set(IDENTITY_COLUMNS) | set(IDENTITY_COLUMNS_LEGACY)
+    return [h for h in header if h in known]
+
+
+def _looks_like_gradebook(header: list[str]) -> bool:
+    """A Canvas gradebook always leads with at least 'Student' and 'ID'."""
+    block = _identity_block(header)
+    return "Student" in block and "ID" in block
+
+
+def detect_csv_format(path) -> bool:
+    """True if `path` looks like a Canvas gradebook export (leads with
+    Student/ID metadata columns). Cheap check for auto-detection / clear
+    errors; makes no assumption about column count or which assignments exist."""
+    try:
+        with open(path, newline="", encoding="utf-8-sig") as f:
+            header = next(csv.reader(f))
+    except (OSError, StopIteration):
+        return False
+    return _looks_like_gradebook(header)
+
+
+def read_canvas_gradebook_csv(path) -> Gradebook:
+    """Parse a Canvas gradebook CSV into a Gradebook.
+
+    Raises ValueError if the header doesn't match a Canvas gradebook layout —
+    fail loud rather than mis-parse (a wrong file would corrupt grades on
+    re-upload).
+    """
+    path = Path(path)
+    # utf-8-sig strips the BOM Canvas sometimes prepends.
+    with path.open(newline="", encoding="utf-8-sig") as f:
+        rows = list(csv.reader(f))
+    if not rows:
+        raise ValueError(f"{path} is empty — not a Canvas gradebook CSV")
+
+    header = rows[0]
+    if not _looks_like_gradebook(header):
+        raise ValueError(
+            f"{path} does not look like a Canvas gradebook export "
+            f"(no leading 'Student'/'ID' columns); got {header[:6]}. "
+            f"Export via Grades → Export → Export Entire Gradebook."
+        )
+    identity = _identity_block(header)
+
+    body = rows[1:]
+    pp_row = body[0] if body and is_points_possible_row(body[0]) else None
+    data_rows = body[1:] if pp_row is not None else body
+
+    # Classify columns and pull assignment metadata from the Points Possible row.
+    assignments: list[AssignmentColumn] = []
+    readonly: set[int] = set()
+    id_count = len(identity)
+    for i, h in enumerate(header):
+        if i < id_count:
+            continue
+        m = _ASSIGNMENT_RE.match(h)
+        if m:
+            pp = (
+                pp_row[i]
+                if pp_row is not None and i < len(pp_row) and pp_row[i] != _READ_ONLY_MARKER
+                else ""
+            )
+            assignments.append(
+                AssignmentColumn(
+                    index=i,
+                    name=m.group("name"),
+                    assignment_id=m.group("id"),
+                    points_possible=pp,
+                )
+            )
+        else:
+            readonly.add(i)
+
+    gb = Gradebook(
+        path=path,
+        header=header,
+        points_possible_row=pp_row,
+        assignments=assignments,
+        identity_columns=identity,
+        readonly_indices=readonly,
+    )
+    # Skip fully blank trailing rows (Canvas sometimes emits one).
+    gb.students = [
+        StudentRow(raw=r, _gradebook=gb)
+        for r in data_rows
+        if any(cell.strip() for cell in r)
+    ]
+    return gb
+
+
+def write_canvas_gradebook_csv(gradebook: Gradebook, path) -> Path:
+    """Write a Gradebook back to Canvas CSV format (QUOTE_MINIMAL, matching
+    Canvas). Read-only/group-total columns are emitted unchanged from `raw`."""
+    path = Path(path)
+    with path.open("w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)  # QUOTE_MINIMAL — quotes only fields needing it
+        w.writerows(gradebook.to_rows())
+    return path

--- a/lib/tools/_file_finder.py
+++ b/lib/tools/_file_finder.py
@@ -1,0 +1,141 @@
+"""
+Locate Canvas UI downloads for offline mode (Sprint 1).
+
+Real export filename conventions (observed, 2026-07):
+  gradebook CSV : '<ISO-ish timestamp>_Grades-<CourseCode>.csv'
+                  e.g. '2026-07-12T1053_Grades-DS_250.csv'   (NO numeric course id)
+  course export : '<32 hex>.imscc'
+                  e.g. '189dea1f71e04e7a9c2396b4fe4d16a6.imscc' (NO course name)
+  submissions   : 'submissions.zip' / '*ubmissions*.zip'
+                  (pattern; not yet verified against a real sample — Sprint 3)
+
+Neither the gradebook CSV nor the .imscc encodes the numeric course id, so these
+finders return the NEWEST match by modification time and expose list_* helpers
+so the calling tool can show the operator exactly which file it picked before a
+destructive re-upload (gradebook import is irreversible via the UI). An optional
+`name_hint` narrows by case-insensitive substring, e.g. a course code 'DS_250'.
+"""
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_DOWNLOADS = Path.home() / "Downloads"
+
+GRADEBOOK_GLOB = "*_Grades-*.csv"
+IMSCC_GLOB = "*.imscc"
+SUBMISSIONS_GLOB = "*ubmissions*.zip"  # matches submissions.zip and *_submissions.zip
+
+
+def _sorted_by_mtime(paths) -> list[Path]:
+    """Newest first. Missing files are skipped defensively."""
+    existing = [p for p in paths if p.is_file()]
+    return sorted(existing, key=lambda p: p.stat().st_mtime, reverse=True)
+
+
+def _list(glob_pat: str, downloads_dir, name_hint: Optional[str]) -> list[Path]:
+    d = Path(downloads_dir) if downloads_dir else DEFAULT_DOWNLOADS
+    if not d.is_dir():
+        return []
+    matches = _sorted_by_mtime(d.glob(glob_pat))
+    if name_hint:
+        h = name_hint.lower()
+        matches = [p for p in matches if h in p.name.lower()]
+    return matches
+
+
+# --- gradebook CSV ---------------------------------------------------------
+
+def list_gradebook_csvs(downloads_dir=None, name_hint=None) -> list[Path]:
+    return _list(GRADEBOOK_GLOB, downloads_dir, name_hint)
+
+
+def find_latest_gradebook_csv(downloads_dir=None, name_hint=None) -> Optional[Path]:
+    matches = list_gradebook_csvs(downloads_dir, name_hint)
+    return matches[0] if matches else None
+
+
+# --- .imscc course export --------------------------------------------------
+
+def list_imscc(downloads_dir=None, name_hint=None) -> list[Path]:
+    return _list(IMSCC_GLOB, downloads_dir, name_hint)
+
+
+def find_latest_imscc(downloads_dir=None, name_hint=None) -> Optional[Path]:
+    matches = list_imscc(downloads_dir, name_hint)
+    return matches[0] if matches else None
+
+
+# --- submissions ZIP -------------------------------------------------------
+
+def list_submissions_zips(downloads_dir=None, name_hint=None) -> list[Path]:
+    return _list(SUBMISSIONS_GLOB, downloads_dir, name_hint)
+
+
+def find_latest_submissions_zip(downloads_dir=None, name_hint=None) -> Optional[Path]:
+    matches = list_submissions_zips(downloads_dir, name_hint)
+    return matches[0] if matches else None
+
+
+# --- hard-stop requires (offline runtime) ----------------------------------
+#
+# In offline mode a missing download is a HARD STOP, not a soft None: grading /
+# content operations cannot proceed until the operator downloads the file. The
+# find_* helpers stay soft (return None) for probing; the require_* helpers
+# below raise with an actionable, machine-legible message so the driving agent
+# knows to PAUSE and prompt for the download rather than continue on empty data.
+
+# Stable prefix so an agent can detect this condition programmatically in stderr.
+MISSING_MARKER = "OFFLINE_DOWNLOAD_MISSING"
+
+# kind -> (human label, glob, Canvas UI path to produce it)
+_DOWNLOAD_SPECS = {
+    "gradebook": (
+        "Canvas gradebook CSV",
+        GRADEBOOK_GLOB,
+        "Grades → Export → Export Entire Gradebook",
+    ),
+    "imscc": (
+        "Canvas course export (.imscc)",
+        IMSCC_GLOB,
+        "Settings → Export Course Content → Common Cartridge (.imscc)",
+    ),
+    "submissions": (
+        "Canvas submissions ZIP",
+        SUBMISSIONS_GLOB,
+        "Assignment → Download Submissions",
+    ),
+}
+
+
+class OfflineDownloadMissing(FileNotFoundError):
+    """A required Canvas UI download is absent in offline mode.
+
+    Hard stop: the caller must halt and prompt the operator to download the
+    file — no grading/content work can proceed on missing data.
+    """
+
+
+def _require(kind, finder, downloads_dir, name_hint) -> Path:
+    found = finder(downloads_dir, name_hint)
+    if found is not None:
+        return found
+    label, glob_pat, ui_path = _DOWNLOAD_SPECS[kind]
+    d = Path(downloads_dir) if downloads_dir else DEFAULT_DOWNLOADS
+    hint = f" matching {name_hint!r}" if name_hint else ""
+    raise OfflineDownloadMissing(
+        f"{MISSING_MARKER}: {label} not found in {d} (pattern '{glob_pat}'{hint}).\n"
+        f"  → Download from Canvas: {ui_path}\n"
+        f"  → Save it to {d}, then re-run.\n"
+        f"  Offline mode is BLOCKED until this file is present."
+    )
+
+
+def require_gradebook_csv(downloads_dir=None, name_hint=None) -> Path:
+    return _require("gradebook", find_latest_gradebook_csv, downloads_dir, name_hint)
+
+
+def require_imscc(downloads_dir=None, name_hint=None) -> Path:
+    return _require("imscc", find_latest_imscc, downloads_dir, name_hint)
+
+
+def require_submissions_zip(downloads_dir=None, name_hint=None) -> Path:
+    return _require("submissions", find_latest_submissions_zip, downloads_dir, name_hint)


### PR DESCRIPTION
## Sprint 1 of the offline-mode plan — foundational infrastructure

Lets faculty **without a Canvas API token** work from Canvas UI downloads. All three helpers are `lib/tools/`-flat, `_`-prefixed (matching `_env_loader.py`), **not** the docs' `lib/utils/`.

### What's here
- **`_canvas_mode.py`** — `CANVAS_MODE` flag (`online` default), `CANVAS_API_TOKEN` validation, loud-on-typo. Explicit flag, not auto-detection.
- **`_csv_utils.py`** — parse/write Canvas gradebook CSV. Identity columns are **derived from the header** (everything before the first `Name (id)` column); assignment ids/names/points read dynamically. **No hardcoded ids or sizes.**
- **`_file_finder.py`** — locate `~/Downloads` exports by **real** filename conventions (`*_Grades-*.csv`, `*.imscc`). `require_*` helpers **hard-stop in offline mode** with an agent-legible `OFFLINE_DOWNLOAD_MISSING` marker + Canvas UI guidance when a file is missing (grading blocked until it is downloaded).

### Verified against real data (Genchi Genbutsu)
Same code parses two different real exports:

| Course | Cols | Assignments | Read-only | Students |
|---|---|---|---|---|
| DS 250 | 120 | 62 | 52 | 33 |
| DS 460 | 78 | 36 | 36 | 31 |

### Tests
**48 passing** — unit tests + a synthetic adaptability case (different identity layout, incl. `Integration ID`) + a gated cross-course integration test that parses every real export in `~/Downloads`.

### Corrections to the plan docs (applied)
- Env var is `CANVAS_API_TOKEN`, not the docs' `CANVAS_TOKEN`.
- Helpers in `lib/tools/`, not `lib/utils/`.
- `imscc_format_knowledge.md` updated with re-import findings: Canvas overwrites by identifier → **preserve** original ids (don't regenerate); destructive re-import guard; New Quizzes revert quirk; gradebook-CSV comment limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
