### PR TITLE
feat(offline): Sprint 8b — accessibility + content_representation read course/

### DIFF
--- a/lib/tests/test_offline_import.py
+++ b/lib/tests/test_offline_import.py
@@ -156,6 +156,27 @@ def test_syllabus_audit_local_runs_without_api(tmp_path):
     assert isinstance(payload, dict) and payload
 
 
+def _run_local_audit(tmp_path, tool, flag):
+    import_imscc(_make_imscc(tmp_path / "c.imscc"), tmp_path / "course")
+    env = {**os.environ, "CANVAS_API_TOKEN": "bogus", "CANVAS_BASE_URL": "https://x"}
+    return subprocess.run(
+        [sys.executable, str(_TOOLS_DIR / tool), "--course-dir", str(tmp_path / "course"), flag],
+        capture_output=True, text=True, env=env,
+    )
+
+
+def test_content_representation_audit_local_runs(tmp_path):
+    r = _run_local_audit(tmp_path, "content_representation_audit.py", "--json")
+    assert r.stdout.strip(), r.stderr
+    assert isinstance(json.loads(r.stdout), dict)   # ran offline, zero API calls
+
+
+def test_accessibility_audit_local_runs(tmp_path):
+    r = _run_local_audit(tmp_path, "accessibility_audit.py", "--emit-json")
+    assert r.stdout.strip(), r.stderr
+    assert isinstance(json.loads(r.stdout), dict)   # ran offline, zero API calls
+
+
 def test_full_pipeline_cross_validation_if_present(tmp_path):
     """Cross-validate the WHOLE offline path — import .imscc -> load -> audit —
     across every real course, fully offline (bogus token = zero API calls)."""

--- a/lib/tools/accessibility_audit.py
+++ b/lib/tools/accessibility_audit.py
@@ -674,17 +674,22 @@ def audit_course(
     course_id: str,
     skip_syllabus: bool, skip_pages: bool, skip_assignments: bool,
     target_grade: float,
+    local_course=None,
 ) -> dict:
-    course = _get(f"/courses/{course_id}", params={"include[]": "syllabus_body"}) or {}
-    if not isinstance(course, dict):
-        return {"error": f"Could not load course {course_id}"}
-    course_name = course.get("name", "<unknown course>")
+    if local_course is not None:
+        course = {}
+        course_name = local_course.name
+    else:
+        course = _get(f"/courses/{course_id}", params={"include[]": "syllabus_body"}) or {}
+        if not isinstance(course, dict):
+            return {"error": f"Could not load course {course_id}"}
+        course_name = course.get("name", "<unknown course>")
     all_findings: list[dict] = []
     surfaces_checked = []
 
     # Syllabus
     if not skip_syllabus:
-        body = course.get("syllabus_body") or ""
+        body = local_course.syllabus() if local_course is not None else (course.get("syllabus_body") or "")
         if body:
             print(f"  Auditing syllabus...", file=sys.stderr)
             all_findings += audit_html(body, "syllabus", target_grade)
@@ -692,23 +697,31 @@ def audit_course(
 
     # Pages
     if not skip_pages:
-        pages_list = _get_paged(f"/courses/{course_id}/pages", params={"published": True})
-        print(f"  Auditing {len(pages_list)} pages...", file=sys.stderr)
-        for p in pages_list:
-            page_url = p.get("url")
-            if not page_url:
-                continue
-            page = _get(f"/courses/{course_id}/pages/{page_url}") or {}
-            body = page.get("body") or ""
+        if local_course is not None:
+            page_surfaces = [(p["title"], p["body"]) for p in local_course.pages()]
+        else:
+            pages_list = _get_paged(f"/courses/{course_id}/pages", params={"published": True})
+            page_surfaces = []
+            for p in pages_list:
+                page_url = p.get("url")
+                if not page_url:
+                    continue
+                page = _get(f"/courses/{course_id}/pages/{page_url}") or {}
+                page_surfaces.append((page.get("title", page_url), page.get("body") or ""))
+        print(f"  Auditing {len(page_surfaces)} pages...", file=sys.stderr)
+        for title, body in page_surfaces:
             if body:
-                all_findings += audit_html(body, f"page:{page.get('title', page_url)}",
-                                           target_grade)
-        surfaces_checked.append(f"pages ({len(pages_list)})")
+                all_findings += audit_html(body, f"page:{title}", target_grade)
+        surfaces_checked.append(f"pages ({len(page_surfaces)})")
 
     # Assignments
     if not skip_assignments:
-        assignments = _get_paged(f"/courses/{course_id}/assignments")
-        published = [a for a in assignments if a.get("workflow_state") == "published"]
+        if local_course is not None:
+            assignments = local_course.assignments
+        else:
+            assignments = _get_paged(f"/courses/{course_id}/assignments")
+        published = [a for a in assignments
+                     if a.get("workflow_state") == "published" or a.get("published")]
         print(f"  Auditing {len(published)} published assignments...", file=sys.stderr)
         for a in published:
             description = a.get("description") or ""
@@ -951,6 +964,13 @@ def _write_report(path: Path, body: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> int:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -977,29 +997,46 @@ def main() -> int:
                          "graduate. Set to 0 to disable.")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="Bypass canvas_course_guard advisory for enrolled-course reads.")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    if not CANVAS_API_TOKEN or not CANVAS_BASE_URL:
