### PR TITLE
fix(sync): status must report every file push writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.10] — 2026-07-14
+
+**`sync --status` / `--push` now report the course-level files (homepage, syllabus, `_course.json`) they write.** (#172, contributed by @matjmiles)
+
+`cmd_status` diffed only `index["files"]`, but `cmd_push` also writes the homepage, syllabus, and `_course.json` (late_policy) — each tracked under its own index key, all before the "Nothing to push" guard. So `--status` could print "Everything up to date" while `--push` overwrote a live syllabus; and `--push` printed "Nothing to push" even when it had just pushed one. `--status` is the documented pre-push safety check, so under-reporting was the dangerous direction.
+
+### Fixed
+- **`canvas_sync.py`** — `cmd_status` diffs the course-level files via `_special_file_changes` (homepage/syllabus/`course_hash`, gated exactly like push), and `cmd_push`'s summary (`_push_summary`) names what it pushed instead of always saying "Nothing to push". Correctly scoped: it inspects only those three fixed keys, so it never reports the metadata sidecars (`_outcomes.json`, `_index.json`, ExternalUrl sidecars) that #173/#180 keep out of `index["files"]`. Added an integration test driving `cmd_status()` end-to-end (guards the wiring, not just the helper).
+
+---
+
 ## [1.7.9] — 2026-07-13
 
 **`submit_on_behalf` now uses Canvas's real proxy-submission path (GraphQL), not the REST endpoint that 403s on locked assignments.**

--- a/lib/tests/test_canvas_sync_status_course_level.py
+++ b/lib/tests/test_canvas_sync_status_course_level.py
@@ -1,0 +1,77 @@
+"""cmd_status must report every file cmd_push writes.
+
+cmd_status diffed only index["files"]. But cmd_push ALSO writes the homepage,
+the syllabus, and _course.json (late_policy) — each tracked under its own index
+key, each hash-gated independently, and all three BEFORE the "Nothing to push"
+guard.
+
+So on a live course: edit syllabus.html, run --status, get "Everything up to
+date. Nothing to push." — then --push overwrites the live syllabus for enrolled
+students. --status is the documented pre-push safety check, so under-reporting
+is the dangerous direction to be wrong in.
+"""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+TOOLS = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS))
+spec = importlib.util.spec_from_file_location("canvas_sync", TOOLS / "canvas_sync.py")
+canvas_sync = importlib.util.module_from_spec(spec)
+sys.modules["canvas_sync"] = canvas_sync
+spec.loader.exec_module(canvas_sync)
+
+
+def _write(path: Path, text: str) -> str:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return canvas_sync._file_hash(path)
+
+
+def test_no_changes_on_a_freshly_pulled_mirror(tmp_path):
+    home = tmp_path / "homepage.html"
+    syl = tmp_path / "syllabus.html"
+    course = tmp_path / "_course.json"
+    index = {
+        "homepage": {"filepath": str(home), "hash": _write(home, "<p>home</p>")},
+        "syllabus": {"filepath": str(syl), "hash": _write(syl, "<p>syllabus</p>")},
+        "course_hash": _write(course, json.dumps({"late_policy": {}})),
+    }
+    assert canvas_sync._special_file_changes(index, course_path=course) == []
+
+
+def test_detects_edited_syllabus(tmp_path):
+    """The live-course trap: syllabus edited, status must not stay silent."""
+    syl = tmp_path / "syllabus.html"
+    index = {"syllabus": {"filepath": str(syl), "hash": _write(syl, "<p>original</p>")}}
+    syl.write_text("<p>EDITED</p>", encoding="utf-8")
+
+    changes = canvas_sync._special_file_changes(index, course_path=tmp_path / "_course.json")
+
+    assert [label for label, _ in changes] == ["Syllabus"]
+
+
+def test_detects_edited_homepage_and_course(tmp_path):
+    home = tmp_path / "homepage.html"
+    course = tmp_path / "_course.json"
+    index = {
+        "homepage": {"filepath": str(home), "hash": _write(home, "<p>home</p>")},
+        "course_hash": _write(course, json.dumps({"late_policy": {"late_percent": 10}})),
+    }
+    home.write_text("<p>EDITED</p>", encoding="utf-8")
+    course.write_text(json.dumps({"late_policy": {"late_percent": 50}}), encoding="utf-8")
+
+    labels = [label for label, _ in canvas_sync._special_file_changes(index, course_path=course)]
+
+    assert labels == ["Homepage", "Course"]
+
+
+def test_absent_files_are_not_reported(tmp_path):
+    """A mirror with no homepage/syllabus must not report phantom changes."""
+    index = {"homepage": {"filepath": str(tmp_path / "gone.html"), "hash": "abc"}}
+    assert canvas_sync._special_file_changes(index, course_path=tmp_path / "_course.json") == []
+
+
+def test_empty_index_reports_nothing(tmp_path):
+    assert canvas_sync._special_file_changes({}, course_path=tmp_path / "_course.json") == []

