### PR TITLE
ci: version-bump Action becomes an auto-tagger (branch-protection-safe)

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,11 +1,12 @@
-name: version-bump
+name: version-tag
 
-# Auto-increment the SemVer version on every merged PR (continuous-patch cadence):
-#   - default            -> patch  (3rd position)
-#   - PR label 'minor'   -> minor  (2nd position, resets patch)
-#   - PR label 'major'   -> major  (1st position, resets minor+patch)
-#   - PR label 'no-bump' -> skip   (releases that set the version by hand)
-# Bumps pyproject.toml, commits to main with [skip ci], and pushes a matching tag.
+# Auto-TAG each merged PR from the version in pyproject.toml.
+#
+# Branch protection blocks the bot from committing to `main`, so the version
+# bump rides IN the PR (bump pyproject.toml in the PR itself: patch by default,
+# minor/major for bigger shifts, unchanged for docs-only). On merge this pushes
+# the matching `vX.Y.Z` tag (tags are not branch-protected) — skipping if the tag
+# already exists (e.g. a docs-only PR that didn't bump the version).
 # See AGENTS.md -> Active Context -> Versioning policy.
 
 on:
@@ -17,10 +18,8 @@ permissions:
   contents: write
 
 jobs:
-  bump:
-    if: >-
-      github.event.pull_request.merged == true &&
-      !contains(github.event.pull_request.labels.*.name, 'no-bump')
+  tag:
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,55 +27,17 @@ jobs:
           ref: main
           fetch-depth: 0
 
-      - name: Determine bump level from PR labels
-        id: level
-        env:
-          LABELS: ${{ join(github.event.pull_request.labels.*.name, ' ') }}
+      - name: Tag the merge commit from pyproject version (if the tag is new)
         run: |
-          if [[ " $LABELS " == *" major "* ]]; then
-            echo "level=major" >> "$GITHUB_OUTPUT"
-          elif [[ " $LABELS " == *" minor "* ]]; then
-            echo "level=minor" >> "$GITHUB_OUTPUT"
-          else
-            echo "level=patch" >> "$GITHUB_OUTPUT"
+          ver=$(grep -m1 -oE '[0-9]+\.[0-9]+\.[0-9]+' pyproject.toml)
+          if [ -z "$ver" ]; then
+            echo "::error::no version = \"X.Y.Z\" in pyproject.toml"
+            exit 1
           fi
-
-      - name: Bump version in pyproject.toml
-        id: bump
-        env:
-          LEVEL: ${{ steps.level.outputs.level }}
-        run: |
-          python - <<'PY'
-          import os, re
-          level = os.environ["LEVEL"]
-          path = "pyproject.toml"
-          text = open(path, encoding="utf-8").read()
-          m = re.search(r'^(version\s*=\s*")(\d+)\.(\d+)\.(\d+)(")', text, re.M)
-          if not m:
-              raise SystemExit("no version = \"X.Y.Z\" line in pyproject.toml")
-          major, minor, patch = int(m.group(2)), int(m.group(3)), int(m.group(4))
-          if level == "major":
-              major, minor, patch = major + 1, 0, 0
-          elif level == "minor":
-              minor, patch = minor + 1, 0
-          else:
-              patch += 1
-          new = f"{major}.{minor}.{patch}"
-          text = text[:m.start()] + m.group(1) + new + m.group(5) + text[m.end():]
-          open(path, "w", encoding="utf-8").write(text)
-          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
-              fh.write(f"version={new}\n")
-          print(f"bumped ({level}) -> {new}")
-          PY
-
-      - name: Commit + tag
-        env:
-          VERSION: ${{ steps.bump.outputs.version }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml
-          git commit -m "chore(release): v${VERSION} [skip ci]"
-          git tag "v${VERSION}"
-          git push origin HEAD:main
-          git push origin "v${VERSION}"
+          if git ls-remote --tags origin "refs/tags/v${ver}" | grep -q .; then
+            echo "v${ver} already tagged — nothing to do"
+          else
+            git tag "v${ver}"
+            git push origin "v${ver}"
+            echo "tagged v${ver}"
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,7 +396,7 @@ _Last updated: 2026-07-12_
 
 Latest 3 releases only — full detail for every version is in [`CHANGELOG.md`](CHANGELOG.md). On each release, add the new entry on top and rotate the oldest out. Kept to ≤3 entries / ≤100 lines / ≤10k tokens for active development phase (faster HERMES cycle during beta/sprint cadence).
 
-**Versioning policy (2026-07-12):** SemVer with a continuous-patch cadence — every merged PR bumps the **patch** (3rd position); a **minor** (2nd) marks a medium shift (like the v1.7 offline suite); a **major** (1st) a breaking change. Automated by [`.github/workflows/version-bump.yml`](.github/workflows/version-bump.yml) — patch by default, a `minor` / `major` PR label bumps that position, a `no-bump` label skips. Consumers track `main` via `git pull`, so the version is a milestone + drift-detection marker, not a per-merge gate.
+**Versioning policy (2026-07-13):** SemVer with a continuous-patch cadence — bump `pyproject.toml` **in the PR itself**: **patch** (3rd) by default, **minor** (2nd) for a medium shift (like the v1.7 offline suite), **major** (1st) for a breaking change; a docs-only PR may leave it unchanged. On merge, [`.github/workflows/version-bump.yml`](.github/workflows/version-bump.yml) auto-tags the commit `vX.Y.Z` from `pyproject` (skips if the tag already exists). The bump rides the protected-PR flow — the bot can't commit to `main`, but tags aren't branch-protected. Consumers track `main` via `git pull`, so the version is a milestone + drift-detection marker, not a per-merge gate.
 
 ### Recent: v1.7 offline mode (v1.7.0, 2026-07-12)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.0"
+version = "1.7.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What
Fixes versioning automation to work with `main`'s branch protection (your Option 1).

## Why
The original Action committed the bump to `main` on merge — rejected by branch protection (the bot `GITHUB_TOKEN` can't bypass, even with `enforce_admins:false`).

## Change
- **Bump `pyproject.toml` in the PR itself** (patch default; minor/major for bigger shifts; docs-only may leave it). Rides the normal protected-PR flow.
- **Action auto-TAGS on merge** — reads `pyproject`, pushes `vX.Y.Z` (tags aren't protected), skips if the tag exists.
- AGENTS.md versioning policy updated. Dogfoods the in-PR bump: `1.7.0 → 1.7.1`.

Labeled `no-bump` so the outgoing Action skips this merge; I'll hand-tag `v1.7.1`, and the new auto-tagger runs from the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
