### PR TITLE
feat(syllabus): make syllabus_audit institution-agnostic (not hardcoded BYUI)

### DIFF
--- a/lib/tests/test_syllabus_audit.py
+++ b/lib/tests/test_syllabus_audit.py
@@ -1,0 +1,56 @@
+"""Tier 1 unit tests — syllabus_audit institution profile (college-agnostic).
+
+Source: lib/tools/syllabus_audit.py — compute_verdict + default_institution.
+The BYUI profile REQUIRES a generative-AI policy for a 'complete' verdict; other
+institutions treat it as advisory (the AI policy is reported but doesn't drive
+the verdict). Institution is inferred from the Canvas host, overridable by
+CANVAS_INSTITUTION / --institution.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+import syllabus_audit as S  # noqa: E402
+
+
+def _all_detected():
+    return [{"label": s["label"], "detected": True} for s in S.REQUIRED_SECTIONS]
+
+
+def test_byui_profile_requires_ai_policy():
+    v, missing = S.compute_verdict(_all_detected(), {"present": False}, 2000,
+                                   ai_policy_required=True)
+    assert v == "incomplete"
+    assert any("AI Policy" in m for m in missing)
+
+
+def test_generic_profile_treats_ai_policy_as_advisory():
+    v, missing = S.compute_verdict(_all_detected(), {"present": False}, 2000,
+                                   ai_policy_required=False)
+    assert v == "complete"
+    assert not any("AI Policy" in m for m in missing)
+
+
+def test_missing_section_fails_regardless_of_profile():
+    secs = _all_detected()
+    secs[0]["detected"] = False
+    for req in (True, False):
+        v, _ = S.compute_verdict(secs, {"present": True}, 2000, ai_policy_required=req)
+        assert v == "incomplete"
+
+
+def test_institution_inferred_from_host(monkeypatch):
+    monkeypatch.delenv("CANVAS_INSTITUTION", raising=False)
+    monkeypatch.setattr(S, "CANVAS_BASE_URL", "https://byui.instructure.com")
+    assert S.default_institution() == "byui"
+    monkeypatch.setattr(S, "CANVAS_BASE_URL", "https://someschool.instructure.com")
+    assert S.default_institution() == "generic"
+
+
+def test_env_overrides_inference(monkeypatch):
+    monkeypatch.setenv("CANVAS_INSTITUTION", "acme")
+    monkeypatch.setattr(S, "CANVAS_BASE_URL", "https://byui.instructure.com")
+    assert S.default_institution() == "acme"

--- a/lib/tools/syllabus_audit.py
+++ b/lib/tools/syllabus_audit.py
@@ -113,6 +113,18 @@ if _raw_url and not _raw_url.startswith("http"):
     _raw_url = "https://" + _raw_url
 CANVAS_BASE_URL = _raw_url
 
+
+def default_institution() -> str:
+    """Institution profile (keeps the audit college-agnostic). CANVAS_INSTITUTION
+    wins; else infer from the Canvas host (byui.instructure.com -> 'byui'); else
+    'generic'. Only the BYUI profile REQUIRES a generative-AI policy for a
+    'complete' verdict — other institutions treat it as advisory."""
+    inst = os.environ.get("CANVAS_INSTITUTION", "").strip().lower()
+    if inst:
+        return inst
+    return "byui" if "byui" in (CANVAS_BASE_URL or "").lower() else "generic"
+
+
 _TIMEOUT = 30
 # Below this many words of real syllabus text we treat the body as effectively
 # empty — the real syllabus is almost certainly a linked page/file we can't see.
@@ -552,15 +564,19 @@ NO_SYLLABUS = "no_syllabus"
 
 
 def compute_verdict(sections: list[dict], ai_policy: dict,
-                    body_words: int) -> tuple[str, list[str]]:
-    """Verdict + the list of human-readable missing items driving it."""
+                    body_words: int, ai_policy_required: bool = True) -> tuple[str, list[str]]:
+    """Verdict + the list of human-readable missing items driving it.
+
+    ai_policy_required is a per-institution profile knob: the BYUI profile
+    REQUIRES a generative-AI statement (drives the verdict); other institutions
+    treat it as advisory (reported but not verdict-driving)."""
     if body_words < _MIN_BODY_WORDS:
         return NO_SYLLABUS, [
             "Syllabus body is empty or near-empty — the real syllabus is likely "
             "a linked Canvas page or file the syllabus_body field doesn't contain."
         ]
     missing = [s["label"] for s in sections if not s["detected"]]
-    if not ai_policy["present"]:
+    if ai_policy_required and not ai_policy["present"]:
         missing.append("AI Policy (REQUIRED — no generative-AI statement detected)")
     return (COMPLETE if not missing else INCOMPLETE), missing
 
@@ -730,9 +746,14 @@ def main() -> None:
                          "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
     ap.add_argument("--course-dir", default=None,
                     help="Local course/ directory to read (implies --local). Default: course")
+    ap.add_argument("--institution", default=None,
+                    help="Institution profile: 'byui' REQUIRES an AI policy for a complete "
+                         "verdict; anything else treats it as advisory. Default: CANVAS_INSTITUTION "
+                         "env, else inferred from the Canvas host, else 'generic'.")
     args = ap.parse_args()
 
     use_local = args.local or bool(args.course_dir) or _is_offline()
+    institution = (args.institution or default_institution()).strip().lower()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
 
     if use_local:
@@ -780,7 +801,8 @@ def main() -> None:
     sections = detect_sections(text)
     ai_policy = detect_ai_policy(text)
     advisory = detect_advisory(text, body)
-    verdict, missing = compute_verdict(sections, ai_policy, body_words)
+    verdict, missing = compute_verdict(sections, ai_policy, body_words,
+                                       ai_policy_required=(institution == "byui"))
 
     # v0.31 — 25-item rubric (run alongside umbrella audit; surfaced when --rubric set)
     rubric_items = detect_rubric_items(text, body)


### PR DESCRIPTION
Makes `syllabus_audit` **college-agnostic**. The required generative-AI-policy gate was a BYUI mandate baked into the verdict; now it is a per-institution profile:

- **BYUI** profile REQUIRES an AI policy for a "complete" verdict (current behavior, preserved).
- **Any other institution** treats the AI policy as advisory (reported, not verdict-driving).

`default_institution()` = `CANVAS_INSTITUTION` env, else inferred from the Canvas host (`byui.instructure.com` -> `byui`), else `generic`; `--institution` overrides. BYU / BYU-Idaho / BYU-Hawaii are distinct — inference keys on `byui` specifically.

6 unit tests.