-        print("ERROR: CANVAS_API_TOKEN and CANVAS_BASE_URL must be set in .env.", file=sys.stderr)
-        return 2
-    course_id = args.course_id or os.environ.get(args.target, "")
-    if not course_id:
-        print(f"ERROR: course ID not found. Pass --course-id <id> or set {args.target}.",
-              file=sys.stderr)
-        return 2
-
-    guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
-                  mode="read", allow_override=args.allow_enrolled, label="audit target")
-
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    print(f"Auditing course {course_id}...", file=sys.stderr)
     # target_grade=0 disables the reading-level check; we treat anything <=0 as disabled
     effective_target = args.target_grade if args.target_grade > 0 else 999.0
+    use_local = args.local or bool(args.course_dir) or _is_offline()
+
+    local_course = None
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            local_course = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        course_id = str(local_course.canvas_id or "local")
+    else:
+        if not CANVAS_API_TOKEN or not CANVAS_BASE_URL:
+            print("ERROR: CANVAS_API_TOKEN and CANVAS_BASE_URL must be set in .env.", file=sys.stderr)
+            return 2
+        course_id = args.course_id or os.environ.get(args.target, "")
+        if not course_id:
+            print(f"ERROR: course ID not found. Pass --course-id <id> or set {args.target}.",
+                  file=sys.stderr)
+            return 2
+        guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+                      mode="read", allow_override=args.allow_enrolled, label="audit target")
+
+    print(f"Auditing course {course_id}...", file=sys.stderr)
     res = audit_course(course_id,
                        skip_syllabus=args.skip_syllabus,
                        skip_pages=args.skip_pages,
                        skip_assignments=args.skip_assignments,
-                       target_grade=effective_target)
+                       target_grade=effective_target,
+                       local_course=local_course)
 
     if "error" in res:
         print(f"ERROR: {res['error']}", file=sys.stderr)

--- a/lib/tools/content_representation_audit.py
+++ b/lib/tools/content_representation_audit.py
@@ -186,6 +186,24 @@ def collect_items(course_id: str, max_pages: int) -> tuple[str, list[tuple[str, 
     return course_name, items
 
 
+def collect_items_from_course(course, max_pages: int) -> list[tuple[str, str]]:
+    """Local equivalent of collect_items: build the same (label, text) surfaces
+    from a loaded Course (syllabus + pages + assignment descriptions)."""
+    items: list[tuple[str, str]] = []
+    syll = _text(course.syllabus())
+    if syll:
+        items.append(("syllabus", syll))
+    for p in course.pages()[:max_pages]:
+        body = _text(p.get("body") or "")
+        if body:
+            items.append((f"page:{p.get('title')}", body))
+    for a in course.assignments:
+        body = _text(a.get("description") or "")
+        if body:
+            items.append((f"assignment:{a.get('name') or a.get('id')}", body))
+    return items
+
+
 # ---------------------------------------------------------------------------
 # Rendering
 # ---------------------------------------------------------------------------
@@ -270,6 +288,13 @@ def _resolve_course_id(target_env: str, literal: str | None) -> tuple[str, str]:
     return val, f"${target_env}"
 
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> None:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -287,22 +312,40 @@ def main() -> None:
     ap.add_argument("--json", action="store_true", dest="emit_json", help="Machine-readable JSON")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="(Read-only; advisory guard. Accepted for symmetry.)")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://" or not CANVAS_API_TOKEN:
-        print("ERROR: set CANVAS_BASE_URL and CANVAS_API_TOKEN in .env.")
-        sys.exit(2)
-
-    course_id, source = _resolve_course_id(args.target, args.course_id)
-    if not course_id:
-        print(f"ERROR: course ID not found via {source}. Pass --course-id <id>.")
-        sys.exit(2)
-
-    guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
-                  mode="read", allow_override=args.allow_enrolled, label="audit target")
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    course_name, items = collect_items(course_id, args.max_pages)
+
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+        course_id = str(c.canvas_id or "local")
+        course_name = c.name
+        items = collect_items_from_course(c, args.max_pages)
+    else:
+        if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://" or not CANVAS_API_TOKEN:
+            print("ERROR: set CANVAS_BASE_URL and CANVAS_API_TOKEN in .env.")
+            sys.exit(2)
+
+        course_id, source = _resolve_course_id(args.target, args.course_id)
+        if not course_id:
+            print(f"ERROR: course ID not found via {source}. Pass --course-id <id>.")
+            sys.exit(2)
+
+        guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+                      mode="read", allow_override=args.allow_enrolled, label="audit target")
+
+        course_name, items = collect_items(course_id, args.max_pages)
     if not items:
         print(f"\nNo readable content fetched for course {course_id}.", file=sys.stderr)
         sys.exit(2)


### PR DESCRIPTION
## Sprint 8b — last two content audits read `course/`

`accessibility_audit` + `content_representation_audit` now run offline via the loader (syllabus + pages + assignment descriptions), keeping their audit logic untouched.

- `content_representation`: `collect_items_from_course()` mirrors `collect_items`.
- `accessibility`: `audit_course()` takes an optional `local_course`; each source branches API-vs-loader, `audit_html`+aggregation shared.
- Both run with a **bogus token** (zero API calls); verdicts match the live API on DS 250. API mode unchanged.

**Noted limitation:** the local store holds module-organized pages; standalone (non-module) pages arent captured (a `canvas_sync` limitation too), so content audits may see slightly fewer surfaces offline than the API `/pages`. To widen later.

Four audits now read `course/`: `workload`, `syllabus`, `accessibility`, `content_representation`.
