### PR TITLE
feat(offline): Sprint 2 — gradebook de-identify / re-identify

### DIFF
--- a/lib/tests/test_csv_utils.py
+++ b/lib/tests/test_csv_utils.py
@@ -137,6 +137,18 @@ def test_edit_persists_through_write(tmp_path):
     assert reloaded.students[0].get_grade("1002") == "10"
 
 
+def test_writer_uses_lf_and_is_idempotent(tmp_path):
+    # Canvas exports LF; csv default is CRLF. Writer must emit LF so an
+    # unedited round-trip is byte-clean, and be stable across re-writes.
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    a = tmp_path / "a.csv"
+    write_canvas_gradebook_csv(gb, a)
+    assert b"\r\n" not in a.read_bytes()
+    b = tmp_path / "b.csv"
+    write_canvas_gradebook_csv(read_canvas_gradebook_csv(a), b)
+    assert a.read_bytes() == b.read_bytes()
+
+
 def test_read_rejects_non_gradebook(tmp_path):
     bad = tmp_path / "bad.csv"
     bad.write_text("foo,bar\n1,2\n", encoding="utf-8")

--- a/lib/tests/test_grader_gradebook_deid.py
+++ b/lib/tests/test_grader_gradebook_deid.py
@@ -1,0 +1,161 @@
+"""Tier 1 unit tests — gradebook de-identify / re-identify (Sprint 2).
+
+Sources:
+  lib/tools/grader_deidentify_gradebook.py  (build_reid_map, apply_deidentification)
+  lib/tools/grader_reidentify_gradebook.py  (reidentify)
+
+Verifies: codes reuse the toolbox-wide deid_code_for; PII is removed; re-ID is a
+deterministic code lookup that exactly restores identity; scores edited while
+de-identified survive re-ID; and a full CLI round-trip. Gated integration
+round-trips the real DS 250 / DS 460 exports in ~/Downloads.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from _csv_utils import read_canvas_gradebook_csv, write_canvas_gradebook_csv  # noqa: E402
+from build_deid_master import deid_code_for  # noqa: E402
+from grader_deidentify_gradebook import build_reid_map, apply_deidentification  # noqa: E402
+from grader_reidentify_gradebook import reidentify  # noqa: E402
+import _file_finder  # noqa: E402
+
+FIXTURE = Path(__file__).resolve().parent / "fixtures" / "gradebook_sample.csv"
+DEID_TOOL = _TOOLS_DIR / "grader_deidentify_gradebook.py"
+REID_TOOL = _TOOLS_DIR / "grader_reidentify_gradebook.py"
+
+
+def _deidentified():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    by_code = build_reid_map(gb, "S-", 6)
+    apply_deidentification(gb, by_code, "S-", 6)
+    return gb, by_code
+
+
+# --- de-identification -----------------------------------------------------
+
+def test_codes_reuse_toolbox_deid_code_for():
+    gb = read_canvas_gradebook_csv(FIXTURE)
+    by_code = build_reid_map(gb, "S-", 6)
+    assert deid_code_for(2001) in by_code
+    assert by_code[deid_code_for(2001)]["student"] == "Anon, Ada"
+    assert by_code[deid_code_for(2002)]["sis_login_id"] == "student2002@example.edu"
+
+
+def test_deid_replaces_name_and_blanks_pii():
+    gb, _ = _deidentified()
+    h = gb.header
+    for s in gb.students:
+        assert s.raw[h.index("Student")].startswith("S-")
+        assert s.raw[h.index("ID")] == ""
+        assert s.raw[h.index("SIS User ID")] == ""
+        assert s.raw[h.index("SIS Login ID")] == ""
+        assert s.raw[h.index("Section")] == "Section A2"  # not PII — kept
+
+
+def test_deid_preserves_grades():
+    gb, _ = _deidentified()
+    # grades untouched by de-identification
+    assert gb.students[0].get_grade("1001") == "95"
+    assert gb.students[1].get_grade("1003") == "EX"
+
+
+def test_deid_output_file_has_no_pii(tmp_path):
+    gb, _ = _deidentified()
+    out = tmp_path / "deid.csv"
+    write_canvas_gradebook_csv(gb, out)
+    text = out.read_text(encoding="utf-8")
+    assert "Anon, Ada" not in text
+    assert "student2001@example.edu" not in text
+    assert "S-" in text
+
+
+# --- re-identification -----------------------------------------------------
+
+def test_deid_then_reid_restores_identity_exactly():
+    original = [list(s.raw) for s in read_canvas_gradebook_csv(FIXTURE).students]
+    gb, by_code = _deidentified()
+    restored, unmatched = reidentify(gb, by_code)
+    assert not unmatched
+    assert restored == len(original)
+    for s, orig in zip(gb.students, original):
+        assert s.raw == orig  # byte-for-byte identity + grade restoration
+
+
+def test_scores_edited_while_deidentified_survive_reid():
+    gb, by_code = _deidentified()
+    gb.students[1].set_grade("1001", "88")  # instructor edits against the code sheet
+    reidentify(gb, by_code)
+    assert gb.students[1].get_grade("1001") == "88"
+    assert gb.students[1].student == "Byte, Ben"  # identity restored
+
+
+def test_reid_reports_unmatched_codes():
+    gb, _ = _deidentified()
+    restored, unmatched = reidentify(gb, {})  # wrong/empty map
+    assert restored == 0
+    assert len(unmatched) == len(gb.students)
+
+
+# --- CLI round-trip --------------------------------------------------------
+
+def test_cli_roundtrip_and_no_names_printed(tmp_path):
+    deid, mp, final = tmp_path / "deid.csv", tmp_path / "map.json", tmp_path / "final.csv"
+    r1 = subprocess.run(
+        [sys.executable, str(DEID_TOOL), "--input", str(FIXTURE), "--out", str(deid), "--map", str(mp)],
+        capture_output=True, text=True,
+    )
+    assert r1.returncode == 0, r1.stderr
+    assert "Anon, Ada" not in r1.stdout        # FERPA: never prints a name
+    assert deid.exists() and mp.exists()
+
+    r2 = subprocess.run(
+        [sys.executable, str(REID_TOOL), "--input", str(deid), "--map", str(mp), "--out", str(final)],
+        capture_output=True, text=True,
+    )
+    assert r2.returncode == 0, r2.stderr
+    assert "Anon, Ada" not in r2.stdout
+    gb_final = read_canvas_gradebook_csv(final)
+    assert gb_final.students[0].student == "Anon, Ada"
+
+
+def test_cli_reid_aborts_on_wrong_map(tmp_path):
+    deid, mp, final = tmp_path / "deid.csv", tmp_path / "map.json", tmp_path / "final.csv"
+    subprocess.run(
+        [sys.executable, str(DEID_TOOL), "--input", str(FIXTURE), "--out", str(deid), "--map", str(mp)],
+        capture_output=True, text=True, check=True,
+    )
+    empty = tmp_path / "empty.json"
+    empty.write_text('{"by_code": {}}', encoding="utf-8")
+    r = subprocess.run(
+        [sys.executable, str(REID_TOOL), "--input", str(deid), "--map", str(empty), "--out", str(final)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 2
+    assert not final.exists()
+
+
+# --- integration: real exports (gated, cross-course) -----------------------
+
+def test_real_gradebooks_roundtrip_if_present():
+    reals = _file_finder.list_gradebook_csvs(name_hint="Grades")
+    if not reals:
+        pytest.skip("no real gradebook CSV in ~/Downloads — integration skipped")
+    for real in reals:
+        gb = read_canvas_gradebook_csv(real)
+        original = [list(s.raw) for s in gb.students]
+        by_code = build_reid_map(gb, "S-", 6)
+        apply_deidentification(gb, by_code, "S-", 6)
+        # PII actually gone from the in-memory rows
+        si = gb.header.index("Student")
+        assert all(s.raw[si].startswith("S-") for s in gb.students)
+        restored, unmatched = reidentify(gb, by_code)
+        assert not unmatched
+        assert restored == len(original)
+        for s, orig in zip(gb.students, original):
+            assert s.raw == orig

--- a/lib/tools/_csv_utils.py
+++ b/lib/tools/_csv_utils.py
@@ -243,6 +243,9 @@ def write_canvas_gradebook_csv(gradebook: Gradebook, path) -> Path:
     Canvas). Read-only/group-total columns are emitted unchanged from `raw`."""
     path = Path(path)
     with path.open("w", newline="", encoding="utf-8") as f:
