### PR TITLE
feat(offline): Sprint 7b — rubrics + rubric_quality/rubric_coverage read course/

### DIFF
--- a/lib/tests/test_offline_import.py
+++ b/lib/tests/test_offline_import.py
@@ -51,7 +51,17 @@ def _make_imscc(path: Path):
             "<points_possible>100.0</points_possible><due_at>2026-09-05T05:59:00</due_at>"
             "<submission_types>online_upload,online_text_entry</submission_types>"
             "<assignment_group_identifierref>gGRP1</assignment_group_identifierref>"
+            "<rubric_identifierref>gRUB</rubric_identifierref>"
+            "<rubric_use_for_grading>true</rubric_use_for_grading>"
             "<grading_type>points</grading_type></assignment>",
+        "course_settings/rubrics.xml":
+            '<rubrics><rubric identifier="gRUB"><title>HW Rubric</title>'
+            "<points_possible>10.0</points_possible><criteria><criterion>"
+            "<criterion_id>c1</criterion_id><points>10.0</points>"
+            "<description>Correctness &amp; clarity</description><ratings>"
+            "<rating><id>r1</id><description>Good</description><points>10.0</points></rating>"
+            "<rating><id>r2</id><description>Poor</description><points>0.0</points></rating>"
+            "</ratings></criterion></criteria></rubric></rubrics>",
         "gAAA/hw-1.html": "<p>Read chapter 1 and submit.</p>",     # assignment description body
         "course_settings/syllabus.html": "<h1>Syllabus</h1><p>Grading policy...</p>",
         "course_settings/assignment_groups.xml":
@@ -196,6 +206,24 @@ def test_grading_structure_audit_local_runs(tmp_path):
     r = _run_local_audit(tmp_path, "grading_structure_audit.py", "--emit-json")
     assert r.stdout.strip(), r.stderr
     assert isinstance(json.loads(r.stdout), dict)   # groups joined, ran offline
+
+
+def test_import_attaches_rubric_with_entities_decoded(tmp_path):
+    import_imscc(_make_imscc(tmp_path / "c.imscc"), tmp_path / "course")
+    from _course_loader import load_course
+    hw = next(a for a in load_course(tmp_path / "course").assignments if a["name"] == "HW 1")
+    assert hw["use_rubric_for_grading"] is True            # API-shape top-level flag
+    assert len(hw["rubric"]) == 1
+    crit = hw["rubric"][0]
+    assert crit["description"] == "Correctness & clarity"  # &amp; decoded
+    assert crit["points"] == 10.0 and len(crit["ratings"]) == 2
+
+
+def test_rubric_audits_run_local(tmp_path):
+    r1 = _run_local_audit(tmp_path, "rubric_quality_audit.py", "--json")
+    assert r1.stdout.strip() and isinstance(json.loads(r1.stdout), dict), r1.stderr
+    r2 = _run_local_audit(tmp_path, "rubric_coverage_audit.py", "--json")
+    assert r2.stdout.strip() and isinstance(json.loads(r2.stdout), dict), r2.stderr
 
 
 def test_item_linked_in_two_modules_is_captured_once(tmp_path):

--- a/lib/tools/offline_import.py
+++ b/lib/tools/offline_import.py
@@ -26,6 +26,7 @@ USAGE
 from __future__ import annotations
 
 import argparse
+import html
 import json
 import re
 import sys
@@ -47,7 +48,9 @@ def slugify(s: str) -> str:
 
 def _field(xml: str, tag: str):
     m = re.search(rf"<{tag}>([^<]*)</{tag}>", xml)
-    return m.group(1) if m else None
+    # Decode XML entities (&amp; -> &, &lt; -> <, ...) so extracted text matches
+    # what the Canvas API returns (and produces clean slugs).
+    return html.unescape(m.group(1)) if m else None
 
 
 def _dates_points(xml: str, d: dict) -> None:
@@ -81,6 +84,10 @@ def assignment_from_xml(xml: str, published: bool | None) -> dict:
     ref = _field(xml, "assignment_group_identifierref")
     if ref:
         d["assignment_group_identifierref"] = ref   # join key for assignment groups
