### PR TITLE
release: v1.7.0 — offline mode + versioning automation

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,82 @@
+name: version-bump
+
+# Auto-increment the SemVer version on every merged PR (continuous-patch cadence):
+#   - default            -> patch  (3rd position)
+#   - PR label 'minor'   -> minor  (2nd position, resets patch)
+#   - PR label 'major'   -> major  (1st position, resets minor+patch)
+#   - PR label 'no-bump' -> skip   (releases that set the version by hand)
+# Bumps pyproject.toml, commits to main with [skip ci], and pushes a matching tag.
+# See AGENTS.md -> Active Context -> Versioning policy.
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    if: >-
+      github.event.pull_request.merged == true &&
+      !contains(github.event.pull_request.labels.*.name, 'no-bump')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Determine bump level from PR labels
+        id: level
+        env:
+          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+        run: |
+          if [[ " $LABELS " == *" major "* ]]; then
+            echo "level=major" >> "$GITHUB_OUTPUT"
+          elif [[ " $LABELS " == *" minor "* ]]; then
+            echo "level=minor" >> "$GITHUB_OUTPUT"
+          else
+            echo "level=patch" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bump version in pyproject.toml
+        id: bump
+        env:
+          LEVEL: ${{ steps.level.outputs.level }}
+        run: |
+          python - <<'PY'
+          import os, re
+          level = os.environ["LEVEL"]
+          path = "pyproject.toml"
+          text = open(path, encoding="utf-8").read()
+          m = re.search(r'^(version\s*=\s*")(\d+)\.(\d+)\.(\d+)(")', text, re.M)
+          if not m:
+              raise SystemExit("no version = \"X.Y.Z\" line in pyproject.toml")
+          major, minor, patch = int(m.group(2)), int(m.group(3)), int(m.group(4))
+          if level == "major":
+              major, minor, patch = major + 1, 0, 0
+          elif level == "minor":
+              minor, patch = minor + 1, 0
+          else:
+              patch += 1
+          new = f"{major}.{minor}.{patch}"
+          text = text[:m.start()] + m.group(1) + new + m.group(5) + text[m.end():]
+          open(path, "w", encoding="utf-8").write(text)
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"version={new}\n")
+          print(f"bumped ({level}) -> {new}")
+          PY
+
+      - name: Commit + tag
+        env:
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml
+          git commit -m "chore(release): v${VERSION} [skip ci]"
+          git tag "v${VERSION}"
+          git push origin HEAD:main
+          git push origin "v${VERSION}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,7 +366,7 @@ which is the per-version mechanical record). One-line check:
 uv run python canvas-toolbox/lib/tools/grader_fetch.py --version
 ```
 
-If the printed version is behind the latest (currently **v0.50.1**),
+If the printed version is behind the latest (currently **v1.7.0**),
 the upgrade is usually a clean `cd canvas-toolbox && git pull && uv sync`.
 UPGRADING.md flags behavior changes the operator might notice (the
 v0.40+ Test Student exclusion, the v0.41-0.42 push guards, the
@@ -396,6 +396,12 @@ _Last updated: 2026-07-12_
 
 Latest 3 releases only — full detail for every version is in [`CHANGELOG.md`](CHANGELOG.md). On each release, add the new entry on top and rotate the oldest out. Kept to ≤3 entries / ≤100 lines / ≤10k tokens for active development phase (faster HERMES cycle during beta/sprint cadence).
 
+**Versioning policy (2026-07-12):** SemVer with a continuous-patch cadence — every merged PR bumps the **patch** (3rd position); a **minor** (2nd) marks a medium shift (like the v1.7 offline suite); a **major** (1st) a breaking change. Automated by [`.github/workflows/version-bump.yml`](.github/workflows/version-bump.yml) — patch by default, a `minor` / `major` PR label bumps that position, a `no-bump` label skips. Consumers track `main` via `git pull`, so the version is a milestone + drift-detection marker, not a per-merge gate.
+
+### Recent: v1.7 offline mode (v1.7.0, 2026-07-12)
+
+Offline mode: tools read a local `course/` (from `canvas_sync --pull` or `offline_import` of a `.imscc`), running identically online/offline. 7 audits gained `--local` with exact parity (workload / syllabus / accessibility / content_representation / grading_structure / rubric_coverage / rubric_quality); offline foundation (`CANVAS_MODE`; gradebook de-id / re-id / apply; `.imscc` date-shift; the `course/` loader; `offline_import`). Also: `clo_catalog_import` (Kuali catalog → Canvas Outcomes), institution-agnostic `syllabus_audit`, and the Cloudflare Workers migrated out to the `edge-infra` sister repo. Proven both ways that a `.imscc` carries course-owned outcomes (export + import round-trip).
+
 ### Recent: v1.6 course-centric architecture (v1.6.0, 2026-07-07)
 
 Major architecture refactor: course files (.env, AGENTS.md, course/, grading/, handoffs/) now live at course root (DS460/), not inside canvas-toolbox/. cb-init auto-detects subdirectory context and creates files in the right location. Includes v1.5 → v1.6 migration detection for .env relocation. 13-step cb-init (was 9): adds .gitignore creation, canvas-sync --pull, course-level AGENTS.md stub generation, and opt-in handoffs/ directory (--with-handoffs flag). Eliminates multi-course "which canvas-toolbox is this?" confusion. Tools continue to run from course root unchanged. Full backward compatibility for standalone mode.
@@ -404,11 +410,7 @@ Major architecture refactor: course files (.env, AGENTS.md, course/, grading/, h
 
 Active Context had grown into a 182 KB append-only release log (past host-tool read limits). Trimmed to latest 5 entries; full history moved to CHANGELOG. CI guard enforces rotation/size thresholds. Also repaired 25 stale relative links (doc moves + `lib/agents/`).
 
-### Earlier: BYUI SAS accommodation sprint — quiz time + test_reschedule + dispatcher (v0.72.0, 2026-06-26)
-
-Three-item SAS sprint: `student_quiz_time_extension.py` (per-student classic-quiz time multiplier), `--shift-by-days` mode on `student_late_accommodation.py` (test_reschedule), and `apply_sas_accommodations.py` (YAML dispatcher, 4-tier classify, FERPA audit log). +55 tests. New Quizzes (LTI) deferred.
-
-_Earlier releases (v0.71.0 and back) live in the [CHANGELOG](CHANGELOG.md)._
+_Earlier releases (v0.72.0 and back) live in the [CHANGELOG](CHANGELOG.md)._
 
 
 ## Domain Terms

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,35 @@
 
 All notable changes to canvas-toolbox. Format follows [Keep a
 Changelog](https://keepachangelog.com/). Versioning follows [SemVer](https://semver.org/)
-on the `v0.x` line (canonical — see [AGENTS.md → Active Context](AGENTS.md#active-context)
-for the versioning rationale).
+on the `1.x` line — see the **Versioning policy** in [AGENTS.md → Active Context](AGENTS.md#active-context).
 
 For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
 ## [Unreleased]
+
+---
+
+## [1.7.0] — 2026-07-12
+
+**Offline mode — run the whole audit + gradebook + content-package workflow without a Canvas API token.**
+
+Tools now read a local `course/` folder (populated by `canvas_sync --pull` from the API *or* `offline_import` from a `.imscc`), so they run identically online and offline. Online stays the default; `--local` is additive — nothing existing changes.
+
+### Added
+- **Offline foundation:** `CANVAS_MODE` + gradebook-CSV utils + download finders (#141); gradebook **de-identify / re-identify** (#142); **apply-scores** to a gradebook CSV (#143); `.imscc` **date-shift** + validator for a semester copy (#144); the local **`course/` loader** (#146); **`offline_import`** (`.imscc → course/`) (#147); cross-validation of the full `.imscc → course/ → audit` pipeline (#148).
+- **7 audits gained `--local`:** `workload` (#146), `syllabus` (#149), `accessibility` + `content_representation` (#150), `grading_structure` (#152), `rubric_coverage` + `rubric_quality` (#154), with **exact online/offline parity** including outcomes (#155).
+- **`clo_catalog_import`** — pull a course's CLOs from the institution's Kuali catalog and create them as Canvas Outcomes (API-only, guarded, idempotent, text-normalized) (#160).
+- **`syllabus_audit` is institution-agnostic** — BYUI profile via host inference / `CANVAS_INSTITUTION` / `--institution`, not hardcoded (#156).
+
+### Changed
+- **Cloudflare Workers migrated out** to the `edge-infra` sister repo; `canvas-toolbox/infra/` removed and references repointed (the deployed `canvas-toolbox-bugs` worker is unaffected) (#159).
+- Offline guides rewritten to match the shipped architecture (#145, #151); roadmap updates for the CLO importer (#157, #161).
+
+### Fixed
+- `imscc_adjust_dates` blocks only shift-*introduced* issues, not pre-existing source quirks (#153).
+- PUBH field deployment feedback — 5 items (#139).
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.6.1"
+version = "1.7.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What
Cuts **v1.7.0** and establishes automated versioning.

## v1.7.0 — the offline release
Batches the 22 PRs since 1.6.1 into one minor bump (backward-compatible; online stays default): offline mode (7 audits gain `--local` with exact parity; `CANVAS_MODE`/gradebook/`.imscc`/loader/`offline_import` foundation), `clo_catalog_import` (Kuali → Canvas Outcomes), institution-agnostic `syllabus_audit`, and the Cloudflare Workers migration to `edge-infra`. Full entry in `CHANGELOG.md`.

## Versioning automation (Option A)
- **Policy** (in `AGENTS.md` → Active Context): continuous-patch — every merged PR bumps **patch**; `minor`/`major` PR labels bump those; `no-bump` skips.
- **`.github/workflows/version-bump.yml`**: on merge, bumps `pyproject.toml`, commits `[skip ci]`, pushes a `vX.Y.Z` tag. Env-var interpolation (actionlint-clean).
- Fixed stale **0.x** refs (`AGENTS.md` `v0.50.1`, CHANGELOG header) to the **1.x** line.

## Note
Labeled **`no-bump`** so the Action doesn't re-bump the hand-set `1.7.0`. After merge I'll tag `v1.7.0` (+ the missing `v1.6.1`). The Action pushes to `main` directly — if branch protection blocks it, it'll need allowlisting or a PAT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
