### PR TITLE
docs(offline): Sprint 9 — rewrite offline guides to match reality

### DIFF
--- a/docs/offline_mode.md
+++ b/docs/offline_mode.md
@@ -1,13 +1,32 @@
 # Offline Mode Plan
 **Goal**: Support faculty who cannot use Canvas API tokens (IT policy restriction)
 
-> ⚠️ **This document is partly out of date — see the STATUS & RE-SCOPE header in
-> [offline_mode_sprints.md](./offline_mode_sprints.md) for what actually shipped
-> and the corrected architecture.** Known errors here (full rewrite pending S9):
-> `grade_assignments.py` / `adjust_dates.py` are fictional (real tools:
-> `grader_*`, `imscc_adjust_dates.py`); comments CANNOT ride a gradebook CSV
-> import (Canvas is scores-only); the env var is `CANVAS_API_TOKEN`, not
-> `CANVAS_TOKEN`.
+> ⚠️ **The design notes below this box are the ORIGINAL plan and are partly
+> superseded.** For the user guide see [offline_readme.md](./offline_readme.md);
+> for build status see [offline_mode_sprints.md](./offline_mode_sprints.md).
+>
+> ### What actually shipped (accurate architecture)
+>
+> Tools read a local **`course/`** folder, source-agnostic: `canvas_sync --pull`
+> fills it from the API; **`offline_import`** fills it from a `.imscc`. A tool run
+> with `--local` / `CANVAS_MODE=offline` reads `course/` and makes **zero API
+> calls**. Gradebook workflows use the exported **CSV** (not `course/`).
+>
+> **Tool boundary** (the load-bearing distinction):
+> - **Read/report** (audits, analysis) → run offline against `course/`. ✅
+> - **Content write-back** (`imscc_adjust_dates.py`) → new/empty course only. ⚠️
+> - **Student-specific writes** (SAS accommodations, quiz-time extensions,
+>   late/exempt, submit-on-behalf) → **API-only** — per-student data isn't in a
+>   content export and there's no safe offline write-back. ❌
+> - **Outcomes / analytics** → **API-only** (outcomes are account-level, absent
+>   from exports; page-views/participation are API-only).
+>
+> **Corrections to the notes below:** `grade_assignments.py` / `adjust_dates.py`
+> are **fictional** (real: `grader_*`, `imscc_adjust_dates.py`); comments
+> **cannot** ride a gradebook CSV import (Canvas is scores-only — use
+> `grader_push_comments.py` with a token, else SpeedGrader paste); the env var is
+> **`CANVAS_API_TOKEN`**; helpers live in `lib/tools/`, not `lib/utils/`;
+> the sandbox is `CANVAS_SANDBOX_ID` (427808).
 
 ## Philosophy: Unified Workflow
 

--- a/docs/offline_mode_sprints.md
+++ b/docs/offline_mode_sprints.md
@@ -36,18 +36,24 @@
 > skips **rubrics, learning outcomes, assignment groups**. Tools needing those
 > require the local store to be widened first. Analytics/engagement is API-only.
 >