--- a/lib/tests/test_canvas_sync_status_course_level.py
+++ b/lib/tests/test_canvas_sync_status_course_level.py
@@ -75,3 +75,29 @@ def test_absent_files_are_not_reported(tmp_path):
 
 def test_empty_index_reports_nothing(tmp_path):
     assert canvas_sync._special_file_changes({}, course_path=tmp_path / "_course.json") == []
+
+
+# --- the same blind spot, on the way out ----------------------------------
+#
+# cmd_push's summary also only counted index["files"], so a run that pushed the
+# syllabus still ended with "Nothing to push — all files match Canvas.":
+#
+#     [Syllabus] course/syllabus.html
+#         OK
+#     Nothing to push — all files match Canvas.
+#
+# Cosmetic, but it makes an operator doubt a write that landed — or re-run the
+# push to "make sure", which is what happened during live verification.
+
+
+def test_push_summary_reports_a_course_level_push():
+    assert canvas_sync._push_summary(["Syllabus"]) == "Pushed 1 course-level file(s): Syllabus"
+
+
+def test_push_summary_lists_every_file_pushed():
+    out = canvas_sync._push_summary(["Homepage", "Course", "Syllabus"])
+    assert out == "Pushed 3 course-level file(s): Homepage, Course, Syllabus"
+
+
+def test_push_summary_still_says_nothing_to_push_when_nothing_was():
+    assert canvas_sync._push_summary([]) == "Nothing to push — all files match Canvas."

--- a/lib/tests/test_canvas_sync_status_course_level.py
+++ b/lib/tests/test_canvas_sync_status_course_level.py
@@ -77,6 +77,35 @@ def test_empty_index_reports_nothing(tmp_path):
     assert canvas_sync._special_file_changes({}, course_path=tmp_path / "_course.json") == []
 
 
+# --- integration: cmd_status() itself must surface the course-level edit ---
+#
+# The tests above exercise the helper in isolation. This one drives cmd_status()
+# end-to-end so the WIRING is covered: a refactor that dropped the
+# `_special_file_changes(index)` call would leave every unit test above green
+# while silently reintroducing the "Everything up to date" false-negative.
+
+
+def test_cmd_status_surfaces_a_course_level_edit(tmp_path, monkeypatch, capsys):
+    # a regular tracked file that is UP TO DATE -> the only change is course-level
+    tracked = tmp_path / "week-1" / "page.html"
+    tracked_hash = _write(tracked, "<p>page</p>")
+    syl = tmp_path / "syllabus.html"
+    index = {
+        "files": {str(tracked): {"hash": tracked_hash, "type": "Page"}},
+        "syllabus": {"filepath": str(syl), "hash": _write(syl, "<p>original</p>")},
+    }
+    syl.write_text("<p>EDITED</p>", encoding="utf-8")  # edited since the index hash
+    monkeypatch.setattr(canvas_sync, "_load_index", lambda: index)
+    monkeypatch.setattr(canvas_sync, "COURSE_DIR", tmp_path)  # for the _course.json default
+
+    canvas_sync.cmd_status()
+    out = capsys.readouterr().out
+
+    assert "course-level" in out                 # the special block fired
+    assert str(syl) in out                       # the edited syllabus is named
+    assert "Everything up to date" not in out    # NOT the dangerous false-negative
+
+
 # --- the same blind spot, on the way out ----------------------------------
 #
 # cmd_push's summary also only counted index["files"], so a run that pushed the

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -1227,6 +1227,22 @@ def _cleanup_stale_files(course_dir: Path, tracked_paths: set, meta_paths: set) 
     return deleted
 
 
