### PR TITLE
feat(offline): Sprint 8a — content path + syllabus_audit reads course/

### DIFF
--- a/lib/tests/test_course_loader.py
+++ b/lib/tests/test_course_loader.py
@@ -46,6 +46,7 @@ def _make_course(root: Path):
     (m / "overview.html").write_text("<p>Welcome</p>", encoding="utf-8")
     # a non-gradeable item (external tool) — must NOT count as an assignment
     (m / "tool.json").write_text(json.dumps({"canvas_id": 13, "name": "LTI", "type": "ExternalTool"}), encoding="utf-8")
+    (root / "syllabus.html").write_text("<p>Course syllabus here</p>", encoding="utf-8")
     return root
 
 
@@ -71,6 +72,13 @@ def test_page_paths(tmp_path):
     c = load_course(_make_course(tmp_path))
     pages = c.page_paths()
     assert len(pages) == 1 and pages[0].name == "overview.html"
+
+
+def test_syllabus_and_pages_bodies(tmp_path):
+    c = load_course(_make_course(tmp_path))
+    assert "Course syllabus here" in c.syllabus()
+    pages = c.pages()
+    assert any(p["title"] == "overview" and "Welcome" in p["body"] for p in pages)
 
 
 def test_missing_course_raises(tmp_path):

--- a/lib/tests/test_offline_import.py
+++ b/lib/tests/test_offline_import.py
@@ -51,6 +51,8 @@ def _make_imscc(path: Path):
             "<points_possible>100.0</points_possible><due_at>2026-09-05T05:59:00</due_at>"
             "<submission_types>online_upload,online_text_entry</submission_types>"
             "<grading_type>points</grading_type></assignment>",
+        "gAAA/hw-1.html": "<p>Read chapter 1 and submit.</p>",     # assignment description body
+        "course_settings/syllabus.html": "<h1>Syllabus</h1><p>Grading policy...</p>",
         "gBBB/assessment_meta.xml":
             "<quiz><title>Quiz 1</title><points_possible>10.0</points_possible>"
             "<due_at>2026-09-12T05:59:00</due_at><quiz_type>assignment</quiz_type></quiz>",
@@ -116,6 +118,11 @@ def test_import_produces_loadable_course(tmp_path):
     hw = next(a for a in c.assignments if a["name"] == "HW 1")
     assert hw["submission_types"] == ["online_upload", "online_text_entry"]
     assert hw["points_possible"] == 100.0
+    assert "Read chapter 1" in hw["description"]        # description body captured
+
+    # syllabus captured at course/syllabus.html
+    assert (out / "syllabus.html").is_file()
+    assert "Grading policy" in c.syllabus()
 
 
 # --- integration: real exports (gated, cross-course) -----------------------
@@ -132,6 +139,21 @@ def test_import_real_exports_if_present(tmp_path):
         c = load_course(out)                       # loader reads what import wrote
         assert len(c.assignments) > 0
         assert all("name" in a for a in c.assignments)
+
+
+def test_syllabus_audit_local_runs_without_api(tmp_path):
+    """The converted syllabus_audit reads the imported course/ syllabus offline."""
+    import_imscc(_make_imscc(tmp_path / "c.imscc"), tmp_path / "course")
+    env = {**os.environ, "CANVAS_API_TOKEN": "bogus", "CANVAS_BASE_URL": "https://x"}
+    r = subprocess.run(
+        [sys.executable, str(_TOOLS_DIR / "syllabus_audit.py"),
+         "--course-dir", str(tmp_path / "course"), "--json"],
+        capture_output=True, text=True, env=env,
+    )
+    # 0/1/2 are audit verdicts (complete/incomplete/near-empty), not crashes.
+    assert r.stdout.strip(), f"no output; stderr={r.stderr}"
+    payload = json.loads(r.stdout)      # ran offline (bogus token) and produced valid JSON
+    assert isinstance(payload, dict) and payload
 
 
 def test_full_pipeline_cross_validation_if_present(tmp_path):

--- a/lib/tools/_course_loader.py
+++ b/lib/tools/_course_loader.py
@@ -74,6 +74,17 @@ class Course:
         """All page .html files across modules."""
         return sorted(p for m in self.modules for p in (self.dir / m.slug).glob("*.html"))
 
