### PR TITLE
feat(offline): Sprint 5 — local course/ loader + first tool reads it

### DIFF
--- a/lib/tests/test_course_loader.py
+++ b/lib/tests/test_course_loader.py
@@ -1,0 +1,102 @@
+"""Tier 1 unit tests — local course/ loader + pilot audit local path (Sprint 5).
+
+Source: lib/tools/_course_loader.py (+ workload_audit.py --local)
+
+Proves the source-agnostic pattern: the loader reads course/ into API-shaped
+dicts, and workload_audit runs off them with ZERO API calls (verified with a
+bogus token). Gated integration loads the real course/ in this repo.
+"""
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from _course_loader import load_course, Course, CourseNotFound  # noqa: E402
+
+WORKLOAD_TOOL = _TOOLS_DIR / "workload_audit.py"
+
+
+def _make_course(root: Path):
+    """Write a minimal but realistic course/ tree (API-shaped item dicts)."""
+    (root / "_course.json").write_text(
+        json.dumps({"canvas_id": 999, "name": "Test Course", "course_code": "T 101"}),
+        encoding="utf-8",
+    )
+    m = root / "week-1"
+    m.mkdir()
+    (m / "_module.json").write_text(
+        json.dumps({"canvas_id": 1, "title": "Week 1", "position": 1, "published": True, "items": []}),
+        encoding="utf-8",
+    )
+    (m / "hw1.json").write_text(json.dumps({
+        "canvas_id": 11, "name": "HW 1", "points_possible": 100.0,
+        "due_at": "2026-09-05T05:59:00Z", "submission_types": ["online_upload"],
+    }), encoding="utf-8")
+    (m / "hw2.json").write_text(json.dumps({
+        "canvas_id": 12, "name": "HW 2", "points_possible": 50.0,
+        "due_at": "2026-09-12T05:59:00Z", "submission_types": ["online_text_entry"],
+    }), encoding="utf-8")
+    (m / "overview.html").write_text("<p>Welcome</p>", encoding="utf-8")
+    # a non-gradeable item (external tool) — must NOT count as an assignment
+    (m / "tool.json").write_text(json.dumps({"canvas_id": 13, "name": "LTI", "type": "ExternalTool"}), encoding="utf-8")
+    return root
+
+
+# --- loader ----------------------------------------------------------------
+
+def test_loads_metadata_modules_items(tmp_path):
+    c = load_course(_make_course(tmp_path))
+    assert isinstance(c, Course)
+    assert c.name == "Test Course"
+    assert c.canvas_id == 999
+    assert len(c.modules) == 1
+    assert c.modules[0].title == "Week 1"
+    assert len(c.items) == 3          # hw1, hw2, tool (excludes _module.json + .html)
+
+
+def test_assignments_are_gradeable_only(tmp_path):
+    c = load_course(_make_course(tmp_path))
+    names = {a["name"] for a in c.assignments}
+    assert names == {"HW 1", "HW 2"}   # ExternalTool excluded (no points/submission_types)
+
+
+def test_page_paths(tmp_path):
+    c = load_course(_make_course(tmp_path))
+    pages = c.page_paths()
+    assert len(pages) == 1 and pages[0].name == "overview.html"
+
+
+def test_missing_course_raises(tmp_path):
+    with pytest.raises(CourseNotFound):
+        load_course(tmp_path / "empty")
+
+
+def test_real_course_loads_if_present():
+    if not Path("course/_course.json").is_file():
+        pytest.skip("no populated course/ in repo — integration skipped")
+    c = load_course("course")
+    assert c.canvas_id is not None
+    assert len(c.assignments) > 0
+    assert all("name" in a for a in c.assignments)
+
+
+# --- pilot audit local path (end-to-end, offline-safe) ---------------------
+
+def test_workload_audit_local_runs_without_api(tmp_path):
+    _make_course(tmp_path)
+    env = {**os.environ, "CANVAS_API_TOKEN": "bogus", "CANVAS_BASE_URL": "https://x"}
+    r = subprocess.run(
+        [sys.executable, str(WORKLOAD_TOOL), "--course-dir", str(tmp_path), "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    assert r.returncode in (0, 1), r.stderr   # 0 balanced / 1 clustered — both are success
+    payload = json.loads(r.stdout)
+    assert payload["tool"] == "workload_audit"
+    assert "verdict" in payload                # produced a real audit from local files, no API

--- a/lib/tools/_course_loader.py
+++ b/lib/tools/_course_loader.py
@@ -1,0 +1,109 @@
+"""
+Read the local course/ folder into a source-agnostic model (Sprint 5).
+
+course/ is produced by `canvas_sync --pull` (from the Canvas API) OR by
+`offline_import` (from a .imscc). Tools that read it therefore run identically
+online or offline — the only difference is how course/ got populated. Reading
+course/ instead of re-hitting the API also removes redundant API calls for
+tools run after a sync.
+
+Structure (see canvas_sync.py):
+  course/_course.json                 course metadata (name, canvas_id, dates, ...)
+  course/<module-slug>/_module.json   module metadata (title, position, items)
+  course/<module-slug>/<item>.json    assignment / quiz / discussion / tool metadata
+  course/<module-slug>/<page>.html    page body
+
+Per-item field names match the Canvas API shape (name, points_possible, due_at,
+submission_types, ...), so a list of these dicts is a drop-in for an API
+`/courses/:id/assignments` response.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+DEFAULT_COURSE_DIR = "course"
+
+
+class CourseNotFound(FileNotFoundError):
+    """course/ isn't populated. Hard stop with actionable guidance."""
+
+
+@dataclass
+class Module:
+    slug: str
+    meta: dict                      # the _module.json
+    items: list[dict] = field(default_factory=list)  # loaded item .json dicts
+
+    @property
+    def title(self) -> str:
+        return self.meta.get("title", self.slug)
+
+
+@dataclass
+class Course:
+    dir: Path
+    meta: dict                      # _course.json
+    modules: list[Module] = field(default_factory=list)
+
+    @property
+    def name(self) -> str:
+        return self.meta.get("name", "<unknown course>")
+
+    @property
+    def canvas_id(self):
+        return self.meta.get("canvas_id")
+
+    @property
+    def items(self) -> list[dict]:
+        """Every per-item metadata dict across all modules (assignments, quizzes,
+        discussions, external tools) — the .json files, not pages."""
+        return [it for m in self.modules for it in m.items]
+
+    @property
+    def assignments(self) -> list[dict]:
+        """Gradeable items — those carrying a points_possible or submission_types.
+        Shaped like an API /assignments response (same field names)."""
+        return [
+            it for it in self.items
+            if "points_possible" in it or "submission_types" in it
+        ]
+
+    def page_paths(self) -> list[Path]:
+        """All page .html files across modules."""
+        return sorted(p for m in self.modules for p in (self.dir / m.slug).glob("*.html"))
+
+
+def load_course(course_dir=DEFAULT_COURSE_DIR) -> Course:
+    """Load course/ into a Course model. Raises CourseNotFound if it isn't
+    populated (run `canvas_sync --pull` online, or `offline_import` offline)."""
+    root = Path(course_dir)
+    course_json = root / "_course.json"
+    if not course_json.is_file():
+        raise CourseNotFound(
+            f"No {course_json} — course/ is not populated.\n"
+            f"  online:  uv run python lib/tools/canvas_sync.py --pull\n"
+            f"  offline: uv run python lib/tools/offline_import.py --imscc <file>"
+        )
+    course = Course(dir=root, meta=json.loads(course_json.read_text(encoding="utf-8")))
+    for mod_meta_path in sorted(root.glob("*/_module.json")):
+        mod_dir = mod_meta_path.parent
+        module = Module(slug=mod_dir.name, meta=json.loads(mod_meta_path.read_text(encoding="utf-8")))
+        for item_path in sorted(mod_dir.glob("*.json")):
+            if item_path.name == "_module.json":
+                continue
+            try:
+                data = json.loads(item_path.read_text(encoding="utf-8"))
+            except json.JSONDecodeError:
+                continue
+            if isinstance(data, dict):
+                data.setdefault("_source_path", str(item_path))
+                # Normalize to the API shape: quizzes store `title`, assignments
+                # store `name`. Give every item a `name` so tools that expect the
+                # API field work uniformly.
+                if "name" not in data and data.get("title"):
+                    data["name"] = data["title"]
+                module.items.append(data)
+        course.modules.append(module)
+    return course

--- a/lib/tools/workload_audit.py
+++ b/lib/tools/workload_audit.py
@@ -263,6 +263,13 @@ def _resolve_course_id(target_env: str, literal: str | None) -> tuple[str, str]:
     return val, f"${target_env}"
 
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> None:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -280,23 +287,42 @@ def main() -> None:
     ap.add_argument("--json", action="store_true", dest="emit_json", help="Machine-readable JSON")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="(Read-only; advisory guard. Accepted for symmetry.)")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://" or not CANVAS_API_TOKEN:
-        print("ERROR: set CANVAS_BASE_URL and CANVAS_API_TOKEN in .env.")
-        sys.exit(2)
-    course_id, source = _resolve_course_id(args.target, args.course_id)
-    if not course_id:
-        print(f"ERROR: course ID not found via {source}. Pass --course-id <id>.")
-        sys.exit(2)
-
-    guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
-                  mode="read", allow_override=args.allow_enrolled, label="audit target")
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    course = _get(f"/courses/{course_id}") or {}
-    course_name = (course.get("name") if isinstance(course, dict) else None) or "<unknown course>"
-    assignments = _get(f"/courses/{course_id}/assignments")
+
+    if use_local:
+        # Same audit, local source: course/ carries API-shaped assignment dicts.
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+        course_id = str(c.canvas_id or "local")
+        course_name = c.name
+        assignments = c.assignments
+    else:
+        if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://" or not CANVAS_API_TOKEN:
+            print("ERROR: set CANVAS_BASE_URL and CANVAS_API_TOKEN in .env.")
+            sys.exit(2)
+        course_id, source = _resolve_course_id(args.target, args.course_id)
+        if not course_id:
+            print(f"ERROR: course ID not found via {source}. Pass --course-id <id>.")
+            sys.exit(2)
+
+        guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+                      mode="read", allow_override=args.allow_enrolled, label="audit target")
+
+        course = _get(f"/courses/{course_id}") or {}
+        course_name = (course.get("name") if isinstance(course, dict) else None) or "<unknown course>"
+        assignments = _get(f"/courses/{course_id}/assignments")
     if not isinstance(assignments, list) or not assignments:
         print(f"\nNo assignments returned for course {course_id}.", file=sys.stderr)
         sys.exit(2)