-        w = csv.writer(f)  # QUOTE_MINIMAL — quotes only fields needing it
+        # LF line endings match Canvas's own export (observed); csv default is
+        # CRLF, which would make every line differ on an otherwise-clean
+        # round-trip. QUOTE_MINIMAL matches Canvas's quoting.
+        w = csv.writer(f, lineterminator="\n")
         w.writerows(gradebook.to_rows())
     return path

--- a/lib/tools/grader_deidentify_gradebook.py
+++ b/lib/tools/grader_deidentify_gradebook.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""
+De-identify a Canvas gradebook CSV for safe sharing / offline work (Sprint 2).
+
+WHY
+  The gradebook export (Grades → Export) carries PII for every student: name,
+  Canvas ID, SIS User ID, SIS Login ID (email). Before sharing a gradebook with
+  a TA, committing it, or handing it to an AI, replace those with stable opaque
+  codes. Offline, this CSV is ALSO the roster — Canvas has no instructor-facing
+  People export — so the de-id master is built from the CSV's own identity
+  columns, no API call needed.
+
+REUSE (toolbox-wide consistency)
+  Codes come from build_deid_master.deid_code_for(user_id): `S-` + 6 hex of
+  sha256(user_id). Same function the API path uses, so a student's code is
+  IDENTICAL online and offline, and matches submission de-id. Collisions are
+  caught with build_deid_master.detect_collisions before anything is written.
+
+WHAT IT DOES
+  - Student  -> deid_code
+  - ID, SIS User ID, SIS Login ID -> blanked
+  - Section, Root Account, grades, read-only columns -> unchanged
+  - Writes a re-id map (JSON, code -> real identity) for grader_reidentify_gradebook.py
+
+FERPA
+  The re-id map holds names and MUST stay gitignored — it defaults under
+  .canvas/ (already gitignored). This tool prints ONLY counts + paths, never a
+  name, so it is safe to run in a shared terminal.
+
+USAGE
+  uv run python lib/tools/grader_deidentify_gradebook.py \
+    --input ~/Downloads/2026-07-12T1053_Grades-DS_250.csv
+  # offline: with no --input, finds the newest ~/Downloads gradebook (hard-stops
+  # if none present)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from _env_loader import force_utf8_console
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+from _csv_utils import read_canvas_gradebook_csv, write_canvas_gradebook_csv
+from build_deid_master import deid_code_for, detect_collisions, StudentRow
+import _file_finder
+
+_PII_BLANK_COLUMNS = ("ID", "SIS User ID", "SIS Login ID")
+_DEFAULT_OUT = Path(".canvas/gradebook/grades_deid.csv")
+_DEFAULT_MAP = Path(".canvas/gradebook/gradebook_reid_map.json")
+
+
+def build_reid_map(gradebook, prefix: str, hash_bits: int) -> dict:
+    """Return {code: {user_id, student, sis_user_id, sis_login_id}} and raise on
+    a code collision (two user_ids -> same code) before any file is written."""
+    header = gradebook.header
+    idx = {c: header.index(c) for c in ("Student",) + _PII_BLANK_COLUMNS if c in header}
+    rows_for_collision: list[StudentRow] = []
+    by_code: dict[str, dict] = {}
+    for s in gradebook.students:
+        cid = s.canvas_id.strip()
+        if not cid.isdigit():
+            continue  # non-student rows (e.g. a stray Test Student w/o id) — leave alone
+        uid = int(cid)
+        code = deid_code_for(uid, prefix=prefix, hash_bits=hash_bits)
+        rows_for_collision.append(
+            StudentRow(deid_code=code, user_id=uid, sortable_name=s.student, withdrawn=0)
+        )
+        by_code[code] = {
+            "user_id": uid,
+            "student": s.raw[idx["Student"]],
+            "sis_user_id": s.raw[idx["SIS User ID"]] if "SIS User ID" in idx else "",
+            "sis_login_id": s.raw[idx["SIS Login ID"]] if "SIS Login ID" in idx else "",
+        }
+    collisions = detect_collisions(rows_for_collision)
+    if collisions:
+        raise ValueError(
+            f"de-id code collision(s): {collisions}. Increase --hash-bits and retry."
+        )
+    return by_code
+
+
+def apply_deidentification(gradebook, by_code: dict, prefix: str, hash_bits: int) -> int:
+    """Rewrite identity cells in place: Student->code, PII columns blanked.
+    Returns the number of student rows de-identified."""
+    header = gradebook.header
+    student_i = header.index("Student")
+    blank_idx = [header.index(c) for c in _PII_BLANK_COLUMNS if c in header]
+    n = 0
+    for s in gradebook.students:
+        cid = s.canvas_id.strip()
+        if not cid.isdigit():
+            continue
+        code = deid_code_for(int(cid), prefix=prefix, hash_bits=hash_bits)
+        s.raw[student_i] = code
+        for i in blank_idx:
+            if i < len(s.raw):
+                s.raw[i] = ""
+        n += 1
+    return n
+
+
+def main(argv=None) -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(description="De-identify a Canvas gradebook CSV.")
+    ap.add_argument("--input", type=Path, help="gradebook CSV (default: newest in ~/Downloads)")
+    ap.add_argument("--course", help="filename hint to disambiguate ~/Downloads (e.g. DS_250)")
+    ap.add_argument("--out", type=Path, default=_DEFAULT_OUT, help="de-identified CSV output")
+    ap.add_argument("--map", type=Path, default=_DEFAULT_MAP, help="re-id map JSON output (gitignored)")
+    ap.add_argument("--prefix", default="S-", help="de-id code prefix (default S-)")
+    ap.add_argument("--hash-bits", type=int, default=6, help="hex chars of hash in code (default 6)")
+    args = ap.parse_args(argv)
+
+    src = args.input or _file_finder.require_gradebook_csv(name_hint=args.course)
+    gb = read_canvas_gradebook_csv(src)
+
+    by_code = build_reid_map(gb, args.prefix, args.hash_bits)
+    n = apply_deidentification(gb, by_code, args.prefix, args.hash_bits)
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.map.parent.mkdir(parents=True, exist_ok=True)
+    write_canvas_gradebook_csv(gb, args.out)
+    args.map.write_text(
+        json.dumps(
+            {"version": 1, "prefix": args.prefix, "hash_bits": args.hash_bits, "by_code": by_code},
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    # FERPA: counts + paths only, never a name.
+    print(f"✓ de-identified {n} students")
+    print(f"  de-identified CSV: {args.out}")
+    print(f"  re-id map (gitignored): {args.map}")
+    print("  Upload to Canvas ONLY after re-identifying: grader_reidentify_gradebook.py")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/tools/grader_reidentify_gradebook.py
+++ b/lib/tools/grader_reidentify_gradebook.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""
+Re-identify a de-identified gradebook CSV for Canvas upload (Sprint 2).
+
+WHY
+  grader_deidentify_gradebook.py replaced each student's identity with a stable
+  opaque code (Student=code; ID / SIS User ID / SIS Login ID blanked). After you
+  edit scores against the de-identified sheet, restore the real identity columns
+  so Canvas can match students on Grades → Import. Re-identification is a
+  DETERMINISTIC lookup on the code (a bijection with the Canvas user_id) — no
+  fuzzy name-matching, so there is no wrong-student risk.
+
+WHO RUNS THIS
+  The instructor, LOCALLY. It restores real names, so — like grader_reidentify.py
+  — the grading AI never runs it. Output holds PII; keep it out of git.
+
+FERPA
+  Prints ONLY counts + the output path, never a name.
+
+USAGE
+  uv run python lib/tools/grader_reidentify_gradebook.py \
+    --input .canvas/gradebook/grades_deid.csv \
+    --map   .canvas/gradebook/gradebook_reid_map.json \
+    --out   ~/Desktop/grades_for_upload.csv
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+try:
+    from _env_loader import force_utf8_console
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+from _csv_utils import read_canvas_gradebook_csv, write_canvas_gradebook_csv
+
+_RESTORE = {  # map field -> gradebook column
+    "student": "Student",
+    "user_id": "ID",
+    "sis_user_id": "SIS User ID",
+    "sis_login_id": "SIS Login ID",
+}
+
+
+def reidentify(gradebook, by_code: dict) -> tuple[int, list[str]]:
+    """Restore identity columns in place from the code in each row's Student
+    cell. Returns (restored_count, unmatched_codes). Unmatched codes are NOT
+    written back — the caller must treat any as a hard error before upload."""
+    header = gradebook.header
+    idx = {col: header.index(col) for col in _RESTORE.values() if col in header}
+    student_i = header.index("Student")
+    restored, unmatched = 0, []
+    for s in gradebook.students:
+        code = s.raw[student_i].strip()
+        rec = by_code.get(code)
+        if rec is None:
+            unmatched.append(code)
+            continue
+        for field, col in _RESTORE.items():
+            if col in idx:
+                while len(s.raw) <= idx[col]:
+                    s.raw.append("")
+                s.raw[idx[col]] = str(rec.get(field, ""))
+        restored += 1
+    return restored, unmatched
+
+
+def main(argv=None) -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(description="Re-identify a de-identified gradebook CSV for upload.")
+    ap.add_argument("--input", type=Path, required=True, help="de-identified (possibly edited) gradebook CSV")
+    ap.add_argument("--map", type=Path, required=True, help="re-id map JSON from grader_deidentify_gradebook.py")
+    ap.add_argument("--out", type=Path, required=True, help="re-identified CSV for Canvas upload")
+    args = ap.parse_args(argv)
+
+    by_code = json.loads(args.map.read_text(encoding="utf-8")).get("by_code", {})
+    gb = read_canvas_gradebook_csv(args.input)
+    restored, unmatched = reidentify(gb, by_code)
+
+    if unmatched:
+        # Fail loud: uploading rows whose code isn't in the map would send scores
+        # against a code-as-name. Never let that reach Canvas.
+        print(
+            f"✗ {len(unmatched)} row(s) have a code not in the re-id map "
+            f"(e.g. {unmatched[0]}). Aborting — wrong map, or rows were added.",
+            file=sys.stderr,
+        )
+        return 2
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    write_canvas_gradebook_csv(gb, args.out)
+    print(f"✓ re-identified {restored} students")
+    print(f"  upload-ready CSV: {args.out}")
+    print("  Upload via Canvas: Grades → Import")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Sprint 2 — gradebook de-identify / re-identify

De-identify a Canvas gradebook CSV for safe sharing (TA, git, AI), then re-identify for upload.

### Design (agreed this session)
- **Roster from the download, not the API.** Canvas has no instructor-facing People export, so the de-id master is built from the gradebook CSV's own identity columns. That one download is the roster.
- **Codes reuse `deid_code_for(user_id)`** — the same function the API path and submission de-id use, so a student's code is identical everywhere in the toolbox.
- **Opt-out posture** (de-id is the intended default for sharing). The fragility worry with mandatory de-id is gone because re-id is a **deterministic lookup on the code** (a bijection with the Canvas user_id), collision-guarded — not fuzzy name-matching. No wrong-student risk on upload.

### Tools
- `grader_deidentify_gradebook.py` — `Student` → code; `ID` / `SIS User ID` / `SIS Login ID` blanked; grades, `Section`, read-only columns untouched. Writes a gitignored re-id map.
- `grader_reidentify_gradebook.py` — restores identity by code for Canvas import; fails loud on any unknown code; instructor-only, prints counts (never names).

### Also
- `_csv_utils` writer now emits **LF** (matches Canvas) so an unedited round-trip is byte-clean.

### Verified (Genchi Genbutsu)
Real CLI round-trip on the DS 250 export is **byte-identical** after de-id → re-id. **16 tests** incl. a full CLI round-trip and a gated cross-course round-trip restoring **DS 250 + DS 460** byte-for-byte.

### FERPA
Re-id map defaults under `.canvas/` (gitignored); tools print counts + paths only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