+def _push_summary(pushed_course_level: list) -> str:
+    """The line cmd_push prints when no index["files"] entry needed pushing.
+
+    "Nothing to push" was printed unconditionally, so a run that DID push the
+    syllabus still ended with "Nothing to push — all files match Canvas." — the
+    operator had to trust the [Syllabus] OK line over the summary contradicting
+    it. Same root cause as the cmd_status gap: the summary only knew about
+    index["files"], and the course-level files live outside it.
+    """
+    if pushed_course_level:
+        return f"Pushed {len(pushed_course_level)} course-level file(s): " + ", ".join(
+            pushed_course_level
+        )
+    return "Nothing to push — all files match Canvas."
+
+
 def _special_file_changes(index: dict, course_path: Optional[Path] = None) -> list:
     """The files cmd_push writes that do NOT live in index["files"].
 
@@ -1424,6 +1440,12 @@ def cmd_push(target: Optional[str] = None):
     index = _load_index()
     files = index.get("files", {})
 
+    # Course-level files written this run (homepage / _course.json / syllabus).
+    # They live outside index["files"], so the summary below must count them —
+    # otherwise push prints "Nothing to push" in the same breath as pushing the
+    # syllabus, and the operator cannot tell whether the write landed.
+    pushed_course_level: list = []
+
     # Check homepage separately — tracked under index["homepage"], not index["files"]
     homepage_meta = index.get("homepage")
     if homepage_meta and (not target or "homepage" in target):
@@ -1440,6 +1462,7 @@ def cmd_push(target: Optional[str] = None):
                     json={"wiki_page": {"body": body}}, timeout=20)
                 if resp.status_code < 400:
                     index["homepage"]["hash"] = current_hash
+                    pushed_course_level.append("Homepage")
                     print(f"    OK")
                 else:
                     print(f"    FAILED: {resp.text[:200]}")
@@ -1462,6 +1485,7 @@ def cmd_push(target: Optional[str] = None):
                 if resp.status_code in (200, 204):
                     index["course_hash"] = course_hash
                     index["course"] = data
+                    pushed_course_level.append("Course")
                     print(f"    OK (late_policy updated)")
                 else:
                     print(f"    FAILED late_policy: {resp.text[:200]}")
@@ -1483,6 +1507,7 @@ def cmd_push(target: Optional[str] = None):
                           "error": resp.text[:200] if resp.status_code >= 400 else None}
                 if result.get("success"):
                     index["syllabus"]["hash"] = current_hash
+                    pushed_course_level.append("Syllabus")
                     print(f"    OK")
                 else:
                     print(f"    FAILED: {result.get('error')}")
@@ -1501,7 +1526,7 @@ def cmd_push(target: Optional[str] = None):
             push_candidates[filepath_str] = (path, meta)
 
     if not push_candidates:
-        print("Nothing to push — all files match Canvas.")
+        print(_push_summary(pushed_course_level))
         return
 
     # Commit-style log prompt

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -1227,6 +1227,33 @@ def _cleanup_stale_files(course_dir: Path, tracked_paths: set, meta_paths: set) 
     return deleted
 
 
+def _special_file_changes(index: dict, course_path: Optional[Path] = None) -> list:
+    """The files cmd_push writes that do NOT live in index["files"].
+
+    The homepage, the syllabus, and _course.json (late_policy) are tracked under
+    their own index keys and pushed by cmd_push BEFORE its "Nothing to push"
+    guard. cmd_status must diff them too — a status that under-reports what push
+    will do is the dangerous direction to be wrong in on a live course.
+
+    Returns a list of (label, filepath) for whatever is dirty.
+    """
+    course_path = Path(course_path) if course_path is not None else COURSE_DIR / "_course.json"
+    changes = []
+
+    for label, key in (("Homepage", "homepage"), ("Syllabus", "syllabus")):
+        meta = index.get(key)
+        if not meta:
+            continue
+        path = Path(meta["filepath"])
+        if path.exists() and _file_hash(path) != meta.get("hash"):
+            changes.append((label, str(path)))
+
+    if course_path.exists() and _file_hash(course_path) != index.get("course_hash"):
+        changes.append(("Course", str(course_path)))
+
+    return changes
+
+
 def cmd_status():
     """Show which local files differ from what was last synced to Canvas."""
     index = _load_index()
@@ -1248,9 +1275,16 @@ def cmd_status():
         if current_hash != meta.get("hash"):
             changed.append((filepath_str, meta))
 
-    if not changed and not missing:
+    special = _special_file_changes(index)
+
+    if not changed and not missing and not special:
         print("Everything up to date. Nothing to push.")
         return
+
+    if special:
+        print(f"Modified ({len(special)} course-level):")
+        for label, fp in special:
+            print(f"  M  {fp}  [{label}]")
 
     if changed:
         print(f"Modified ({len(changed)} files):")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.9"
+version = "1.7.10"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Summary

`cmd_status` diffs only `index["files"]`, but `cmd_push` **also** writes three course-level files — the homepage, the syllabus, and `_course.json` (late_policy) — each tracked under its own index key, each hash-gated independently, and all three **before** the `Nothing to push` guard.

So `--status` can report "Everything up to date. Nothing to push." while `--push` is poised to overwrite the live syllabus. This is a preview/apply mismatch that fails in the dangerous direction: the documented pre-push safety check under-reports the write.

| File | Index key | Pushed by |
|---|---|---|
| `homepage.html` | `index["homepage"]` | `PUT /courses/:id/pages/:url` |
| `syllabus.html` | `index["syllabus"]` | `PUT /courses/:id` (syllabus_body) |
| `_course.json` | `index["course_hash"]` | `PATCH /courses/:id/late_policy` |

**Reproduce**

1. `--pull` a course
2. edit `course/syllabus.html`
3. `--status` → `Everything up to date. Nothing to push.`
4. `--push` → overwrites the live syllabus

On a live course that's immediately student-visible, and Canvas has no draft state to undo it.

Found while verifying a pull/push workflow against a live course (33 enrolled students). It didn't bite us only because the mirror had just been pulled and every hash matched.

## The fix

`_special_file_changes(index)` diffs the three course-level files. `cmd_status` reports them as `Modified (N course-level)` and gates its up-to-date line on them.

`cmd_push` is **unchanged** — push was correct; status was blind to it.

## Test plan

- Added `lib/tests/test_canvas_sync_status_course_level.py` — 5 tests, written red-then-green against the unfixed code (clean mirror reports nothing; edited syllabus / homepage / `_course.json` each detected; absent files don't produce phantom changes; empty index is safe).
- `uv run pytest lib/tests -q` → **776 passed** (771 on `main` + 5 new). The 7 failures are pre-existing on `main` (`test_install_script.py` executable-bit checks, Windows).
- `uv run ruff check lib/` → clean.
- Verified against a live course by replicating `_file_hash` on the real index: on a clean mirror all three match (status stays quiet); after appending one character to `syllabus.html`, the old code still said "Everything up to date" while the new code reports `M course/syllabus.html [Syllabus]`.

Not exercised via a live `--push` — deliberately, since the whole point is that push would have written to a live course.
