### PR TITLE
feat(offline): offline_import parses learning_outcomes.xml -> _outcomes.json

### DIFF
--- a/lib/tests/test_offline_import_outcomes.py
+++ b/lib/tests/test_offline_import_outcomes.py
@@ -1,0 +1,43 @@
+"""Tier 1 — offline_import.parse_learning_outcomes.
+
+Canvas exports course-OWNED outcomes into course_settings/learning_outcomes.xml;
+this parser turns them into canvas_sync's _outcomes.json shape so the loader +
+CLO/alignment audits read a .imscc source and an API pull identically.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+import offline_import as O  # noqa: E402
+
+_XML = """<?xml version="1.0"?>
+<learningOutcomes xmlns="http://canvas.instructure.com/xsd/cccv1p0">
+  <learningOutcome identifier="g126">
+    <title>DS250 CLO 1</title>
+    <description>Use functions &amp; data structures.</description>
+    <calculation_method>standard_decaying_average</calculation_method>
+  </learningOutcome>
+  <learningOutcome identifier="g0e1">
+    <title>DS250 CLO 2</title>
+    <description>Load data.</description>
+  </learningOutcome>
+</learningOutcomes>"""
+
+
+def test_parse_shape_and_entity_unescape():
+    got = O.parse_learning_outcomes(_XML)
+    assert len(got) == 2
+    assert got[0] == {
+        "id": "g126", "title": "DS250 CLO 1",
+        "description": "Use functions & data structures.",  # &amp; unescaped
+        "display_name": "DS250 CLO 1",
+    }
+    assert got[1]["title"] == "DS250 CLO 2"
+
+
+def test_parse_empty_or_absent():
+    assert O.parse_learning_outcomes("") == []
+    assert O.parse_learning_outcomes(None) == []

--- a/lib/tools/_course_loader.py
+++ b/lib/tools/_course_loader.py
@@ -115,10 +115,12 @@ class Course:
         return any((g.get("group_weight") or 0) > 0 for g in self.assignment_groups())
 
     def outcomes(self) -> list[dict]:
-        """Course outcomes ({id, title, description, display_name}) if synced to
-        course/_outcomes.json. `canvas_sync --pull` writes them; a .imscc export
-        has NO outcomes (account-level), so offline_import can't — returns [] then,
-        which is why offline rubric/CLO checks report 'unverified' rather than guess."""
+        """Course outcomes ({id, title, description, display_name}) if present in
+        course/_outcomes.json. `canvas_sync --pull` writes them; `offline_import`
+        also writes them when the .imscc carries course-OWNED outcomes
+        (course_settings/learning_outcomes.xml). Account-level *linked* outcomes
+        aren't exported, so a course whose CLOs are account-linked yields [] offline
+        (audits fall back to the syllabus, or report 'unverified')."""
         p = self.dir / "_outcomes.json"
         if not p.is_file():
             return []

--- a/lib/tools/offline_import.py
+++ b/lib/tools/offline_import.py
@@ -175,6 +175,22 @@ def _manifest_hrefs(manifest: str) -> dict:
     ))
 
 
+def parse_learning_outcomes(lo: str) -> list[dict]:
+    """Parse course_settings/learning_outcomes.xml into canvas_sync's
+    _outcomes.json shape: {id, title, description, display_name}. The id is the
+    cartridge identifier (there is no Canvas numeric id offline). Empty list when
+    the XML is empty/absent — account-level *linked* outcomes aren't exported."""
+    outcomes = []
+    for m in re.finditer(r'<learningOutcome\s+identifier="([^"]+)"[^>]*>(.*?)</learningOutcome>', lo or "", re.S):
+        oid, body = m.group(1), m.group(2)
+        title = _field(body, "title")
+        outcomes.append({
+            "id": oid, "title": title,
+            "description": _field(body, "description"), "display_name": title,
+        })
+    return outcomes
+
+
 def import_imscc(imscc_path, out_dir="course") -> dict:
     """Convert a .imscc into course/. Returns a summary count dict."""
     out = Path(out_dir)
@@ -217,6 +233,16 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
                 "position": int(_field(body, "position") or 0),
             })
         (out / "_assignment_groups.json").write_text(json.dumps(groups, indent=2), encoding="utf-8")
+
+    # Learning outcomes (course-OWNED CLOs). Canvas exports course-level outcomes
+    # into course_settings/learning_outcomes.xml (account-level *linked* outcomes
+    # are NOT exported). Matches canvas_sync's _outcomes.json shape
+    # {id, title, description, display_name} so the loader + CLO/alignment audits
+    # read either source identically. The id is the cartridge identifier — there's
+    # no Canvas numeric id offline, so alignment matches on text, not id.
+    outcomes = parse_learning_outcomes(read("course_settings/learning_outcomes.xml"))
+    if outcomes:
+        (out / "_outcomes.json").write_text(json.dumps(outcomes, indent=2), encoding="utf-8")
 
     rubrics = parse_rubrics(read("course_settings/rubrics.xml"))  # attached per-assignment below
 


### PR DESCRIPTION
## What
`offline_import` now parses `course_settings/learning_outcomes.xml` into `course/_outcomes.json` (canvas_sync's `{id, title, description, display_name}` shape).

## Why
We proved (427808 export → import round-trip) that Canvas *does* carry course-**owned** outcomes in a `.imscc`. So a `.imscc` source can supply authoritative CLOs offline — the unblock for `clo_quality_audit --local` and `course_alignment_audit --local`. Account-level *linked* outcomes still aren't exported (they yield `[]` offline; audits fall back to the syllabus). Also corrects the loader docstring that wrongly claimed a `.imscc` has no outcomes.

## Test
`test_offline_import_outcomes.py` — parse shape + `&amp;` unescape + empty/absent. Live-verified on the real cartridge (5 DS250 CLOs → `_outcomes.json`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