+    rr = _field(xml, "rubric_identifierref")
+    if rr:
+        d["rubric_identifierref"] = rr              # attached in import (attach_rubric)
+        d["rubric_use_for_grading"] = _field(xml, "rubric_use_for_grading") or "false"
     _dates_points(xml, d)
     return d
 
@@ -98,6 +105,67 @@ def quiz_from_xml(xml: str, published: bool | None) -> dict:
         d["assignment_group_identifierref"] = ref   # quizzes belong to a group too
     _dates_points(xml, d)
     return d
+
+
+def _num(v):
+    try:
+        return float(v)
+    except (TypeError, ValueError):
+        return None
+
+
+def parse_rubrics(xml: str) -> dict:
+    """rubrics.xml -> {rubric_identifier: {id, title, points_possible, criteria}}.
+    Each criterion is API-shaped: {id, description, points, ratings:[{id, description, points}]}."""
+    rubrics = {}
+    for rm in re.finditer(r'<rubric\b[^>]*\bidentifier="([^"]+)"[^>]*>(.*?)</rubric>', xml, re.S):
+        rid, body = rm.group(1), rm.group(2)
+        criteria = []
+        for cm in re.finditer(r"<criterion\b[^>]*>(.*?)</criterion>", body, re.S):
+            cbody = cm.group(1)
+            head = cbody.split("<ratings>")[0]  # criterion's own fields precede its ratings
+            crit = {
+                "id": _field(head, "criterion_id"),
+                "description": _field(head, "description"),
+                "points": _num(_field(head, "points")),
+                "ratings": [],
+            }
+            rblock = re.search(r"<ratings>(.*?)</ratings>", cbody, re.S)
+            if rblock:
+                for rt in re.finditer(r"<rating\b[^>]*>(.*?)</rating>", rblock.group(1), re.S):
+                    rb = rt.group(1)
+                    crit["ratings"].append({
+                        "id": _field(rb, "id"),
+                        "description": _field(rb, "description"),
+                        "points": _num(_field(rb, "points")),
+                    })
+            criteria.append(crit)
+        rubrics[rid] = {
+            "id": rid,
+            "title": _field(body, "title"),
+            "points_possible": _num(_field(body, "points_possible")),
+            "criteria": criteria,
+        }
+    return rubrics
+
+
+def attach_rubric(data: dict, rubrics: dict) -> None:
+    """If an assignment references a rubric, attach it API-shaped: data['rubric']
+    (criteria list) + data['rubric_settings'] (use_rubric_for_grading, ...)."""
+    ref = data.pop("rubric_identifierref", None)
+    use = data.pop("rubric_use_for_grading", "false")
+    if ref and ref in rubrics:
+        r = rubrics[ref]
+        data["rubric"] = r["criteria"]
+        # The API exposes use_rubric_for_grading at the assignment TOP LEVEL
+        # (rubric_coverage_audit reads it there) — mirror that, not just settings.
+        data["use_rubric_for_grading"] = (use == "true")
+        data["rubric_settings"] = {
+            "id": r["id"],
+            "title": r["title"],
+            "points_possible": r["points_possible"],
+            "use_rubric_for_grading": (use == "true"),
+        }
 
 
 def _manifest_hrefs(manifest: str) -> dict:
@@ -150,6 +218,8 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
             })
         (out / "_assignment_groups.json").write_text(json.dumps(groups, indent=2), encoding="utf-8")
 
+    rubrics = parse_rubrics(read("course_settings/rubrics.xml"))  # attached per-assignment below
+
     hrefs = _manifest_hrefs(read("imsmanifest.xml"))
     counts = {"modules": 0, "assignments": 0, "quizzes": 0, "pages": 0}
     captured: set[str] = set()   # identifierrefs written via modules
@@ -174,6 +244,7 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
                 continue
             if ct == "Assignment" and f"{ref}/assignment_settings.xml" in names:
                 data = assignment_from_xml(read(f"{ref}/assignment_settings.xml"), it_pub)
