### PR TITLE
fix(sync): protect the whole _*.json metadata class from the pull stale-sweep

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -219,6 +219,7 @@ AI agents working in this repo must follow three core quality principles:
 - Use pre-commit hooks to catch errors
 - Type hints catch errors at write-time
 - Block operations that would create defects
+- **Always run via `uv run`** (`uv run pytest lib/tests -q`, `uv run python lib/tools/...`) — dependencies (`markdownify`, etc.) live in the uv venv; system `python3`/`pytest` will report false failures from missing modules.
 
 **Behavioral trigger**: When manual verification required → Design it out
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.8] — 2026-07-13
+
+**`pull` stale-sweep no longer deletes metadata sidecars — the whole `_*.json` class is now protected.**
+
+Follow-up to #173 (which fixed the ExternalUrl/ExternalTool sidecars). The stale-file sweep in `canvas_sync.py` (`_cleanup_stale_files`) globs `*.json` / `*.html` and deletes anything untracked; it only name-exempted `_module.json`. A `_*.json` at the course root is always a metadata sidecar, never a Canvas content mirror (`<slug>.json` / `<slug>.html`), so the whole class is now exempt. This fixes two live problems:
+
+- **`_outcomes.json` self-deleted on every online pull** — the pull writes it (`canvas_sync.py:704`) but never tracked it, so the sweep removed it in the same run, silently leaving the local mirror without outcomes (broke `--local` CLO audits).
+- **Offline write-path artifacts were exposed** — `offline_import`'s `_index.json` (the `ref→file` map `imscc_record` needs) and `_assignment_groups.json` would be swept if a `pull` ran over an offline-imported `course/`. (`.source.imscc` already survived — `.imscc` isn't globbed; `_course.json` was already protected.)
+
+### Fixed
+- `_cleanup_stale_files` exempts any `_*.json` (subsumes the `_module.json` exemption; keeps `*.questions.json` / `*.newquiz.json` and #173's `meta_paths`). 3 new tests in `test_canvas_sync_metadata_sidecars.py`: `_outcomes.json` survives the sweep, `_index.json` / `_assignment_groups.json` survive, and a genuinely stale non-underscore `<slug>.json` is still deleted.
+
+---
+
 ## [1.7.7] — 2026-07-13
 
 **Offline WRITE — record `course/` edits back into the source `.imscc` faithfully (`imscc_record`).**

--- a/lib/tests/test_canvas_sync_metadata_sidecars.py
+++ b/lib/tests/test_canvas_sync_metadata_sidecars.py
@@ -91,3 +91,47 @@ def test_sidecars_stay_out_of_index_so_push_never_touches_them():
     would try to POST an ExternalUrl/ExternalTool item back to Canvas (L8)."""
     assert "ExternalUrl" in canvas_sync.METADATA_ONLY_TYPES
     assert "ExternalTool" in canvas_sync.METADATA_ONLY_TYPES
+
+
+# --- the _*.json metadata class: same self-delete bug, other sidecars ---------
+
+def test_outcomes_json_written_by_pull_survives_the_sweep(tmp_path):
+    """The pull writes course/_outcomes.json (canvas_sync.py:704) but never adds
+    it to tracked_paths, so the sweep deleted it in the same run — the mirror lost
+    its outcomes (breaking --local CLO audits). As a `_*.json` metadata sidecar it
+    must now survive without needing an index or meta_paths entry."""
+    outcomes = tmp_path / "_outcomes.json"
+    outcomes.write_text(json.dumps([{"id": 1, "title": "CLO 1"}]), encoding="utf-8")
+
+    deleted = canvas_sync._cleanup_stale_files(tmp_path, tracked_paths=set(), meta_paths=set())
+
+    assert deleted == []
+    assert outcomes.exists(), "the pull's own _outcomes.json was deleted in the same run"
+
+
+def test_offline_import_metadata_survives_the_sweep(tmp_path):
+    """offline_import writes _index.json (the ref->file map imscc_record needs)
+    and _assignment_groups.json at the course root. A pull run over an
+    offline-imported course/ must not sweep them, or the offline write path breaks."""
+    names = ("_index.json", "_assignment_groups.json", "_course.json")
+    for name in names:
+        (tmp_path / name).write_text("{}", encoding="utf-8")
+
+    deleted = canvas_sync._cleanup_stale_files(tmp_path, tracked_paths=set(), meta_paths=set())
+
+    assert deleted == []
+    assert all((tmp_path / n).exists() for n in names)
+
+
+def test_non_underscore_stale_json_is_still_swept(tmp_path):
+    """The exemption is scoped to `_*.json` — a real content-mirror file Canvas no
+    longer has (<slug>.json, no leading underscore) must still be deleted."""
+    mod = tmp_path / "week-1"
+    mod.mkdir(parents=True)
+    stale = mod / "old-assignment.json"
+    stale.write_text("{}", encoding="utf-8")
+
+    deleted = canvas_sync._cleanup_stale_files(tmp_path, tracked_paths=set(), meta_paths=set())
+
+    assert deleted == [str(stale)]
+    assert not stale.exists()

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -1200,12 +1200,19 @@ def _cleanup_stale_files(course_dir: Path, tracked_paths: set, meta_paths: set) 
     created them, so the mirror silently omitted every ExternalUrl/ExternalTool
     item. They are Canvas-backed, not stale: protect them here, and let a pull
     that stops writing one (because Canvas dropped it) legitimately sweep it.
+
+    Any `_*.json` is a metadata sidecar, never a Canvas content mirror (which is
+    always <slug>.json / <slug>.html), so the whole class is exempt: _module.json,
+    _course.json, the pull's own _outcomes.json (written but not tracked → it
+    self-deleted every run), and offline_import's _assignment_groups.json /
+    _index.json (the ref->file join map imscc_record needs). A stale such file is
+    simply overwritten or left by its writer, not swept.
     """
     deleted = []
     for ext in ("*.json", "*.html"):
         for f in course_dir.rglob(ext):
-            if f.name == "_module.json":
-                continue
+            if f.name.startswith("_") and f.name.endswith(".json"):
+                continue  # metadata sidecar (see docstring) — never Canvas content
             if f.name.endswith(".questions.json"):
                 continue  # local-only quiz push source — never Canvas-backed
             if f.name.endswith(".newquiz.json"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.7"
+version = "1.7.8"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.2"
+version = "1.7.8"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Protect the whole `_*.json` metadata class from the pull stale-sweep

Follow-up to **#173**. That PR fixed the ExternalUrl/ExternalTool sidecars via a `meta_paths` exemption; reviewing it surfaced that the *same* sweep (`_cleanup_stale_files`) still self-deletes other metadata. It globs `*.json` / `*.html` under `course/` and deletes anything untracked, name-exempting only `_module.json`.

A `_*.json` at the course root is **always** a metadata sidecar, never a Canvas content mirror (content is `<slug>.json` / `<slug>.html`) — so the whole class should be exempt. This closes two live gaps:

1. **`_outcomes.json` self-deleted on every online pull.** The pull writes it ([`canvas_sync.py:704`](lib/tools/canvas_sync.py#L704)) but never adds it to `tracked_paths`, so the sweep removed it in the same run — the local mirror silently lost its outcomes, breaking `--local` CLO audits (`clo_quality_audit`, `course_alignment_audit`). Same bug class as #173, unaddressed by it.
2. **Offline write-path artifacts exposed (from #179).** `offline_import` writes `_index.json` (the `ref→file` map `imscc_record` needs) and `_assignment_groups.json` at the course root; a `pull` over an offline-imported `course/` would sweep both. (`.source.imscc` already survives — `.imscc` isn't globbed; `_course.json` was already explicitly protected.)

### Change
- `_cleanup_stale_files`: exempt any `_*.json` (subsumes the `_module.json` exemption; **keeps** `*.questions.json` / `*.newquiz.json` and #173's `meta_paths` — the ExternalUrl sidecars are `<slug>.json`, not `_`-prefixed).
- `AGENTS.md`: poka-yoke note to always run via `uv run` (deps live in the uv venv; system `python3` reports false missing-module failures).

### Tests / verification
- 3 new tests in `test_canvas_sync_metadata_sidecars.py`: `_outcomes.json` survives the sweep; `_index.json` / `_assignment_groups.json` survive; a genuinely stale **non-underscore** `<slug>.json` is still deleted. All 8 in that file green.
- **End-to-end:** ran the sweep over a real `offline_import`'d m119 `course/` — `_index.json` / `_assignment_groups.json` / `_course.json` / `.source.imscc` all survive, and `imscc_record` still records against the intact index.
- The pull-survival regression tests in this area (`test_sprint2::test_*_survives_pull`, `test_questions_json_survives_pull`, `test_new_quiz_sidecar_survives_pull`) pass under `uv run`.

`1.7.7 → 1.7.8`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
