### PR TITLE
feat(offline): Sprint 6 — offline_import (.imscc -> course/)

### DIFF
--- a/lib/tests/test_offline_import.py
+++ b/lib/tests/test_offline_import.py
@@ -1,0 +1,132 @@
+"""Tier 1 unit tests — offline_import (.imscc -> course/) (Sprint 6).
+
+Source: lib/tools/offline_import.py
+
+Builds a minimal synthetic .imscc and asserts the produced course/ matches the
+API-shaped model the loader expects (assignments with list submission_types,
+quizzes shaped as assignments, pages as .html). Gated integration imports the
+real DS 250 / DS 460 / ITM 327 / M 119 exports and confirms the loader reads them.
+"""
+import json
+import sys
+import zipfile
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from offline_import import import_imscc, slugify, assignment_from_xml, quiz_from_xml  # noqa: E402
+from _course_loader import load_course  # noqa: E402
+import _file_finder  # noqa: E402
+
+
+def _make_imscc(path: Path):
+    files = {
+        "imsmanifest.xml":
+            '<manifest><resources>'
+            '<resource identifier="gCCC" type="webcontent"><file href="wiki_content/overview.html"/></resource>'
+            '</resources></manifest>',
+        "course_settings/course_settings.xml":
+            "<course><title>Sample Course</title><course_code>S 101</course_code>"
+            "<start_at>2026-09-01T06:00:00</start_at></course>",
+        "course_settings/context.xml": "<context_info><course_id>4242</course_id></context_info>",
+        "course_settings/module_meta.xml":
+            '<modules><module identifier="m1"><title>Week 1</title>'
+            "<workflow_state>active</workflow_state><position>1</position><items>"
+            '<item identifier="i1"><content_type>Assignment</content_type>'
+            "<workflow_state>active</workflow_state><title>HW 1</title>"
+            "<identifierref>gAAA</identifierref></item>"
+            '<item identifier="i2"><content_type>Quizzes::Quiz</content_type>'
+            "<title>Quiz 1</title><identifierref>gBBB</identifierref></item>"
+            '<item identifier="i3"><content_type>WikiPage</content_type>'
+            "<title>Overview</title><identifierref>gCCC</identifierref></item>"
+            "</items></module></modules>",
+        "gAAA/assignment_settings.xml":
+            "<assignment><title>HW 1</title><workflow_state>published</workflow_state>"
+            "<points_possible>100.0</points_possible><due_at>2026-09-05T05:59:00</due_at>"
+            "<submission_types>online_upload,online_text_entry</submission_types>"
+            "<grading_type>points</grading_type></assignment>",
+        "gBBB/assessment_meta.xml":
+            "<quiz><title>Quiz 1</title><points_possible>10.0</points_possible>"
+            "<due_at>2026-09-12T05:59:00</due_at><quiz_type>assignment</quiz_type></quiz>",
+        "wiki_content/overview.html": "<p>hi</p>",
+    }
+    with zipfile.ZipFile(path, "w") as z:
+        for name, content in files.items():
+            z.writestr(name, content)
+    return path
+
+
+# --- field mapping ---------------------------------------------------------
+
+def test_assignment_mapping():
+    xml = ("<a><title>HW</title><workflow_state>published</workflow_state>"
+           "<points_possible>50.0</points_possible><due_at>2026-09-05T05:59:00</due_at>"
+           "<submission_types>online_upload,online_text_entry</submission_types></a>")
+    d = assignment_from_xml(xml, None)
+    assert d["name"] == "HW"
+    assert d["published"] is True
+    assert d["points_possible"] == 50.0
+    assert d["submission_types"] == ["online_upload", "online_text_entry"]  # list, not string
+    assert d["due_at"] == "2026-09-05T05:59:00"
+
+
+def test_quiz_mapping_is_assignment_shaped():
+    d = quiz_from_xml("<q><title>Q</title><points_possible>10.0</points_possible></q>", True)
+    assert d["name"] == "Q"
+    assert d["submission_types"] == ["online_quiz"]
+    assert d["points_possible"] == 10.0
+
+
+def test_slugify():
+    assert slugify("W02 U0: Core Task 1 — Setup") == "w02-u0-core-task-1-setup"
+    assert slugify("") == "item"
+
+
+# --- full import -> course/ ------------------------------------------------
+
+def test_import_produces_loadable_course(tmp_path):
+    src = _make_imscc(tmp_path / "c.imscc")
+    out = tmp_path / "course"
+    counts = import_imscc(src, out)
+    assert counts == {"modules": 1, "assignments": 1, "quizzes": 1, "pages": 1}
+
+    # _course.json
+    meta = json.loads((out / "_course.json").read_text())
+    assert meta["name"] == "Sample Course"
+    assert meta["canvas_id"] == "4242"
+
+    # module dir + files
+    mod = out / "week-1"
+    assert (mod / "_module.json").is_file()
+    assert (mod / "hw-1.json").is_file()
+    assert (mod / "quiz-1.json").is_file()
+    assert (mod / "overview.html").read_text() == "<p>hi</p>"
+
+    # the loader reads it into API-shaped assignments
+    c = load_course(out)
+    assert c.name == "Sample Course"
+    names = {a["name"] for a in c.assignments}
+    assert names == {"HW 1", "Quiz 1"}
+    hw = next(a for a in c.assignments if a["name"] == "HW 1")
+    assert hw["submission_types"] == ["online_upload", "online_text_entry"]
+    assert hw["points_possible"] == 100.0
+
+
+# --- integration: real exports (gated, cross-course) -----------------------
+
+def test_import_real_exports_if_present(tmp_path):
+    reals = _file_finder.list_imscc(name_hint="export")
+    if not reals:
+        pytest.skip("no real *_export.imscc in ~/Downloads — integration skipped")
+    for real in reals:
+        out = tmp_path / real.stem
+        counts = import_imscc(real, out)
+        assert counts["modules"] > 0
+        assert counts["assignments"] + counts["quizzes"] > 0
+        c = load_course(out)                       # loader reads what import wrote
+        assert len(c.assignments) > 0
+        assert all("name" in a for a in c.assignments)