+    def syllabus(self) -> str:
+        """The syllabus HTML (course/syllabus.html), or '' if none — mirrors the
+        API's course.syllabus_body."""
+        p = self.dir / "syllabus.html"
+        return p.read_text(encoding="utf-8") if p.is_file() else ""
+
+    def pages(self) -> list[dict]:
+        """Page bodies shaped loosely like an API /pages response
+        ({title, body}). Title is the file slug (identifies the page in reports)."""
+        return [{"title": p.stem, "body": p.read_text(encoding="utf-8")} for p in self.page_paths()]
+
 
 def load_course(course_dir=DEFAULT_COURSE_DIR) -> Course:
     """Load course/ into a Course model. Raises CourseNotFound if it isn't

--- a/lib/tools/offline_import.py
+++ b/lib/tools/offline_import.py
@@ -121,6 +121,11 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
     }
     (out / "_course.json").write_text(json.dumps(course_meta, indent=2), encoding="utf-8")
 
+    # Syllabus (course/syllabus.html — same path canvas_sync/course_quality_check use)
+    syllabus = read("course_settings/syllabus.html")
+    if syllabus:
+        (out / "syllabus.html").write_text(syllabus, encoding="utf-8")
+
     hrefs = _manifest_hrefs(read("imsmanifest.xml"))
     counts = {"modules": 0, "assignments": 0, "quizzes": 0, "pages": 0}
 
@@ -142,6 +147,10 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
                 continue
             if ct == "Assignment" and f"{ref}/assignment_settings.xml" in names:
                 data = assignment_from_xml(read(f"{ref}/assignment_settings.xml"), it_pub)
+                # description body is a sibling .html in the assignment dir
+                body = next((n for n in names if n.startswith(f"{ref}/") and n.endswith(".html")), None)
+                if body:
+                    data["description"] = read(body)
                 (mod_dir / f"{slugify(it_title)}.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
                 counts["assignments"] += 1
             elif ct == "Quizzes::Quiz" and f"{ref}/assessment_meta.xml" in names:

--- a/lib/tools/syllabus_audit.py
+++ b/lib/tools/syllabus_audit.py
@@ -689,6 +689,13 @@ def _resolve_course_id(target_env: str, literal: str | None) -> tuple[str, str]:
     return val, f"${target_env}"
 
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> None:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -718,38 +725,55 @@ def main() -> None:
                          "instead of (or in addition to) the 9-section summary. "
                          "Scores 0/1/2 per item with link-presence detection. "
                          "Use with --detailed to keep the umbrella audit too.")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    missing_cfg: list[str] = []
-    if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://":
-        missing_cfg.append("CANVAS_BASE_URL")
-    if not CANVAS_API_TOKEN:
-        missing_cfg.append("CANVAS_API_TOKEN")
-    if missing_cfg:
-        print("ERROR: Missing required configuration:")
-        for m in missing_cfg:
-            print(f"  {m}")
-        print("\nSet these in your .env file.")
-        sys.exit(2)
-
-    course_id, source = _resolve_course_id(args.target, args.course_id)
-    if not course_id:
-        print(f"ERROR: course ID not found via {source}.")
-        print("       Set the env var, or pass --course-id <id> directly.")
-        sys.exit(2)
-
-    guard.enforce(
-        base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
-        mode="read", allow_override=args.allow_enrolled, label="audit target",
-    )
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
-    course_name, body = fetch_syllabus(course_id)
-    if body is None:
-        print(f"\nCould not fetch course {course_id} (or the request failed).",
-              file=sys.stderr)
-        sys.exit(2)
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+        course_id = str(c.canvas_id or "local")
+        course_name = c.name
+        body = c.syllabus()          # mirrors course.syllabus_body
+    else:
+        missing_cfg: list[str] = []
+        if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://":
+            missing_cfg.append("CANVAS_BASE_URL")
+        if not CANVAS_API_TOKEN:
+            missing_cfg.append("CANVAS_API_TOKEN")
+        if missing_cfg:
+            print("ERROR: Missing required configuration:")
+            for m in missing_cfg:
+                print(f"  {m}")
+            print("\nSet these in your .env file.")
+            sys.exit(2)
+
+        course_id, source = _resolve_course_id(args.target, args.course_id)
+        if not course_id:
+            print(f"ERROR: course ID not found via {source}.")
+            print("       Set the env var, or pass --course-id <id> directly.")
+            sys.exit(2)
+
+        guard.enforce(
+            base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+            mode="read", allow_override=args.allow_enrolled, label="audit target",
+        )
+
+        course_name, body = fetch_syllabus(course_id)
+        if body is None:
+            print(f"\nCould not fetch course {course_id} (or the request failed).",
+                  file=sys.stderr)
+            sys.exit(2)
 
     text = html_to_text(body)
     body_words = word_count(text)


### PR DESCRIPTION
## Sprint 8a — content path + first content audit converted

Extends the local store to carry page/assignment **content**, then converts `syllabus_audit`.

- **`offline_import`**: captures the syllabus (`course_settings/syllabus.html` → `course/syllabus.html`) and each assignment description (sibling `.html` in the assignment dir → `assignment.json` `description`). Same content `canvas_sync` stores.
- **`_course_loader`**: `syllabus()` + `pages()` ({title, body}).
- **`syllabus_audit`**: `--local`/`--course-dir` reads `course/`. **Parity**: local and API on DS 250 both = `incomplete` / 2 missing sections; local runs with a bogus token (zero API calls).

Sets up `accessibility_audit` + `content_representation_audit` (the multi-source content collectors) as the immediate next conversion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
