### PR TITLE
feat(offline): outcome parity for rubric_quality --local (removes unverified gap)

### DIFF
--- a/lib/tests/test_course_loader.py
+++ b/lib/tests/test_course_loader.py
@@ -52,6 +52,9 @@ def _make_course(root: Path):
     (root / "_assignment_groups.json").write_text(json.dumps([
         {"identifier": "gGRP1", "name": "Homework", "group_weight": 100.0, "position": 1},
     ]), encoding="utf-8")
+    (root / "_outcomes.json").write_text(json.dumps([
+        {"id": 1, "title": "CLO 1", "description": "Analyze data", "display_name": "CLO 1"},
+    ]), encoding="utf-8")
     return root
 
 
@@ -84,6 +87,20 @@ def test_syllabus_and_pages_bodies(tmp_path):
     assert "Course syllabus here" in c.syllabus()
     pages = c.pages()
     assert any(p["title"] == "overview" and "Welcome" in p["body"] for p in pages)
+
+
+def test_outcomes_from_local_file(tmp_path):
+    c = load_course(_make_course(tmp_path))
+    outs = c.outcomes()
+    assert len(outs) == 1 and outs[0]["title"] == "CLO 1"
+
+
+def test_outcomes_empty_when_absent(tmp_path):
+    # a bare course/ with no _outcomes.json — the offline .imscc case (returns [])
+    root = tmp_path / "bare"
+    root.mkdir()
+    (root / "_course.json").write_text('{"canvas_id": 1, "name": "X"}', encoding="utf-8")
+    assert load_course(root).outcomes() == []
 
 
 def test_assignment_groups_join(tmp_path):

--- a/lib/tools/_course_loader.py
+++ b/lib/tools/_course_loader.py
@@ -114,6 +114,16 @@ class Course:
         .imscc course_settings.xml omits the explicit flag)."""
         return any((g.get("group_weight") or 0) > 0 for g in self.assignment_groups())
 
+    def outcomes(self) -> list[dict]:
+        """Course outcomes ({id, title, description, display_name}) if synced to
+        course/_outcomes.json. `canvas_sync --pull` writes them; a .imscc export
+        has NO outcomes (account-level), so offline_import can't — returns [] then,
+        which is why offline rubric/CLO checks report 'unverified' rather than guess."""
+        p = self.dir / "_outcomes.json"
+        if not p.is_file():
+            return []
+        return json.loads(p.read_text(encoding="utf-8"))
+
 
 def load_course(course_dir=DEFAULT_COURSE_DIR) -> Course:
     """Load course/ into a Course model. Raises CourseNotFound if it isn't

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -683,6 +683,27 @@ def cmd_init():
     }
     _vprint(f"  [syllabus] syllabus.html ({len(syllabus_body)} chars)")
 
+    # Outcomes (course-linked) -> course/_outcomes.json. Lets audits that read
+    # course/ locally (rubric_quality, clo_quality) use outcomes without
+    # re-hitting the API. A .imscc export has NO outcomes (account-level), so a
+    # canvas_sync pull is the only local source — offline stays "unverified".
+    outcome_links = _get(f"/courses/{course_id}/outcome_group_links",
+                         params={"outcome_style": "full", "per_page": 100})
+    outcomes = []
+    if isinstance(outcome_links, list):
+        for ln in outcome_links:
+            o = ln.get("outcome") or {}
+            if o.get("id"):
+                outcomes.append({
+                    "id": o.get("id"),
+                    "title": o.get("title") or "",
+                    "description": o.get("description") or "",
+                    "display_name": o.get("display_name") or "",
+                })
+    if outcomes:
+        (COURSE_DIR / "_outcomes.json").write_text(json.dumps(outcomes, indent=2), encoding="utf-8")
+        _vprint(f"  [outcomes] _outcomes.json ({len(outcomes)} outcomes)")
+
     # Modules
     modules = _get(f"/courses/{course_id}/modules", params={"per_page": 50, "include[]": "items"})
     print(f"Pulling {len(modules)} modules...")

--- a/lib/tools/rubric_quality_audit.py
+++ b/lib/tools/rubric_quality_audit.py
@@ -918,7 +918,20 @@ def main() -> None:
             sys.exit(2)
         course_id = str(c.canvas_id or "local")
         course_name = c.name
-        outcomes = []  # outcomes are account-level, not in a .imscc export (API-only)
+        # Mirror fetch_course_outcomes locally: real outcomes (course/_outcomes.json,
+        # written by canvas_sync --pull) as title+description strings, else the SAME
+        # syllabus-text fallback the API path uses (the syllabus IS in a .imscc, so
+        # this recovers outcomes even fully offline).
+        real = c.outcomes()
+        if real:
+            outcomes = []
+            for o in real:
+                txt = re.sub(r"<[^>]+>", " ",
+                             ((o.get("title") or "") + "  " + (o.get("description") or "")).strip()).strip()
+                if len(txt) >= 12:
+                    outcomes.append(txt)
+        else:
+            outcomes = extract_outcomes(c.syllabus())
         assignments = c.assignments
     else:
         missing: list[str] = []


### PR DESCRIPTION
Removes the "unverified" gap in `rubric_quality --local`.

Mirrors the API`s `fetch_course_outcomes` locally: real outcomes from `course/_outcomes.json` (canvas_sync now pulls them), else the **same syllabus-text fallback** (`extract_outcomes`) — and the syllabus **is** in a `.imscc`, so outcomes are recovered even fully offline.

- `loader.outcomes()` reads `course/_outcomes.json`.
- `canvas_sync --pull`: additive fetch of `/outcome_group_links` -> `course/_outcomes.json`.
- `rubric_quality --local`: real-or-syllabus outcomes as the strings the audit expects.

**Parity on M 119** (0 real Canvas outcomes, 6 in the syllabus): LOCAL now **exactly** matches API — `outcomes=6, heuristic, meets=1, unverified=0, partial=12` (was `meets=0/unverified=1`). Fully offline.
