### PR TITLE
fix(offline): imscc_adjust_dates blocks only shift-introduced issues + blueprint finding

### DIFF
--- a/lib/agents/knowledge/imscc_format_knowledge.md
+++ b/lib/agents/knowledge/imscc_format_knowledge.md
@@ -331,6 +331,25 @@ Re-importing a **New Quizzes** assessment reverts it to the original — edits d
 update a New Quiz you must duplicate it in Canvas, then import. Flag New Quizzes during
 validation so faculty aren't surprised.
 
+### Blueprint-locked items "shift back" (2026-07-12 finding)
+
+If a course is **associated with a Canvas Blueprint**, blueprint-locked items (commonly
+standardized things like the end-of-course evaluation) get their locked attributes —
+including dates — from the MASTER course. A date-shift + re-import does NOT stick on those
+items: the blueprint sync (or the import itself) overrides the shifted dates with the
+master's, so they **revert / "shift back."** Shifting a locked item is therefore futile as
+well as against policy — **do not touch blueprint-locked items.**
+
+Crucially, **blueprint-lock status is NOT in the `.imscc`** — it's a Canvas-side association,
+not exported content. So `imscc_adjust_dates` (which edits the file) cannot see or skip
+locked items; it shifts every date, and Canvas reverts the locked ones on import. A
+blueprint-aware shift (exclude/flag locked items) would require the **API**
+(`GET /courses/:id/blueprint_subscriptions` / blueprint restrictions), not the export.
+
+Observed: the sandbox's "W13 End-of-Course Evaluation" had `lock_at` 59 seconds before
+`due_at` (a blueprint-set value Canvas tolerates) — which also surfaced that the date
+validator must NOT block on pre-existing source quirks, only on issues a shift introduces.
+
 ### Related gradebook finding (not .imscc, but shapes the offline flow)
 
 Canvas gradebook **CSV import does not carry submission comments** — scores only (open,

--- a/lib/tests/test_imscc.py
+++ b/lib/tests/test_imscc.py
@@ -192,6 +192,26 @@ def test_adjust_cli(tmp_path):
         assert "2026-06-30T05:59:59" in z.read("g1/assignment_settings.xml").decode()
 
 
+def test_adjust_carries_preexisting_issue_without_blocking(tmp_path):
+    # Source already has lock_at seconds before due_at (a quirk Canvas accepts).
+    # A uniform shift preserves it, so it must carry through — not block.
+    bad = ("<assignment><due_at>2026-06-23T05:59:59</due_at>"
+           "<lock_at>2026-06-23T05:59:00</lock_at></assignment>")
+    src = _make_imscc(tmp_path / "src.imscc", extra_xml={"g1/assignment_settings.xml": bad})
+    out = tmp_path / "out.imscc"
+    r = subprocess.run(
+        [sys.executable, str(ADJUST_TOOL), "--input", str(src),
+         "--shift-days", "364", "--utc", "--out", str(out)],
+        capture_output=True, text=True,
+    )
+    assert r.returncode == 0, r.stderr          # NOT blocked by the pre-existing quirk
+    assert out.exists()
+    with zipfile.ZipFile(out) as z:
+        x = z.read("g1/assignment_settings.xml").decode()
+        assert "2027-06-22T05:59:59" in x        # due_at shifted +364
+        assert "2027-06-22T05:59:00" in x        # lock_at shifted equally (quirk preserved)
+
+
 # --- integration: real exports (gated, cross-course) -----------------------
 
 def test_real_imscc_validate_and_shift_if_present(tmp_path):
@@ -199,7 +219,6 @@ def test_real_imscc_validate_and_shift_if_present(tmp_path):
     if not reals:
         pytest.skip("no real *_export.imscc in ~/Downloads — integration skipped")
     for real in reals:
-        assert validate_imscc(real) == [], f"{real.name} should validate clean"
         out = tmp_path / f"shift_{real.name}"
         n = adjust_dates_in_imscc(real, out, 365, tz=_DENVER)  # DST-correct path on real data
         assert n > 0
@@ -207,7 +226,9 @@ def test_real_imscc_validate_and_shift_if_present(tmp_path):
         with zipfile.ZipFile(real) as za, zipfile.ZipFile(out) as zb:
             assert manifest_resource_identifiers(za.read("imsmanifest.xml").decode("utf-8", "ignore")) == \
                    manifest_resource_identifiers(zb.read("imsmanifest.xml").decode("utf-8", "ignore"))
-        assert validate_imscc(out) == []  # output still clean
+        # the shift must introduce NO new validation issues (real exports may carry
+        # benign pre-existing quirks — e.g. lock_at seconds before due_at)
+        assert set(validate_imscc(out)) <= set(validate_imscc(real))
         # reverse shift restores the original date count
         back = tmp_path / f"back_{real.name}"
         assert adjust_dates_in_imscc(out, back, -365) == n

--- a/lib/tools/imscc_adjust_dates.py
+++ b/lib/tools/imscc_adjust_dates.py
@@ -56,21 +56,27 @@ def main(argv=None) -> int:
     src = args.input or _file_finder.require_imscc()
 
     pre = validate_imscc(src)
-    if pre:
-        print(f"⚠ input has {len(pre)} pre-existing issue(s) (Canvas's, not ours):", file=sys.stderr)
-        for i in pre:
-            print(f"    - {i}", file=sys.stderr)
-
     args.out.parent.mkdir(parents=True, exist_ok=True)
     n = adjust_dates_in_imscc(src, args.out, args.shift_days, tz=tz)
 
+    # Block ONLY on issues the shift introduced — not ones already in the source.
+    # A uniform day-shift preserves date ordering, so pre-existing quirks (e.g. a
+    # lock_at seconds before due_at that Canvas already accepted) carry through
+    # and must not block an otherwise-valid shift.
     post = validate_imscc(args.out)
-    if post:
-        args.out.unlink(missing_ok=True)  # Jidoka: never hand back a broken .imscc
-        print(f"✗ output failed validation ({len(post)} issue(s)) — not written:", file=sys.stderr)
-        for i in post:
+    pre_set = set(pre)
+    new_issues = [i for i in post if i not in pre_set]
+    if new_issues:
+        args.out.unlink(missing_ok=True)  # Jidoka: don't hand back NEW breakage
+        print(f"✗ the shift INTRODUCED {len(new_issues)} validation issue(s) — not written:", file=sys.stderr)
+        for i in new_issues:
             print(f"    - {i}", file=sys.stderr)
         return 2
+    if pre:
+        print(f"⚠ {len(pre)} pre-existing source issue(s) carried through "
+              f"(Canvas already tolerates these):", file=sys.stderr)
+        for i in pre:
+            print(f"    - {i}", file=sys.stderr)
 
     mode = "raw UTC" if args.utc else f"DST-correct ({args.timezone})"
     print(f"✓ shifted {n} dates by {args.shift_days:+d} days [{mode}]")


### PR DESCRIPTION
Fixes `imscc_adjust_dates` to block only on validation issues the **shift introduced**, not pre-existing quirks in the source (a uniform day-shift preserves ordering, so it cannot create constraint violations).

Found on the sandbox: "W13 End-of-Course Evaluation" has `lock_at` 59s before `due_at` (a blueprint-set value Canvas accepts) — the tool was wrongly refusing to write.

Also captures the **blueprint** finding: blueprint-locked items get dates from the master, so a shift+re-import reverts them ("shift back"); and blueprint status isnt in the `.imscc`, so the offline shifter cant skip them (needs the API).
