### PR TITLE
feat(offline): course_alignment_audit --local + quiz-rubric attach

### DIFF
--- a/lib/tools/course_alignment_audit.py
+++ b/lib/tools/course_alignment_audit.py
@@ -223,6 +223,27 @@ def pull_module_overviews(course_id: str) -> list[dict]:
     return out
 
 
+def local_module_overviews(course) -> list[dict]:
+    """Offline mirror of pull_module_overviews — module text from the local
+    course/<module>/*.html page bodies (offline_import / canvas_sync --pull).
+
+    The API path merges each module's Page-item bodies; offline the module's
+    pages ARE its <module-slug>/*.html files, so we merge those. The module id
+    is the cartridge slug (no Canvas numeric module id exists offline)."""
+    out: list[dict] = []
+    for pos, m in enumerate(course.modules):
+        html_paths = sorted((course.dir / m.slug).glob("*.html"))
+        text = "\n".join(p.read_text(encoding="utf-8") for p in html_paths)
+        out.append({
+            "id": m.slug,
+            "name": m.title,
+            "position": m.meta.get("position", pos),
+            "text": text,
+            "tokens": _significant_tokens(text),
+        })
+    return out
+
+
 # ---------------------------------------------------------------------------
 # The audit
 # ---------------------------------------------------------------------------