+                attach_rubric(data, rubrics)
                 # description body is a sibling .html in the assignment dir
                 body = next((n for n in names if n.startswith(f"{ref}/") and n.endswith(".html")), None)
                 if body:
@@ -210,6 +281,7 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
         unfiled.mkdir(parents=True, exist_ok=True)
         if n.endswith("assignment_settings.xml"):
             data = assignment_from_xml(read(n), None)
+            attach_rubric(data, rubrics)
             body = next((b for b in names if b.startswith(f"{rid}/") and b.endswith(".html")), None)
             if body:
                 data["description"] = read(body)

--- a/lib/tools/rubric_coverage_audit.py
+++ b/lib/tools/rubric_coverage_audit.py
@@ -426,6 +426,13 @@ def _resolve_course_id(target_env: str, literal: str | None) -> tuple[str, str]:
     return val, f"${target_env}"
 
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> None:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -453,46 +460,58 @@ def main() -> None:
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="(Read-only tool; safety guard is advisory only. "
                          "Flag accepted for symmetry with write tools.)")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    # env check
-    missing: list[str] = []
-    if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://":
-        missing.append("CANVAS_BASE_URL")
-    if not CANVAS_API_TOKEN:
-        missing.append("CANVAS_API_TOKEN")
-    if missing:
-        print("ERROR: Missing required configuration:")
-        for m in missing:
-            print(f"  {m}")
-        print("\nSet these in your .env file.")
-        sys.exit(2)
-
-    course_id, source = _resolve_course_id(args.target, args.course_id)
-    if not course_id:
-        print(f"ERROR: course ID not found via {source}.")
-        print("       Set the env var, or pass --course-id <id> directly.")
-        sys.exit(2)
-
-    # Advisory safety guard (P-LL4 — read-only mode, never blocks)
-    guard.enforce(
-        base_url=CANVAS_BASE_URL,
-        headers=_headers(),
-        course_id=course_id,
-        mode="read",
-        allow_override=args.allow_enrolled,
-        label="audit target",
-    )
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
-    # Fetch course name for the report header
-    course_obj = _get(f"/courses/{course_id}") or {}
-    course_name = (course_obj.get("name") if isinstance(course_obj, dict)
-                   else None) or "<unknown course>"
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+        course_id = str(c.canvas_id or "local")
+        course_name = c.name
+        assignments = c.assignments
+    else:
+        missing: list[str] = []
+        if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://":
+            missing.append("CANVAS_BASE_URL")
+        if not CANVAS_API_TOKEN:
+            missing.append("CANVAS_API_TOKEN")
+        if missing:
+            print("ERROR: Missing required configuration:")
+            for m in missing:
+                print(f"  {m}")
+            print("\nSet these in your .env file.")
+            sys.exit(2)
 
-    # Fetch assignments (with rubric + rubric_settings includes)
-    assignments = list_assignments_with_settings(course_id)
+        course_id, source = _resolve_course_id(args.target, args.course_id)
+        if not course_id:
+            print(f"ERROR: course ID not found via {source}.")
+            print("       Set the env var, or pass --course-id <id> directly.")
+            sys.exit(2)
+
+        guard.enforce(
+            base_url=CANVAS_BASE_URL,
+            headers=_headers(),
+            course_id=course_id,
+            mode="read",
+            allow_override=args.allow_enrolled,
+            label="audit target",
+        )
+
+        course_obj = _get(f"/courses/{course_id}") or {}
+        course_name = (course_obj.get("name") if isinstance(course_obj, dict)
+                       else None) or "<unknown course>"
+        assignments = list_assignments_with_settings(course_id)
     if not assignments:
         # Always to stderr — stdout reserved for the audit payload (prose or JSON)
         print(f"\nNo assignments returned for course {course_id} "

--- a/lib/tools/rubric_quality_audit.py
+++ b/lib/tools/rubric_quality_audit.py
@@ -868,6 +868,13 @@ def _resolve_course_id(target_env: str, literal: str | None) -> tuple[str, str]:
     return val, f"${target_env}"
 
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> None:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -892,49 +899,60 @@ def main() -> None:
                          "When combined with --report, writes JSON to file.")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="(Read-only tool; guard is advisory only. Accepted for symmetry.)")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    # env check