### PR DESCRIPTION
## Sprint 5 — local `course/` loader + first tool converted

Foundation for the real offline architecture: **tools read `course/`, source-agnostic.** `canvas_sync --pull` fills it from the API; a future `offline_import` fills it from `.imscc`. Reading it also stops the redundant API overuse in online mode.

### What's here
- **`_course_loader.py`** — `load_course()` reads `_course.json` + per-module `_module.json` + item `.json` into a `Course`/`Module` model. Normalizes quiz `title` → `name` (API shape); `assignments` = gradeable items. Hard-stops with `CourseNotFound` if `course/` isn't populated.
- **`workload_audit.py`** — `--local` / `--course-dir` (and `CANVAS_MODE=offline`) read assignments from the loader instead of the API. **Compute core untouched** — the swap is only the data source.

### Verified
- **Parity** on sandbox 427808: local and API both return `verdict=balanced` (week distribution differs only because `course/` is a Jul-2 snapshot vs the live course).
- **Offline-safe**: the local audit runs to completion with a **bogus token** (zero API calls) — proven in a test.
- **No online regression**: API mode returns the same verdict as before.

### The swap is mechanical (answers "can most tools do this?")
Same ~15-line pattern applies to any audit reading only `course/`-available data. Scan result:
- **Simple now:** `accessibility_audit`, `content_representation_audit`, `syllabus_audit` (need `/assignments`, `/pages`, syllabus).
- **Blocked on S7** (widen local store): `formative_variety_audit`, `grading_structure_audit` (assignment_groups), `clo_quality_audit` (outcomes), rubric audits (rubrics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