@@ -245,13 +266,21 @@ def audit_alignment(
       }
     """
     # Build outcome lookup
-    outcomes_by_id: dict[int, dict] = {}
+    outcomes_by_id: dict = {}
     for clo in clos:
         oid = clo.get("id")
         if oid is None:
             continue
-        outcomes_by_id[int(oid)] = {
-            "id": int(oid),
+        # Online outcomes carry a Canvas numeric id; local (offline_import) ones
+        # carry the .imscc cartridge identifier (a string like "g126f5..."). Keep
+        # whatever id we have — coerce numerics to int, leave cartridge strings
+        # as-is. Never fabricate a numeric id (there is no Canvas outcome offline).
+        try:
+            oid = int(oid)
+        except (TypeError, ValueError):
+            pass
+        outcomes_by_id[oid] = {
+            "id": oid,
             "text": clo.get("description") or clo.get("display_name") or "",
             "short_description": clo.get("title") or clo.get("short_description") or "",
             "linked_criteria": [],
@@ -502,6 +531,13 @@ def _write_report(path: Path, body: str) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+try:
+    from _canvas_mode import is_offline_mode as _is_offline
+except ImportError:
+    def _is_offline() -> bool:
+        return False
+
+
 def main() -> int:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -520,37 +556,66 @@ def main() -> int:
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="Bypass canvas_course_guard advisory for enrolled-course reads (read is "
                          "advisory anyway; this flag silences the verdict echo).")
+    ap.add_argument("--local", action="store_true",
+                    help="Read the local course/ folder (canvas_sync --pull / offline_import) "
+                         "instead of the Canvas API. Auto-on when CANVAS_MODE=offline.")
+    ap.add_argument("--course-dir", default=None,
+                    help="Local course/ directory to read (implies --local). Default: course")
     args = ap.parse_args()
 
-    if not CANVAS_API_TOKEN:
-        print("ERROR: CANVAS_API_TOKEN missing from .env.", file=sys.stderr)
-        return 2
-    if not CANVAS_BASE_URL:
-        print("ERROR: CANVAS_BASE_URL missing from .env.", file=sys.stderr)
-        return 2
-
-    course_id = args.course_id
-    source = "--course-id"
-    if not course_id:
-        course_id = os.environ.get(args.target, "")
-        source = f"env {args.target}"
-    if not course_id:
-        print(f"ERROR: course ID not found via {source}. Pass --course-id <id>.", file=sys.stderr)
-        return 2
-
-    guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
-                  mode="read", allow_override=args.allow_enrolled, label="audit target")
-
+    use_local = args.local or bool(args.course_dir) or _is_offline()
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
-    course = _get(f"/courses/{course_id}") or {}
-    course_name = (course.get("name") if isinstance(course, dict) else None) or "<unknown course>"
 
-    print(f"[1/3] Fetching course outcomes for {course_id}...", file=sys.stderr)
-    clos = fetch_course_outcomes_structured(course_id)
-    print(f"[2/3] Fetching assignments + rubrics...", file=sys.stderr)
-    assignments = pull_assignments_with_rubrics(course_id)
-    print(f"[3/3] Fetching module overviews (soft-match)...", file=sys.stderr)
-    modules = pull_module_overviews(course_id)
+    if use_local:
+        from _course_loader import load_course, CourseNotFound
+        try:
+            c = load_course(args.course_dir or "course")
+        except CourseNotFound as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        course_id = str(c.canvas_id or "local")
+        course_name = c.name
+        # Outcomes: course/_outcomes.json (offline_import writes course-OWNED CLOs
+        # from learning_outcomes.xml). Shaped {id, title, description, display_name}
+        # exactly like fetch_course_outcomes_structured — but the `id` is the .imscc
+        # cartridge identifier, NOT a Canvas numeric outcome id. Rubric criteria
+        # carry NO learning_outcome_id offline (the .imscc doesn't export the link),
+        # so the deterministic outcome↔criterion linkage cannot be reconstructed
+        # offline: every criterion reads as orphan_criterion and every outcome as
+        # orphan_outcome. This is the correct, honest offline behavior — no id is
+        # fabricated to force a match. The soft module-overview signal still runs.
+        clos = c.outcomes()
+        assignments = c.assignments
+        modules = local_module_overviews(c)
+    else:
+        if not CANVAS_API_TOKEN:
+            print("ERROR: CANVAS_API_TOKEN missing from .env.", file=sys.stderr)
+            return 2
+        if not CANVAS_BASE_URL:
+            print("ERROR: CANVAS_BASE_URL missing from .env.", file=sys.stderr)
+            return 2
+
+        course_id = args.course_id
+        source = "--course-id"
+        if not course_id:
+            course_id = os.environ.get(args.target, "")
+            source = f"env {args.target}"
+        if not course_id:
+            print(f"ERROR: course ID not found via {source}. Pass --course-id <id>.", file=sys.stderr)
+            return 2
+
+        guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+                      mode="read", allow_override=args.allow_enrolled, label="audit target")
+
+        course = _get(f"/courses/{course_id}") or {}
+        course_name = (course.get("name") if isinstance(course, dict) else None) or "<unknown course>"
+
+        print(f"[1/3] Fetching course outcomes for {course_id}...", file=sys.stderr)
+        clos = fetch_course_outcomes_structured(course_id)
+        print(f"[2/3] Fetching assignments + rubrics...", file=sys.stderr)
+        assignments = pull_assignments_with_rubrics(course_id)
+        print(f"[3/3] Fetching module overviews (soft-match)...", file=sys.stderr)
+        modules = pull_module_overviews(course_id)
 
     res = audit_alignment(clos, assignments, modules)
 

--- a/lib/tools/offline_import.py
+++ b/lib/tools/offline_import.py
@@ -103,6 +103,10 @@ def quiz_from_xml(xml: str, published: bool | None) -> dict:
     ref = _field(xml, "assignment_group_identifierref")
     if ref:
         d["assignment_group_identifierref"] = ref   # quizzes belong to a group too
+    rr = _field(xml, "rubric_identifierref")
+    if rr:
+        d["rubric_identifierref"] = rr              # a quiz can carry a rubric too
+        d["rubric_use_for_grading"] = _field(xml, "rubric_use_for_grading") or "false"
     _dates_points(xml, d)
     return d
 
@@ -280,6 +284,7 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
                 captured.add(ref)
             elif ct == "Quizzes::Quiz" and f"{ref}/assessment_meta.xml" in names:
                 data = quiz_from_xml(read(f"{ref}/assessment_meta.xml"), it_pub)
+                attach_rubric(data, rubrics)
                 (mod_dir / f"{slugify(it_title)}.json").write_text(json.dumps(data, indent=2), encoding="utf-8")
                 counts["quizzes"] += 1
                 captured.add(ref)
@@ -315,6 +320,7 @@ def import_imscc(imscc_path, out_dir="course") -> dict:
             counts["assignments"] += 1
         else:
             data = quiz_from_xml(read(n), None)
+            attach_rubric(data, rubrics)
             counts["quizzes"] += 1
         (unfiled / f"{slugify(data.get('name') or rid)}.json").write_text(
             json.dumps(data, indent=2), encoding="utf-8")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.4"
+version = "1.7.5"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What
`course_alignment_audit --local` + a root fix: `offline_import` now attaches rubrics to **quizzes** (not just assignments).

## The quiz-rubric fix (root cause)
A quiz can carry a `rubric_identifierref`, and `rubrics.xml` holds the rubric — but `offline_import` only attached rubrics to *assignments*, so a rubric-bearing quiz showed `has_rubric=False` offline. Fixed. This corrects the quiz's classification across `rubric_coverage` / `rubric_quality` / `course_alignment` — **all conclusions verified unchanged/exact** (the quiz correctly lands in `decorative_rubric` both online and offline).

## Parity
`course_alignment --local`: verdict, outcome analysis, orphan counts, and `criterion_count` (27) are **exact** vs 427808. Residual `--local` vs API diffs are **Canvas identity/ordering metadata only** — numeric ids, `module_location`, bucket list order — which a `.imscc` genuinely can't carry (same inherent class as `module_id`).

## Outcome-id linking (honest limit)
For a course that links rubric criteria to Canvas Outcomes by numeric id, offline can't reconstruct that link (the id isn't exported). 427808 has 0 linked criteria (all orphan) online and offline, so parity holds; documented in-code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