--- a/lib/tools/offline_import.py
+++ b/lib/tools/offline_import.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""
+Import a Canvas .imscc export into the local course/ folder (Sprint 6).
+
+Produces the SAME structure canvas_sync --pull creates, so _course_loader and
+every tool converted to read course/ work identically offline — the only
+difference is that course/ was populated from a .imscc instead of the API.
+
+Mapping (verified against 5 real exports — see imscc_format_knowledge.md):
+  course_settings/course_settings.xml   -> course/_course.json
+  course_settings/module_meta.xml       -> course/<module-slug>/_module.json
+  <identifierref>/assignment_settings.xml -> course/<mod>/<item>.json (name,
+      points_possible, due_at, submission_types, ...)  [module item = Assignment]
+  <identifierref>/assessment_meta.xml   -> course/<mod>/<item>.json (quiz, shaped
+      like an assignment: submission_types=["online_quiz"])  [item = Quizzes::Quiz]
+  wiki_content/<page>.html (via manifest href) -> course/<mod>/<item>.html  [WikiPage]
+
+Item field names match the Canvas API shape so the local dicts are drop-in for
+API responses. (SubHeaders / ExternalUrls / external tools are skipped — they
+carry no gradeable or page content.)
+
+USAGE
+  uv run python lib/tools/offline_import.py --imscc ~/Downloads/course_export.imscc
+  uv run python lib/tools/offline_import.py --imscc export.imscc --out course
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+try:
+    from _env_loader import force_utf8_console
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+
+def slugify(s: str) -> str:
+    s = re.sub(r"[^\w\s-]", "", (s or "").lower())
+    s = re.sub(r"[\s_]+", "-", s).strip("-")
+    return s or "item"
+
+
+def _field(xml: str, tag: str):
+    m = re.search(rf"<{tag}>([^<]*)</{tag}>", xml)
+    return m.group(1) if m else None
+
+
+def _dates_points(xml: str, d: dict) -> None:
+    for t in ("due_at", "unlock_at", "lock_at"):
+        v = _field(xml, t)
+        if v:
+            d[t] = v
+    pp = _field(xml, "points_possible")
+    if pp:
+        try:
+            d["points_possible"] = float(pp)
+        except ValueError:
+            pass
+
+
+def assignment_from_xml(xml: str, published: bool | None) -> dict:
+    d = {"name": _field(xml, "title")}
+    ws = _field(xml, "workflow_state")
+    d["published"] = (ws == "published") if ws else bool(published)
+    st = _field(xml, "submission_types")
+    if st is not None:
+        d["submission_types"] = [s for s in st.split(",") if s]
+    gt = _field(xml, "grading_type")
+    if gt:
+        d["grading_type"] = gt
+    ae = _field(xml, "allowed_extensions")
+    if ae:
+        d["allowed_extensions"] = [e for e in ae.split(",") if e]
+    _dates_points(xml, d)
+    return d
+
+
+def quiz_from_xml(xml: str, published: bool | None) -> dict:
+    d = {"name": _field(xml, "title"), "submission_types": ["online_quiz"]}
+    ws = _field(xml, "workflow_state")
+    d["published"] = (ws == "published") if ws else bool(published)
+    qt = _field(xml, "quiz_type")
+    if qt:
+        d["quiz_type"] = qt
+    _dates_points(xml, d)
+    return d
+
+
+def _manifest_hrefs(manifest: str) -> dict:
+    """identifier -> first file href, for resolving WikiPage items."""
+    return dict(re.findall(
+        r'<resource\b[^>]*\bidentifier="([^"]+)"[^>]*>\s*<file\s+href="([^"]+)"', manifest
+    ))
+
+
+def import_imscc(imscc_path, out_dir="course") -> dict:
+    """Convert a .imscc into course/. Returns a summary count dict."""
+    out = Path(out_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    z = zipfile.ZipFile(imscc_path)
+    names = set(z.namelist())
+
+    def read(n):
+        return z.read(n).decode("utf-8", "ignore") if n in names else ""
+
+    # --- course metadata ---
+    cs = read("course_settings/course_settings.xml")
+    ctx = read("course_settings/context.xml")
+    course_meta = {
+        "name": _field(cs, "title") or "<imported course>",
+        "course_code": _field(cs, "course_code"),
+        "start_at": _field(cs, "start_at"),
+        "end_at": _field(cs, "conclude_at"),
+        "canvas_id": _field(ctx, "course_id") or _field(cs, "canvas_id"),
+        "workflow_state": _field(cs, "workflow_state"),
+    }
+    (out / "_course.json").write_text(json.dumps(course_meta, indent=2), encoding="utf-8")
+
+    hrefs = _manifest_hrefs(read("imsmanifest.xml"))
+    counts = {"modules": 0, "assignments": 0, "quizzes": 0, "pages": 0}
+
+    mm = read("course_settings/module_meta.xml")
+    for mod in re.findall(r"<module\b[^>]*>(.*?)</module>", mm, re.S):
+        title = _field(mod, "title") or "module"
+        mod_slug = slugify(title)
+        mod_dir = out / mod_slug
+        mod_dir.mkdir(parents=True, exist_ok=True)
+        published = _field(mod, "workflow_state") == "active"
+        item_summaries = []
+        for it in re.findall(r"<item\b[^>]*>(.*?)</item>", mod, re.S):
+            ct = _field(it, "content_type")
+            ref = _field(it, "identifierref")
+            it_title = _field(it, "title") or "item"
+            it_pub = _field(it, "workflow_state") == "active"
+            item_summaries.append({"title": it_title, "content_type": ct, "identifierref": ref})
+            if not ref:
+                continue
+            if ct == "Assignment" and f"{ref}/assignment_settings.xml" in names:
+                data = assignment_from_xml(read(f"{ref}/assignment_settings.xml"), it_pub)
+                (mod_dir / f"{slugify(it_title)}.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
+                counts["assignments"] += 1
+            elif ct == "Quizzes::Quiz" and f"{ref}/assessment_meta.xml" in names:
+                data = quiz_from_xml(read(f"{ref}/assessment_meta.xml"), it_pub)
+                (mod_dir / f"{slugify(it_title)}.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
+                counts["quizzes"] += 1
+            elif ct == "WikiPage" and hrefs.get(ref) in names:
+                (mod_dir / f"{slugify(it_title)}.html").write_text(read(hrefs[ref]), encoding="utf-8")
+                counts["pages"] += 1
+        (mod_dir / "_module.json").write_text(
+            json.dumps({"title": title, "published": published, "items": item_summaries}, indent=2),
+            encoding="utf-8",
+        )
+        counts["modules"] += 1
+    return counts
+
+
+def main(argv=None) -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(description="Import a Canvas .imscc into course/.")
+    ap.add_argument("--imscc", type=Path, required=True, help="the .imscc export")
+    ap.add_argument("--out", type=Path, default=Path("course"), help="output course dir (default: course)")
+    args = ap.parse_args(argv)
+
+    if not zipfile.is_zipfile(args.imscc):
+        print(f"ERROR: {args.imscc} is not a valid .imscc (ZIP).", file=sys.stderr)
+        return 2
+    c = import_imscc(args.imscc, args.out)
+    print(f"✓ imported {args.imscc.name} -> {args.out}/")
+    print(f"  modules={c['modules']} assignments={c['assignments']} quizzes={c['quizzes']} pages={c['pages']}")
+    print("  Now any tool with --local reads it: e.g. workload_audit.py --local")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Sprint 6 — `offline_import` (`.imscc → course/`)

Completes the offline data path: a no-API instructor imports a `.imscc` once, and every tool converted to read `course/` (S5+) works offline. Same tool, same folder — `canvas_sync` fills `course/` from the API, `offline_import` fills it from a `.imscc`.

### Mapping (verified vs 5 real exports)
- `course_settings.xml` → `_course.json`
- `module_meta.xml` → per-module `_module.json` + item order
- `<ref>/assignment_settings.xml` → `<item>.json` (name, points_possible, due_at, **`submission_types` as a list**, published)
- `<ref>/assessment_meta.xml` → quiz shaped as an assignment (`["online_quiz"]`)
- WikiPage (manifest href) → `<item>.html`

### Verified end-to-end
Import DS 250 (415194) → `course/`: **20 modules, 41 assignments, 27 quizzes, 26 pages**. `workload_audit --local` on the imported folder runs **offline with a bogus token** and returns **`verdict=balanced`, 14 weeks — matching the live API** (14 weeks, balanced). Heaviest-week differs only because a full `.imscc` and the API's filtered `/assignments` carry slightly different item sets.

### Tests
5 — field-mapping units, a full synthetic import the loader reads back, and a gated real-export pass over all four courses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