-    missing: list[str] = []
-    if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://":
-        missing.append("CANVAS_BASE_URL")
-    if not CANVAS_API_TOKEN:
-        missing.append("CANVAS_API_TOKEN")
-    if missing:
-        print("ERROR: Missing required configuration:")
-        for m in missing:
-            print(f"  {m}")
-        print("\nSet these in your .env file.")
-        sys.exit(2)
-
-    course_id, source = _resolve_course_id(args.target, args.course_id)
-    if not course_id:
-        print(f"ERROR: course ID not found via {source}.")
-        print("       Set the env var, or pass --course-id <id> directly.")
-        sys.exit(2)
-
-    # Advisory safety guard (read-only)
-    guard.enforce(
-        base_url=CANVAS_BASE_URL,
-        headers=_headers(),
-        course_id=course_id,
-        mode="read",
-        allow_override=args.allow_enrolled,
-        label="audit target",
-    )
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
-    # Course meta
-    course_obj = _get(f"/courses/{course_id}") or {}
-    course_name = (course_obj.get("name") if isinstance(course_obj, dict)
-                   else None) or "<unknown course>"
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            sys.exit(2)
+        course_id = str(c.canvas_id or "local")
+        course_name = c.name
+        outcomes = []  # outcomes are account-level, not in a .imscc export (API-only)
+        assignments = c.assignments
+    else:
+        missing: list[str] = []
+        if not CANVAS_BASE_URL or CANVAS_BASE_URL == "https://":
+            missing.append("CANVAS_BASE_URL")
+        if not CANVAS_API_TOKEN:
+            missing.append("CANVAS_API_TOKEN")
+        if missing:
+            print("ERROR: Missing required configuration:")
+            for m in missing:
+                print(f"  {m}")
+            print("\nSet these in your .env file.")
+            sys.exit(2)
 
-    # Outcomes (best-effort; empty list means Criterion 1 stays unverified)
-    outcomes = fetch_course_outcomes(course_id)
+        course_id, source = _resolve_course_id(args.target, args.course_id)
+        if not course_id:
+            print(f"ERROR: course ID not found via {source}.")
+            print("       Set the env var, or pass --course-id <id> directly.")
+            sys.exit(2)
 
-    # Assignments + rubrics
-    assignments = list_assignments_with_rubrics(course_id)
+        guard.enforce(
+            base_url=CANVAS_BASE_URL,
+            headers=_headers(),
+            course_id=course_id,
+            mode="read",
+            allow_override=args.allow_enrolled,
+            label="audit target",
+        )
+
+        course_obj = _get(f"/courses/{course_id}") or {}
+        course_name = (course_obj.get("name") if isinstance(course_obj, dict)
+                       else None) or "<unknown course>"
+        outcomes = fetch_course_outcomes(course_id)
+        assignments = list_assignments_with_rubrics(course_id)
     if not assignments:
         # stderr — stdout reserved for the audit payload (prose or JSON)
         print(f"\nNo assignments returned for course {course_id} "


### PR DESCRIPTION
## Sprint 7b — rubrics + both rubric audits read `course/`

- **offline_import**: parses `rubrics.xml` into API-shaped criteria and attaches each to its assignment via `rubric_identifierref` (exposing `rubric`, top-level `use_rubric_for_grading`, `rubric_settings`). Also **decodes XML entities** (`&amp;` -> `&`) so text matches the API.
- **rubric_quality_audit** + **rubric_coverage_audit**: `--local` read from the loader.

### Parity on M 119 (offline vs live API)
- `rubric_coverage`: **EXACT** — has_rubric 0=0, decorative 13=13, total 108=108.
- `rubric_quality`: 12/13 identical; the 1 diff is the **outcomes-dependent Criterion 1**, correctly reported "unverified" offline (outcomes are account-level / API-only) — exactly the gap the parked CLO importer would fill.

7th + 8th audits converted. `formative_variety` (groups) + the student-write poka-yoke remain as optional follow-ups.