-> ### Re-scoped remaining sprints
-> - **S5 — Local-read foundation:** `_course_loader.py` (reads `course/` into a
->   model) + convert 1 pilot audit (`workload_audit.py` — needs only assignments)
->   to read local, source-agnostic. Parity-test local-vs-API on sandbox 427808.
-> - **S6 — offline_import:** `.imscc → course/` so offline populates the SAME
->   store. Test the pilot audit on imported DS 250 data.
-> - **S7 — Widen the local store:** pull/store rubrics + outcomes + assignment
->   groups in `canvas_sync` (+ `offline_import`); convert the audits that need
->   them (`grading_structure_audit`, rubric audits).
-> - **S8 — Fan out:** convert remaining content/structure audits to the loader.
-> - **S9 — Remainder + honest docs:** convert remaining local-feasible tools;
->   document what stays API-only; correct `offline_mode.md` / `offline_readme.md`.
+> ### Re-scoped sprints — status
+> - **S5 ✅ (#146)** — `_course_loader.py` + `workload_audit --local`, parity-tested on 427808.
+> - **S6 ✅ (#147, #148)** — `offline_import` (`.imscc → course/`) + 4-course cross-validation.
+> - **S8 ✅ (#149, #150)** — content path (syllabus + descriptions) + 3 content audits
+>   (`syllabus`, `accessibility`, `content_representation`) read `course/`.
+> - **S9 ✅** — honest docs: `offline_readme.md` rewritten; `offline_mode.md` accurate
+>   architecture header; tool boundary documented.
+> - **S7 (pending)** — widen the store: **assignment groups** (needs a group↔assignment
+>   join) and **rubrics** (nested) in `offline_import` (+ optionally `canvas_sync`), then
+>   convert `grading_structure_audit` / `formative_variety_audit` / rubric audits.
+>   **Learning outcomes are API-only** — account-level, `learning_outcomes.xml` empty in a
+>   course export → `clo_quality_audit` stays API-only.
+>
+> ### Tool boundary (decided)
+> - **Read/report** (audits) → offline via `course/`.
+> - **Content write-back** (`imscc_adjust_dates`) → new/empty course only (destructive on live).
+> - **Student-specific writes** (SAS, quiz-time ext, late/exempt, submit-on-behalf) → **API-only**.
+> - **Outcomes / analytics** → **API-only**.
 >
 > ### Doc corrections to fold in at S9
 > - `grade_assignments.py` and `adjust_dates.py` are **fictional** — the real

--- a/docs/offline_readme.md
+++ b/docs/offline_readme.md
@@ -1,514 +1,128 @@
-# Canvas Toolbox - Offline Mode Guide
+# Canvas Toolbox — Offline Mode Guide
 
-**For faculty without API access** - Use Canvas UI downloads + local processing
+**For faculty without a Canvas API token** — work from Canvas UI downloads instead of the API.
 
----
-
-## What is Offline Mode?
-
-Offline mode allows you to use Canvas Toolbox tools **without a Canvas API token**. Instead of connecting directly to Canvas via API, you:
-
-1. **Download** files via Canvas UI (Settings → Export, Grades → Export, etc.)
-2. **Process** locally using Canvas Toolbox tools (same editing workflow)
-3. **Upload** results back to Canvas via UI (Settings → Import, Grades → Import)
-
-**Benefits**:
-- Works when IT restricts API access
-- Faculty-controlled (no permanent API credentials)
-- Same editing workflows (e.g., `_all_comments.md`)
-- FERPA-compliant (automatic de-identification)
-
-**Tradeoffs**:
-- Manual download/upload steps (vs automatic API sync)
-- Some tools require data not available via Canvas UI
-- Slower for bulk operations
+> Rewritten 2026-07-12 to match what actually shipped. Earlier drafts of this
+> guide described tools and flows that don't exist (`grade_assignments.py`,
+> comment upload via gradebook CSV, `CANVAS_TOKEN`). Those are corrected here.
 
 ---
 
-## Quick Start
+## The core idea
 
-### 1. Configure Offline Mode
+Almost every toolbox tool ultimately reads a course into a **local `course/` folder** and works from that. How the folder gets filled is the only thing that changes between online and offline:
+
+```
+online:   canvas_sync --pull   (Canvas API)   ─┐
+                                                ├─►  course/  ─►  tools read course/
+offline:  offline_import  (a .imscc export)    ─┘
+```
+
+A tool run with `--local` (or `CANVAS_MODE=offline`) reads `course/` and makes **zero API calls** — so it needs no token, and it doesn't re-fetch data that's already synced. "Offline" is just "the folder was filled from a `.imscc` instead of the API."
+
+The gradebook workflows are separate (they use the exported CSV, not `course/`) — see below.
+
+---
+
+## What can and can't run offline
+
+| Category | Offline? | Notes |
+|---|---|---|
+| **Read / report** — audits & analysis | ✅ **yes** | Read `course/`, emit a report. Never touch the live course. |
+| **Gradebook** — grades, de-ID, scores → CSV | ✅ **yes** | Work from the exported gradebook CSV; upload via **Grades → Import**. |
+| **Content write-back** — `.imscc` date-shift | ⚠️ **new/empty course only** | Re-importing to a *live* section is destructive; use a new course. |
+| **Student-specific writes** — SAS accommodations, quiz-time extensions, late/exempt, submit-on-behalf | ❌ **API-only** | Per-student data isn't in a content export, and there's no safe offline write-back. Do these in the Canvas UI. |
+| **Learning-outcome & analytics tools** | ❌ **API-only** | Outcomes are account-level (empty in a course export); page-views/participation are API-only. |
+
+**Why the split:** a read-only audit on a slightly-stale local snapshot just produces an out-of-date *report* (re-sync and re-run). A *write* derived from stale data can clobber live changes — and student accommodations were never in the local store to begin with.
+
+---
+
+## Setup
 
 ```bash
-# In your .env file
-CANVAS_MODE=offline  # Enable offline mode
-CANVAS_TOKEN=        # Leave empty (no API token needed)
+# .env
+CANVAS_MODE=offline        # optional — makes --local the default for tools that support it
+CANVAS_API_TOKEN=          # not needed in offline mode
+CANVAS_TIMEZONE=America/Denver   # for DST-correct .imscc date shifting (set your institution's zone)
 ```
 
-### 2. Download Course Data (via Canvas UI)
+The env var is **`CANVAS_API_TOKEN`** (online only). Helpers live in `lib/tools/` (e.g. `_course_loader.py`).
 
-**Course Content** (for course copying, date adjustment):
-- Canvas → Course → Settings → Export Course Content
-- Select: "Common Cartridge (.imscc)"
-- Download: `course_export_145706.imscc` → `~/Downloads/`
+---
 
-**Gradebook** (for grading workflows):
-- Canvas → Grades → Export
-- Select: "Export Entire Gradebook"
-- Download: `grades-145706.csv` → `~/Downloads/`
+## Workflow 1 — Audit a course offline
 
-**Submissions** (for grading individual assignments):
-- Canvas → Assignments → [Assignment Name] → Download Submissions
-- Download: `submissions_123.zip` → `~/Downloads/`
-
-### 3. Run Tools (Same as API Mode)
-
-Tools automatically detect files in `~/Downloads/`:
+**Download:** Canvas → Course → Settings → **Export Course Content** → Common Cartridge (`.imscc`) → `~/Downloads/`.
 
 ```bash
-# Grading workflow
-python lib/tools/grader_fetch.py              # Auto-detects submissions_*.zip
-python lib/tools/grader_grade.py              # Works on local files
-python lib/tools/grader_push.py               # Exports CSV for upload
+# .imscc -> course/
+uv run python lib/tools/offline_import.py --imscc ~/Downloads/<course>.imscc
 
-# Course management
-python lib/tools/canvas_sync.py --import-imscc ~/Downloads/course_export.imscc
-python lib/tools/adjust_dates.py --shift-days 365
-python lib/tools/sync_to_new.py --export-imscc ~/Desktop/course_import.imscc
+# then any converted audit reads course/ (no API):
+uv run python lib/tools/workload_audit.py        --local
+uv run python lib/tools/syllabus_audit.py        --local
+uv run python lib/tools/accessibility_audit.py   --local
+uv run python lib/tools/content_representation_audit.py --local
 ```
 
-### 4. Upload Results (via Canvas UI)
+Converted audits accept `--local` (read `course/`) or `--course-dir <dir>`. With `CANVAS_MODE=offline` set, `--local` is automatic.
 
-**Grades**:
-- Canvas → Grades → Import
-- Upload: `grades-145706-updated.csv`
+**Read-only:** these emit reports and never touch Canvas.
 
-**Course Content**:
-- Canvas → Settings → Import Course Content
-- Upload: `course_import.imscc`
+**Staleness caveat:** the report reflects the `.imscc` you imported (or your last `canvas_sync --pull`), not the live course. Re-export/re-import to refresh.
+
+**Not yet offline** (need data a content export doesn't include or reconstruct yet): `grading_structure_audit`, `formative_variety_audit`, `rubric_quality_audit`, `rubric_coverage_audit` (assignment-group / rubric joins — planned), and `clo_quality_audit` (outcomes are account-level, absent from exports → API-only).
 
 ---
 
-## Workflows
+## Workflow 2 — Grade offline (scores)
 
-### Workflow 1: Grading Assignments (Offline)
-
-**Download** (via Canvas UI):
-```
-1. Grades → Export → grades-145706.csv → ~/Downloads/
-2. Assignments → [Assignment] → Download Submissions → submissions_123.zip → ~/Downloads/
-```
-
-**Process** (using tools):
-```bash
-# Set offline mode
-echo "CANVAS_MODE=offline" >> .env
-
-# Fetch submissions (auto-detects ~/Downloads)
-python lib/tools/grader_fetch.py
-# Output: ✓ Found submissions: ~/Downloads/submissions_123.zip
-# Output: ⚠ Real student data detected - de-identifying...
-
-# Grade locally
-vim course/_all_comments.md  # Edit grades and comments
-
-# Generate upload CSV
-python lib/tools/grader_push.py
-# Output: ✓ Export for upload: ~/Desktop/grades-145706-updated.csv
-```
-
-**Upload** (via Canvas UI):
-```
-Grades → Import → Upload grades-145706-updated.csv
-```
-
-**Result**: Grades and comments updated in Canvas (same as API mode)
-
----
-
-### Workflow 2: Copy Course to New Semester (Offline)
-
-**Download** (via Canvas UI):
-```
-Settings → Export Course Content → .imscc → course_export_145706.imscc → ~/Downloads/
-```
-
-**Process** (using tools):
-```bash
-# Import course content
-python lib/tools/canvas_sync.py --import-imscc ~/Downloads/course_export_145706.imscc
-# Output: ✓ Imported to .canvas/ directory
-
-# Adjust dates for new semester
-python lib/tools/adjust_dates.py --shift-days 365
-
-# Export for new course
-python lib/tools/sync_to_new.py --export-imscc ~/Desktop/course_spring_2027.imscc
-# Output: ✓ Exported to course_spring_2027.imscc
-```
-
-**Upload** (via Canvas UI):
-```
-1. Create new course in Canvas (or use existing empty course)
-2. Settings → Import Course Content → Upload course_spring_2027.imscc
-```
-
-**Result**: New course created with adjusted dates (same as API workflow)
-
----
-
-### Workflow 3: Audit Course Quality (Offline)
-
-**Download** (via Canvas UI):
-```
-Settings → Export Course Content → .imscc → course_export.imscc → ~/Downloads/
-```
-
-**Process** (using tools):
-```bash
-# Import course
-python lib/tools/canvas_sync.py --import-imscc ~/Downloads/course_export.imscc
-
-# Run audits (all work on local data)
-python lib/tools/course_audit.py
-python lib/tools/course_alignment_audit.py
-python lib/tools/accessibility_audit.py
-python lib/tools/rubric_quality_audit.py
-
-# Review reports in course/reports/
-```
-
-**No Upload Needed** - Audits are read-only reports
-
----
-
-## Tool Compatibility Matrix
-
-### ✅ Fully Supported in Offline Mode
-
-These tools work identically in offline mode (with `.imscc` or CSV downloads):
-
-| Tool | Offline Data Source | Notes |
-|------|---------------------|-------|
-| **Grading Tools** |
-| `grader_fetch.py` | `submissions_*.zip` (UI download) | Auto-detects ~/Downloads |
-| `grader_grade.py` | Local files | Works on fetched submissions |
-| `grader_push.py` | Local CSV | Exports CSV for UI upload |
-| `grader_deidentify_*` | Local files | De-ID happens automatically |
-| `grader_reidentify.py` | Local mapping | Re-ID before upload |
-| `fix_group_override_recalc.py` | `grades-*.csv` (UI export) | Recalculates weighted grades |
-| **Course Management** |
-| `canvas_sync.py` | `.imscc` file (UI export) | Use `--import-imscc` flag |
-| `sync_to_new.py` | `.canvas/` directory | Use `--export-imscc` flag |
-| `adjust_dates.py` | Local JSON | No Canvas connection needed |
-| `course_mirror.py` | `.imscc` import/export | Roundtrip via UI |
-| **Auditing Tools** |
-| `course_audit.py` | `.imscc` import | Audits local course data |
-| `course_alignment_audit.py` | `.imscc` import | Checks learning objectives |
-| `accessibility_audit.py` | `.imscc` import | WCAG compliance check |
-| `rubric_quality_audit.py` | `.imscc` import | Rubric analysis |
-| `rubric_coverage_audit.py` | `.imscc` import | CLO coverage |
-| `grading_structure_audit.py` | `.imscc` import | Assignment structure |
-| `content_representation_audit.py` | `.imscc` import | Media balance |
-| `syllabus_audit.py` | `.imscc` import | Syllabus completeness |
-| `workload_audit.py` | `.imscc` import | Student workload analysis |
-| **Utilities** |
-| `deidentify_gradebook.py` | `grades-*.csv` | PII removal |
-| `reidentify_gradebook.py` | De-identified CSV | PII restoration |
-| `export_imscc.py` | `.canvas/` directory | Pack for Canvas import |
-
----
-
-### ⚠️ Partially Supported (Limited Functionality)
-
-These tools work offline but with reduced capabilities:
-
-| Tool | Offline Limitation | Workaround |
-|------|-------------------|------------|
-| `course_engagement_audit.py` | No page views / participation data | Download multiple semester exports for basic trend analysis |
-| `grader_submission_health.py` | No real-time submission status | Use submission timestamps from downloaded ZIP |
-| `module_structure_diff.py` | Requires two .imscc files | Download both courses via UI, import separately |
-
----
-
-### ❌ Not Supported in Offline Mode
-
-These tools require API-only data not available via Canvas UI:
-
-| Tool | Why API Required | Alternative |
-|------|------------------|-------------|
-| **Analytics & Engagement** |
-| `course_engagement_audit.py` (full) | Page views, participation metrics | Use Canvas Analytics UI |
-| `grading_load_audit.py` | Real-time grading workload data | Manual tracking in spreadsheet |
-| **Blueprint Operations** |
-| `blueprint_sync.py` | Blueprint sync requires API | Use Canvas UI for blueprint sync |
-| `blueprint_presync_check.py` | Checks API-only blueprint metadata | Manual verification |
-| `blueprint_exception_report.py` | Blueprint exception tracking | Canvas UI reports |
-| `blueprint_orphan_pages.py` | Cross-course blueprint comparison | Manual comparison |
-| **Student-Specific Modifications** |
-| `apply_sas_accommodations.py` | Per-student accommodation updates | Canvas SAS integration UI |
-| `student_quiz_time_extension.py` | Per-student quiz time adjustments | Canvas quiz settings UI (individual) |
-| `student_late_accommodation.py` | Per-student late exemptions | Canvas assignment settings UI |
-| `exempt_by_date.py` | Per-student assignment exemptions | Canvas gradebook UI (individual) |
-| `submit_on_behalf.py` | Student submission creation | Manual Canvas UI submission |
-| **Real-Time Operations** |
-| `grader_pull_ta_grades.py` | Pull TA grades from API | Use Canvas Gradebook export |
-| `submission_history_fetch.py` | Submission version history | Download submission comments via UI |
-| **Development Tools** |
-| `sandbox_rubric_fixtures.py` | Creates test rubrics via API | Create manually in Canvas |
-| `canvas_api_tool.py` | Direct API access | N/A (API tool) |
-| **Voting/Feature Tools** |
-| `vote_feature.py` | Canvas Community API | Use Canvas Community website |
-| `update_roadmap_votes.py` | GitHub + Canvas integration | Manual updates |
-| `add_roadmap_feature.py` | GitHub issue creation | Use GitHub UI |
-
----
-
-## Data Sources Quick Reference
-
-### What You Can Download via Canvas UI
-
-| Canvas UI Action | File Format | Tools That Use It |
-|------------------|-------------|-------------------|
-| **Settings → Export Course Content** | `.imscc` (ZIP) | `canvas_sync.py`, all audit tools, `sync_to_new.py`, date adjustment tools |
-| **Grades → Export** | `.csv` | `grader_push.py`, `fix_group_override_recalc.py`, de-ID tools |
-| **Assignment → Download Submissions** | `.zip` | `grader_fetch.py`, all `grader_deidentify_*` tools |
-| **Gradebook → Comments** | Included in CSV | `grader_push.py` (comments column) |
-
-**Important**: `.imscc` files include **course-level dates** (assignment due dates, unlock dates, lock dates, module unlock dates). This means you CAN adjust dates for semester copies offline! However, `.imscc` does NOT include **student-specific** accommodations (SAS extensions, individual quiz time, late exemptions).
-
-### What's NOT Available via UI
-
-| Data Type | Why API Required | Impact |
-|-----------|------------------|--------|
-| **Page Views** | Analytics API only | No engagement tracking |
-| **Participation Metrics** | Analytics API only | No activity tracking |
-| **Submission Version History** | API pagination required | No version comparison |
-| **Real-Time Submission Status** | API polling required | No live tracking |
-| **Blueprint Metadata** | Blueprint API only | No blueprint automation |
-| **Cross-Course Comparisons** | Requires multi-course API access | Manual comparison needed |
-
----
-
-## FERPA Compliance in Offline Mode
-
-### Automatic De-Identification
-
-When you download a gradebook CSV via Canvas UI, it contains **real student names**. Canvas Toolbox automatically de-identifies this data for local work:
-
-**Before De-ID** (as downloaded from Canvas):
-```csv
-Student,ID,SIS User ID,Assignment1,Assignment2
-"Doe, John",12345,sis123,95,88
-"Smith, Jane",12346,sis456,92,90
-```
-
-**After De-ID** (automatic, used for local work):
-```csv
-Student,ID,SIS User ID,Assignment1,Assignment2
-"Student 001",1,sid001,95,88
-"Student 002",2,sid002,92,90
-```
-
-**Re-ID for Upload** (automatic, before Canvas import):
-```csv
-Student,ID,SIS User ID,Assignment1,Assignment2,Comments
-"Doe, John",12345,sis123,95,88,"Great work!"
-"Smith, Jane",12346,sis456,92,90,"Excellent analysis"
-```
-
-### How It Works
-
-1. **Download**: You get real student data from Canvas
-2. **Auto De-ID**: Tool detects PII and de-identifies before local work
-3. **Work Safely**: Edit grades/comments with anonymous data
-4. **Auto Re-ID**: Tool restores real names before export
-5. **Upload**: You upload real student data back to Canvas
-
-**Mapping File**: `.canvas/gradebook/student_mapping.json` (git-ignored)
-
-**No Manual Steps**: De-ID/Re-ID happens automatically when tools detect real names
-
----
-
-## Troubleshooting
-
-### "No data source available"
-
-**Problem**: Tool can't find API token or downloaded files
-
-**Solution**:
-```bash
-# 1. Verify offline mode is set
-grep CANVAS_MODE .env
-# Should show: CANVAS_MODE=offline
-
-# 2. Check for downloaded files
-ls -la ~/Downloads/grades-*.csv
-ls -la ~/Downloads/submissions_*.zip
-ls -la ~/Downloads/*.imscc
-
-# 3. Download via Canvas UI if missing (see Quick Start above)
-```
-
----
-
-### "CSV format not recognized"
-
-**Problem**: Downloaded CSV doesn't match expected Canvas format
-
-**Solution**:
-```bash
-# Ensure you downloaded via "Export Entire Gradebook" (not "Export Current View")
-# Canvas UI: Grades → Actions → Export → Export Entire Gradebook
-```
-
----
-
-### "Real student data detected in export"
-
-**Warning** (not error): Tool is reminding you it will de-identify
-
-**Action**: This is normal. Tool will automatically de-identify before local work.
-
-**Verify**:
-```bash
-# Check that mapping file was created
-ls -la .canvas/gradebook/student_mapping.json
-
-# Verify CSV is de-identified
-head .canvas/gradebook/grades-deidentified.csv
-# Should show "Student 001", not real names
-```
-
----
-
-### "Cannot upload de-identified CSV"
-
-**Problem**: Trying to upload anonymous CSV to Canvas (would fail)
-
-**Solution**: Use the re-identified export:
-```bash
-# Tool automatically creates re-identified CSV
-ls ~/Desktop/grades-*-updated.csv
-
-# Upload this file (has real names restored)
-# Canvas: Grades → Import → Upload grades-*-updated.csv
-```
-
----
-
-### ".imscc file is corrupted or incomplete"
-
-**Problem**: Canvas export failed or file truncated during download
-
-**Solution**:
-```bash
-# 1. Verify file size is reasonable (>1MB for most courses)
-ls -lh ~/Downloads/*.imscc
-
-# 2. Re-export from Canvas
-# Settings → Export Course Content → Wait for email → Download fresh copy
-
-# 3. Verify ZIP is valid
-unzip -t ~/Downloads/course_export.imscc
-```
-
----
-
-## Hybrid Mode (Recommended for Most Faculty)
-
-You don't have to choose all-or-nothing. **Hybrid mode** uses API when available, falls back to CSV when not:
+**Download:** Canvas → **Grades → Export** → `~/Downloads/`.
 
 ```bash
-# .env configuration
-CANVAS_MODE=online       # Use API by default
-CANVAS_TOKEN=<token>     # Keep your token
+# (optional, for sharing) de-identify:
+uv run python lib/tools/grader_deidentify_gradebook.py --input ~/Downloads/<grades>.csv
+
+# apply scores to the gradebook CSV, then re-identify for upload:
+uv run python lib/tools/grader_gradebook_apply.py --scores scores.csv --assignment-id <id> \
+    --gradebook ~/Downloads/<grades>.csv --out ~/Desktop/grades_upload.csv
+uv run python lib/tools/grader_reidentify_gradebook.py --input <deid>.csv --map <map>.json --out upload.csv
 ```
 
-**Benefits**:
-- Fast API operations when IT allows
-- CSV backup workflow when API restricted
-- Smooth transition if IT policy changes
+**Upload:** Canvas → **Grades → Import** → `grades_upload.csv`.
 
-**Example**:
-```bash
-# Normally: API mode (fast)
-python lib/tools/grader_push.py
-# → Uploads via API
-
-# When API blocked: Download CSV manually
-# ~/Downloads/grades-145706.csv
-
-# Tool auto-detects and uses CSV
-python lib/tools/grader_push.py
-# → Exports CSV for manual upload
-```
+**Comments do NOT ride the gradebook CSV** — Canvas gradebook import is scores-only. Offline, use `feedback/_all_comments.md` as a SpeedGrader paste sheet; with a token, `grader_push_comments.py` posts them via the API.
 
 ---
 
-## Migration Path
+## Workflow 3 — Copy a course to a new semester
 
-Faculty can transition gradually:
+**Download** the `.imscc`, then:
 
+```bash
+uv run python lib/tools/imscc_adjust_dates.py --input ~/Downloads/<course>.imscc \
+    --shift-days 364 --out ~/Desktop/next_semester.imscc
 ```
-100% API → Hybrid (API + CSV backup) → 100% Offline
-```
 
-1. **Start with API mode** - Fastest, most convenient
-2. **Try hybrid mode** - Keep API, learn CSV workflow
-3. **Switch to offline if needed** - When IT restricts API
+- Shifts every schedule date, **preserving identifiers** (so a re-import overwrites in place) and **DST-correct** (a Saturday 11:59 PM due date stays Saturday). Use a multiple of **7** (e.g. 364) to keep weekdays.
+- Validates before writing; **import to a NEW/empty course** — re-importing to a live section is destructive.
 
-**No lock-in**: Switch modes anytime by changing `.env`
+---
+
+## FERPA
+
+- De-ID uses stable codes (`deid_code_for`, consistent toolbox-wide); the re-id map lives under `.canvas/` (git-ignored). De-ID tools print counts only, never names.
+- `course/` and gradebook CSVs hold real data — keep them out of git (`.canvas/` is already ignored).
 
 ---
 
 ## FAQ
 
-### Q: Is offline mode slower?
+**Do I need a token?** No — offline audits, gradebook CSV work, and `.imscc` date-shift all run tokenless.
 
-**A**: Download/upload steps add time, but **editing workflows are identical**. Grading 50 students takes the same time whether you use API or CSV.
+**Can I do SAS accommodations offline?** No. They're per-student live writes; do them in the Canvas UI. This is a hard limitation, not a missing feature.
 
-**Overhead**: ~2-5 minutes for download + upload steps per session
+**Is offline data live?** No — it reflects your last export/sync. Re-import to refresh.
 
----
-
-### Q: Can I mix API and CSV workflows?
-
-**A**: Yes! Use hybrid mode. Tools auto-detect data source.
-
----
-
-### Q: Will offline mode work forever?
-
-**A**: Yes, as long as Canvas supports CSV import/export and .imscc format (both are stable, decade-old Canvas features).
-
----
-
-### Q: What if Canvas changes CSV format?
-
-**A**: Tools include format detection and validation. We'll update parsers if Canvas changes formats.
-
----
-
-### Q: Can I still use API mode after setting up offline mode?
-
-**A**: Yes! Just change `CANVAS_MODE=online` in `.env` and tools will use API.
-
----
-
-### Q: Is my data safe in offline mode?
-
-**A**: Yes. De-identification is automatic, mapping files are git-ignored, and PII is only restored at the last moment before Canvas upload.
-
----
-
-## Next Steps
-
-1. **Try offline grading workflow** (Workflow 1 above) - Most common use case
-2. **Test course copy workflow** (Workflow 2 above) - Useful for semester setup
-3. **Run course audits** (Workflow 3 above) - Quality improvement
-4. **Read**: [offline_mode.md](./offline_mode.md) - Technical architecture
-5. **Read**: [offline_mode_sprints.md](./offline_mode_sprints.md) - Implementation plan
-
----
-
-## Support
-
-**Issues**: If a tool doesn't work in offline mode as documented, please report:
-- Tool name
-- Error message
-- Which Canvas UI download you used
-- Your `.env` configuration (without token)
-
-**Feature Requests**: Request offline support for currently API-only tools via GitHub issues.
+**Related:** [offline_mode_sprints.md](./offline_mode_sprints.md) (build status + architecture), [offline_mode.md](./offline_mode.md) (design notes).


### PR DESCRIPTION
Rewrites the offline guides to match what shipped.

- **offline_readme.md** (full rewrite): read-local architecture (`course/` filled by `canvas_sync` OR `offline_import`); the tool boundary (read/report offline; content-write new-course-only; **student-writes + outcomes/analytics API-only**); real tool names/commands; honest limitations.
- **offline_mode.md**: accurate architecture + boundary header; old design notes kept below, marked superseded.
- **offline_mode_sprints.md**: S5/S6/S8/S9 marked done; outcomes recorded as API-only.

Corrects the fictional-tool / comments-via-CSV / `CANVAS_TOKEN` errors. Doc-only.
