### PR TITLE
feat(offline): Sprint 7a — assignment groups + grading_structure_audit reads course/

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -704,6 +704,23 @@ If you build a tool for one of these API categories:
 
 **Filed:** 2026-07-09. See `docs/research/odysseus-2026-07-09.md` for detailed research notes.
 
+- **Catalog CLO importer (API-only write):** with explicit permission, look up a
+  course's catalog Course Learning Outcomes and add them into the Canvas course
+  via a script.
+  - **API-only, by nature.** Outcomes are account/catalog-level and are NOT in a
+    content export (`learning_outcomes.xml` is empty in a `.imscc`), so there is
+    no offline path — this is a live write that must go through the API. It's the
+    complement to the offline-mode work: offline covers read/report + content
+    date-shift; this fills the outcomes gap online.
+  - Design notes: needs a permission gate (writes course outcomes), a catalog
+    source (where do the catalog CLOs live — SIS? a maintained mapping?), and
+    idempotency (don't duplicate outcomes on re-run). Pairs with
+    `clo_quality_audit` (which stays API-only for the same reason).
+  - **Testing bonus:** it would let us seed outcomes into the sandbox (427808)
+    and finally exercise the outcomes path end-to-end (`clo_quality_audit`) —
+    coverage we can't get from a `.imscc` export (outcomes are absent there).
+  - **Filed:** 2026-07-12 during offline-mode S7.
+
 ---
 
 ## References

--- a/lib/tests/test_course_loader.py
+++ b/lib/tests/test_course_loader.py
@@ -38,15 +38,20 @@ def _make_course(root: Path):
     (m / "hw1.json").write_text(json.dumps({
         "canvas_id": 11, "name": "HW 1", "points_possible": 100.0,
         "due_at": "2026-09-05T05:59:00Z", "submission_types": ["online_upload"],
+        "assignment_group_identifierref": "gGRP1",
     }), encoding="utf-8")
     (m / "hw2.json").write_text(json.dumps({
         "canvas_id": 12, "name": "HW 2", "points_possible": 50.0,
         "due_at": "2026-09-12T05:59:00Z", "submission_types": ["online_text_entry"],
+        "assignment_group_identifierref": "gGRP1",
     }), encoding="utf-8")
     (m / "overview.html").write_text("<p>Welcome</p>", encoding="utf-8")
     # a non-gradeable item (external tool) — must NOT count as an assignment
     (m / "tool.json").write_text(json.dumps({"canvas_id": 13, "name": "LTI", "type": "ExternalTool"}), encoding="utf-8")
     (root / "syllabus.html").write_text("<p>Course syllabus here</p>", encoding="utf-8")
+    (root / "_assignment_groups.json").write_text(json.dumps([
+        {"identifier": "gGRP1", "name": "Homework", "group_weight": 100.0, "position": 1},
+    ]), encoding="utf-8")
     return root
 
 
@@ -79,6 +84,16 @@ def test_syllabus_and_pages_bodies(tmp_path):
     assert "Course syllabus here" in c.syllabus()
     pages = c.pages()
     assert any(p["title"] == "overview" and "Welcome" in p["body"] for p in pages)
+
+
+def test_assignment_groups_join(tmp_path):
+    c = load_course(_make_course(tmp_path))
+    groups = c.assignment_groups()
+    assert len(groups) == 1
+    g = groups[0]
+    assert g["name"] == "Homework" and g["group_weight"] == 100.0
+    assert {a["name"] for a in g["assignments"]} == {"HW 1", "HW 2"}   # joined by ref
+    assert c.apply_assignment_group_weights() is True
 
 
 def test_missing_course_raises(tmp_path):

--- a/lib/tests/test_offline_import.py
+++ b/lib/tests/test_offline_import.py
@@ -50,9 +50,14 @@ def _make_imscc(path: Path):
             "<assignment><title>HW 1</title><workflow_state>published</workflow_state>"
             "<points_possible>100.0</points_possible><due_at>2026-09-05T05:59:00</due_at>"
             "<submission_types>online_upload,online_text_entry</submission_types>"
+            "<assignment_group_identifierref>gGRP1</assignment_group_identifierref>"
             "<grading_type>points</grading_type></assignment>",
         "gAAA/hw-1.html": "<p>Read chapter 1 and submit.</p>",     # assignment description body
         "course_settings/syllabus.html": "<h1>Syllabus</h1><p>Grading policy...</p>",
+        "course_settings/assignment_groups.xml":
+            '<assignmentGroups><assignmentGroup identifier="gGRP1">'
+            "<title>Homework</title><position>1</position><group_weight>100.0</group_weight>"
+            "</assignmentGroup></assignmentGroups>",
         "gBBB/assessment_meta.xml":
             "<quiz><title>Quiz 1</title><points_possible>10.0</points_possible>"
             "<due_at>2026-09-12T05:59:00</due_at><quiz_type>assignment</quiz_type></quiz>",
@@ -175,6 +180,22 @@ def test_accessibility_audit_local_runs(tmp_path):
     r = _run_local_audit(tmp_path, "accessibility_audit.py", "--emit-json")
     assert r.stdout.strip(), r.stderr
     assert isinstance(json.loads(r.stdout), dict)   # ran offline, zero API calls
+
+
+def test_import_captures_assignment_groups(tmp_path):
+    import_imscc(_make_imscc(tmp_path / "c.imscc"), tmp_path / "course")
+    from _course_loader import load_course
+    groups = load_course(tmp_path / "course").assignment_groups()
+    assert any(
+        g["name"] == "Homework" and any(a["name"] == "HW 1" for a in g["assignments"])
+        for g in groups
+    )
+
+
+def test_grading_structure_audit_local_runs(tmp_path):
+    r = _run_local_audit(tmp_path, "grading_structure_audit.py", "--emit-json")
+    assert r.stdout.strip(), r.stderr
+    assert isinstance(json.loads(r.stdout), dict)   # groups joined, ran offline
 
 
 def test_full_pipeline_cross_validation_if_present(tmp_path):

--- a/lib/tests/test_offline_import.py
+++ b/lib/tests/test_offline_import.py
@@ -198,6 +198,36 @@ def test_grading_structure_audit_local_runs(tmp_path):
     assert isinstance(json.loads(r.stdout), dict)   # groups joined, ran offline
 
 
+def test_item_linked_in_two_modules_is_captured_once(tmp_path):
+    # Canvas allows one assignment in several modules (module items are links).
+    # It must be written ONCE, or audits double-count it.
+    mm = ('<modules>'
+          '<module identifier="m1"><title>Week 1</title><workflow_state>active</workflow_state>'
+          '<items><item identifier="i1"><content_type>Assignment</content_type>'
+          '<title>Shared</title><identifierref>gDUP</identifierref></item></items></module>'
+          '<module identifier="m2"><title>Collector</title><workflow_state>active</workflow_state>'
+          '<items><item identifier="i2"><content_type>Assignment</content_type>'
+          '<title>Shared</title><identifierref>gDUP</identifierref></item></items></module>'
+          '</modules>')
+    files = {
+        "imsmanifest.xml": "<manifest><resources></resources></manifest>",
+        "course_settings/course_settings.xml": "<course><title>C</title></course>",
+        "course_settings/module_meta.xml": mm,
+        "gDUP/assignment_settings.xml":
+            "<assignment><title>Shared</title><workflow_state>published</workflow_state>"
+            "<points_possible>10.0</points_possible><submission_types>online_upload</submission_types>"
+            "</assignment>",
+    }
+    src = tmp_path / "dup.imscc"
+    with zipfile.ZipFile(src, "w") as z:
+        for n, content in files.items():
+            z.writestr(n, content)
+    counts = import_imscc(src, tmp_path / "course")
+    assert counts["assignments"] == 1                       # written once, not twice
+    c = load_course(tmp_path / "course")
+    assert len([a for a in c.assignments if a["name"] == "Shared"]) == 1
+
+
 def test_full_pipeline_cross_validation_if_present(tmp_path):
     """Cross-validate the WHOLE offline path — import .imscc -> load -> audit —
     across every real course, fully offline (bogus token = zero API calls)."""

--- a/lib/tools/_course_loader.py
+++ b/lib/tools/_course_loader.py
@@ -85,6 +85,35 @@ class Course:
         ({title, body}). Title is the file slug (identifies the page in reports)."""
         return [{"title": p.stem, "body": p.read_text(encoding="utf-8")} for p in self.page_paths()]
 
+    def assignment_groups(self) -> list[dict]:
+        """Assignment groups with their assignments nested — shaped like an API
+        /assignment_groups?include[]=assignments response. Empty if the local
+        store has no _assignment_groups.json (e.g. an older canvas_sync pull)."""
+        p = self.dir / "_assignment_groups.json"
+        if not p.is_file():
+            return []
+        groups = json.loads(p.read_text(encoding="utf-8"))
+        by_ref: dict[str, list[dict]] = {}
+        for a in self.assignments:
+            ref = a.get("assignment_group_identifierref")
+            if ref:
+                by_ref.setdefault(ref, []).append(a)
+        return [
+            {
+                "id": g.get("identifier"),
+                "name": g.get("name"),
+                "group_weight": g.get("group_weight", 0),
+                "position": g.get("position", 0),
+                "assignments": by_ref.get(g.get("identifier"), []),
+            }
+            for g in groups
+        ]
+
+    def apply_assignment_group_weights(self) -> bool:
+        """Inferred: weighting is on if any group carries a nonzero weight (the
+        .imscc course_settings.xml omits the explicit flag)."""
+        return any((g.get("group_weight") or 0) > 0 for g in self.assignment_groups())
+
 
 def load_course(course_dir=DEFAULT_COURSE_DIR) -> Course:
     """Load course/ into a Course model. Raises CourseNotFound if it isn't

--- a/lib/tools/grading_structure_audit.py
+++ b/lib/tools/grading_structure_audit.py
@@ -547,6 +547,13 @@ def _write_report(path: Path, body: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> int:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -569,35 +576,57 @@ def main() -> int:
                     help="%%-of-points-due-in-last-2-weeks threshold. Default 40.0.")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="Bypass canvas_course_guard advisory for enrolled-course reads.")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    if not CANVAS_API_TOKEN:
-        print("ERROR: CANVAS_API_TOKEN missing from .env.", file=sys.stderr)
-        return 2
-    if not CANVAS_BASE_URL:
-        print("ERROR: CANVAS_BASE_URL missing from .env.", file=sys.stderr)
-        return 2
-
-    course_id = args.course_id or os.environ.get(args.target, "")
-    if not course_id:
-        print(f"ERROR: course ID not found. Pass --course-id <id> or set "
-              f"{args.target} in .env.", file=sys.stderr)
-        return 2
-
-    guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
-                  mode="read", allow_override=args.allow_enrolled, label="audit target")
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    course = _get(f"/courses/{course_id}") or {}
-    if not isinstance(course, dict):
-        print(f"ERROR: couldn't load course {course_id}.", file=sys.stderr)
-        return 2
 
-    groups = _get_paged(f"/courses/{course_id}/assignment_groups",
-                        params={"include[]": "assignments"})
-    if not groups:
-        print(f"ERROR: no assignment groups for course {course_id}.", file=sys.stderr)
-        return 2
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        course_id = str(c.canvas_id or "local")
+        course = {"name": c.name, "apply_assignment_group_weights": c.apply_assignment_group_weights()}
+        groups = c.assignment_groups()
+        if not groups:
+            print("ERROR: no assignment groups in course/ — run offline_import first "
+                  "(canvas_sync doesn't yet store groups locally).", file=sys.stderr)
+            return 2
+    else:
+        if not CANVAS_API_TOKEN:
+            print("ERROR: CANVAS_API_TOKEN missing from .env.", file=sys.stderr)
+            return 2
+        if not CANVAS_BASE_URL:
+            print("ERROR: CANVAS_BASE_URL missing from .env.", file=sys.stderr)
+            return 2
+
+        course_id = args.course_id or os.environ.get(args.target, "")
+        if not course_id:
+            print(f"ERROR: course ID not found. Pass --course-id <id> or set "
+                  f"{args.target} in .env.", file=sys.stderr)
+            return 2
+
+        guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+                      mode="read", allow_override=args.allow_enrolled, label="audit target")
+
+        course = _get(f"/courses/{course_id}") or {}
+        if not isinstance(course, dict):
+            print(f"ERROR: couldn't load course {course_id}.", file=sys.stderr)
+            return 2
+
+        groups = _get_paged(f"/courses/{course_id}/assignment_groups",
+                            params={"include[]": "assignments"})
+        if not groups:
+            print(f"ERROR: no assignment groups for course {course_id}.", file=sys.stderr)
+            return 2
 
     res = audit_structure(
         course, groups,

--- a/lib/tools/offline_import.py
+++ b/lib/tools/offline_import.py
@@ -65,8 +65,10 @@ def _dates_points(xml: str, d: dict) -> None:
 
 def assignment_from_xml(xml: str, published: bool | None) -> dict:
     d = {"name": _field(xml, "title")}
-    ws = _field(xml, "workflow_state")
-    d["published"] = (ws == "published") if ws else bool(published)
+    # Emit workflow_state (API shape) — audits filter on it ("published").
+    ws = _field(xml, "workflow_state") or ("published" if published else "unpublished")
+    d["workflow_state"] = ws
+    d["published"] = (ws == "published")
     st = _field(xml, "submission_types")
     if st is not None:
         d["submission_types"] = [s for s in st.split(",") if s]
@@ -76,17 +78,24 @@ def assignment_from_xml(xml: str, published: bool | None) -> dict:
     ae = _field(xml, "allowed_extensions")
     if ae:
         d["allowed_extensions"] = [e for e in ae.split(",") if e]
+    ref = _field(xml, "assignment_group_identifierref")
+    if ref:
+        d["assignment_group_identifierref"] = ref   # join key for assignment groups
     _dates_points(xml, d)
     return d
 
 
 def quiz_from_xml(xml: str, published: bool | None) -> dict:
     d = {"name": _field(xml, "title"), "submission_types": ["online_quiz"]}
-    ws = _field(xml, "workflow_state")
-    d["published"] = (ws == "published") if ws else bool(published)
+    ws = _field(xml, "workflow_state") or ("published" if published else "unpublished")
+    d["workflow_state"] = ws
+    d["published"] = (ws == "published")
     qt = _field(xml, "quiz_type")
     if qt:
         d["quiz_type"] = qt
+    ref = _field(xml, "assignment_group_identifierref")
+    if ref:
+        d["assignment_group_identifierref"] = ref   # quizzes belong to a group too
     _dates_points(xml, d)
     return d
 
@@ -126,8 +135,24 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
     if syllabus:
         (out / "syllabus.html").write_text(syllabus, encoding="utf-8")
 
+    # Assignment groups (for grading-structure / weighting audits). The group↔
+    # assignment link is assignment_group_identifierref on each assignment.
+    ag = read("course_settings/assignment_groups.xml")
+    if ag:
+        groups = []
+        for m in re.finditer(r'<assignmentGroup\s+identifier="([^"]+)"[^>]*>(.*?)</assignmentGroup>', ag, re.S):
+            gid, body = m.group(1), m.group(2)
+            groups.append({
+                "identifier": gid,
+                "name": _field(body, "title"),
+                "group_weight": float(_field(body, "group_weight") or 0),
+                "position": int(_field(body, "position") or 0),
+            })
+        (out / "_assignment_groups.json").write_text(json.dumps(groups, indent=2), encoding="utf-8")
+
     hrefs = _manifest_hrefs(read("imsmanifest.xml"))
     counts = {"modules": 0, "assignments": 0, "quizzes": 0, "pages": 0}
+    captured: set[str] = set()   # identifierrefs written via modules
 
     mm = read("course_settings/module_meta.xml")
     for mod in re.findall(r"<module\b[^>]*>(.*?)</module>", mm, re.S):
@@ -153,10 +178,12 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
                     data["description"] = read(body)
                 (mod_dir / f"{slugify(it_title)}.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
                 counts["assignments"] += 1
+                captured.add(ref)
             elif ct == "Quizzes::Quiz" and f"{ref}/assessment_meta.xml" in names:
                 data = quiz_from_xml(read(f"{ref}/assessment_meta.xml"), it_pub)
                 (mod_dir / f"{slugify(it_title)}.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
                 counts["quizzes"] += 1
+                captured.add(ref)
             elif ct == "WikiPage" and hrefs.get(ref) in names:
                 (mod_dir / f"{slugify(it_title)}.html").write_text(read(hrefs[ref]), encoding="utf-8")
                 counts["pages"] += 1
@@ -165,6 +192,35 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
             encoding="utf-8",
         )
         counts["modules"] += 1
+
+    # Non-module assignments/quizzes: present in the .imscc but not referenced by
+    # any module (e.g. a standalone graded item). Capture into an "_unfiled"
+    # module so grading/points audits see the full set.
+    unfiled = out / "_unfiled"
+    for n in names:
+        if not (n.endswith("/assignment_settings.xml") or n.endswith("/assessment_meta.xml")):
+            continue
+        rid = n.split("/")[0]
+        if rid in captured:
+            continue
+        captured.add(rid)
+        unfiled.mkdir(parents=True, exist_ok=True)
+        if n.endswith("assignment_settings.xml"):
+            data = assignment_from_xml(read(n), None)
+            body = next((b for b in names if b.startswith(f"{rid}/") and b.endswith(".html")), None)
+            if body:
+                data["description"] = read(body)
+            counts["assignments"] += 1
+        else:
+            data = quiz_from_xml(read(n), None)
+            counts["quizzes"] += 1
+        (unfiled / f"{slugify(data.get('name') or rid)}.json").write_text(
+            json.dumps(data, indent=2), encoding="utf-8")
+    if unfiled.is_dir():
+        (unfiled / "_module.json").write_text(
+            json.dumps({"title": "(unfiled)", "published": False, "items": []}, indent=2),
+            encoding="utf-8")
+
     return counts
 
 

--- a/lib/tools/offline_import.py
+++ b/lib/tools/offline_import.py
@@ -168,7 +168,9 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
             it_title = _field(it, "title") or "item"
             it_pub = _field(it, "workflow_state") == "active"
             item_summaries.append({"title": it_title, "content_type": ct, "identifierref": ref})
-            if not ref:
+            # An item can be linked from several modules — write it ONCE (the
+            # module summaries still reference it), else audits double-count it.
+            if not ref or ref in captured:
                 continue
             if ct == "Assignment" and f"{ref}/assignment_settings.xml" in names:
                 data = assignment_from_xml(read(f"{ref}/assignment_settings.xml"), it_pub)
@@ -187,6 +189,7 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
             elif ct == "WikiPage" and hrefs.get(ref) in names:
                 (mod_dir / f"{slugify(it_title)}.html").write_text(read(hrefs[ref]), encoding="utf-8")
                 counts["pages"] += 1
+                captured.add(ref)
         (mod_dir / "_module.json").write_text(
             json.dumps({"title": title, "published": published, "items": item_summaries}, indent=2),
             encoding="utf-8",


### PR DESCRIPTION
## Sprint 7a — assignment groups + `grading_structure_audit` (EXACT parity)

Widens the local store with **assignment groups** and converts the group-weighting audit.

- **offline_import**: extracts `assignment_groups.xml`; captures `assignment_group_identifierref` (join key) + `workflow_state` on assignments **and** quizzes; captures **non-module** assignments/quizzes into `_unfiled`; and **dedupes items linked in multiple modules** (writes each once; `_module.json` still records membership in every module).
- **_course_loader**: `assignment_groups()` join + `apply_assignment_group_weights()`.
- **grading_structure_audit**: `--local` reads `course/`.

### Parity (DS 250, offline vs live API): **EXACT**
published **63 = 63**, total_points **303.0 = 303.0**, flags **4 = 4**. Runs with a bogus token.

Root cause of the earlier 2%: the 6 "Career Success Certification (Bronze)" steps are each linked in their week module AND a collector module (Canvas allows one assignment in many modules) — the importer was writing a copy per link. Fixed + regression-tested.

Fifth audit converted. Also parks a roadmap idea (catalog CLO importer, API-only).
