### PR TITLE
feat(offline): formative_variety_audit --local (exact parity)

### DIFF
--- a/lib/tests/test_formative_variety_local.py
+++ b/lib/tests/test_formative_variety_local.py
@@ -1,0 +1,29 @@
+"""Tier 1 — formative_variety_audit offline-parity guard.
+
+The --local path reads `.imscc`-derived dates, which are naive UTC, while the
+API's are tz-aware (`...Z`). `_parse_due_at` coerces naive -> UTC so local and
+online produce byte-identical timestamps (exact --local parity, verified live
+against course 427808).
+"""
+import sys
+from datetime import timezone
+from pathlib import Path
+
+_TOOLS = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS) not in sys.path:
+    sys.path.insert(0, str(_TOOLS))
+
+import formative_variety_audit as F  # noqa: E402
+
+
+def test_parse_due_at_coerces_naive_to_utc():
+    naive = F._parse_due_at("2026-09-20T05:59:00")        # .imscc (naive UTC)
+    aware = F._parse_due_at("2026-09-20T05:59:00Z")       # API (tz-aware)
+    assert naive.tzinfo == timezone.utc
+    assert naive == aware                                  # same instant
+    assert naive.isoformat() == aware.isoformat()          # byte-identical output
+
+
+def test_parse_due_at_none_and_bad():
+    assert F._parse_due_at(None) is None
+    assert F._parse_due_at("not-a-date") is None

--- a/lib/tools/formative_variety_audit.py
+++ b/lib/tools/formative_variety_audit.py
@@ -147,9 +147,12 @@ def _parse_due_at(due_at: str | None) -> datetime | None:
     if not due_at:
         return None
     try:
-        return datetime.fromisoformat(due_at.replace("Z", "+00:00"))
+        dt = datetime.fromisoformat(due_at.replace("Z", "+00:00"))
     except (TypeError, ValueError):
         return None
+    # .imscc dates are naive UTC; the API's are tz-aware. Coerce naive -> UTC so
+    # local and online produce byte-identical timestamps (exact --local parity).
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
 
 
 # ---------------------------------------------------------------------------
@@ -511,6 +514,13 @@ def _write_report(path: Path, body: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> int:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -532,31 +542,56 @@ def main() -> int:
                     help="Number of weeks before a high-weight item to look for formative practice. Default 3.")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="Bypass canvas_course_guard advisory for enrolled-course reads.")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    if not CANVAS_API_TOKEN or not CANVAS_BASE_URL:
-        print("ERROR: CANVAS_API_TOKEN and CANVAS_BASE_URL must be set in .env.", file=sys.stderr)
-        return 2
-    course_id = args.course_id or os.environ.get(args.target, "")
-    if not course_id:
-        print(f"ERROR: course ID not found. Pass --course-id <id> or set {args.target}.",
-              file=sys.stderr)
-        return 2
-
-    guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
-                  mode="read", allow_override=args.allow_enrolled, label="audit target")
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    course = _get(f"/courses/{course_id}") or {}
-    if not isinstance(course, dict):
-        print(f"ERROR: couldn't load course {course_id}.", file=sys.stderr)
-        return 2
 
-    groups = _get_paged(f"/courses/{course_id}/assignment_groups",
-                        params={"include[]": "assignments"})
-    if not groups:
-        print(f"ERROR: no assignment groups for course {course_id}.", file=sys.stderr)
-        return 2
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        course = {
+            "id": c.canvas_id or "local",
+            "name": c.name,
+            "apply_assignment_group_weights": c.apply_assignment_group_weights(),
+        }
+        groups = c.assignment_groups()
+        if not groups:
+            print("ERROR: no assignment groups in course/ — run offline_import (or "
+                  "canvas_sync --pull) first.", file=sys.stderr)
+            return 2
+    else:
+        if not CANVAS_API_TOKEN or not CANVAS_BASE_URL:
+            print("ERROR: CANVAS_API_TOKEN and CANVAS_BASE_URL must be set in .env.", file=sys.stderr)
+            return 2
+        course_id = args.course_id or os.environ.get(args.target, "")
+        if not course_id:
+            print(f"ERROR: course ID not found. Pass --course-id <id> or set {args.target}.",
+                  file=sys.stderr)
+            return 2
+
+        guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+                      mode="read", allow_override=args.allow_enrolled, label="audit target")
+
+        course = _get(f"/courses/{course_id}") or {}
+        if not isinstance(course, dict):
+            print(f"ERROR: couldn't load course {course_id}.", file=sys.stderr)
+            return 2
+
+        groups = _get_paged(f"/courses/{course_id}/assignment_groups",
+                            params={"include[]": "assignments"})
+        if not groups:
+            print(f"ERROR: no assignment groups for course {course_id}.", file=sys.stderr)
+            return 2
 
     records = classify_assignments(course, groups,
                                    low_weight_pct=args.low_weight_pct,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.1"
+version = "1.7.2"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What
`formative_variety_audit` gains `--local` / `--course-dir` — offline parity for the formative-vs-summative audit. Read gap 1 of 6 closed.

## How
- Mirrors the established `use_local` branch (from `grading_structure_audit`): reads `assignment_groups` from the local `course/` loader instead of the API; skips the guard offline.
- **Fix:** `_parse_due_at` coerces naive `.imscc` dates → UTC, so `--local` timestamps byte-match the tz-aware API (the last 1% blocking exact parity).

## Verified
Exact parity vs course **427808** (`offline_import` of its export → `course/` vs the API): verdict `flags_present`, counts `61/0/1/62`, distribution boundaries byte-identical. Unit test guards the date coercion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
