### PR TITLE
feat(grader): no-opt-out AI-disclosure tag on feedback + README transparency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.12] — 2026-07-15
+
+**Transparency: every AI-drafted feedback comment is now tagged `— AI drafted, instructor reviewed` — default, no opt-out.**
+
+Reframes the README's grading positioning from "the instructor stays the author" (which could read as passing AI-drafted feedback off as solely the instructor's) to honest disclosure, and backs it with a real mechanism so the claim is true, not just stated.
+
+### Added
+- **`append_disclosure_tag`** (`grader_push.py`) — appends `— AI drafted, instructor reviewed` to every AI-drafted feedback comment at send-time, applied by both `grader_push` and `grader_push_comments`. Idempotent (never double-tags on re-push); never invents a tag-only comment on a grade-only push. Honesty cuts both ways: only AI-drafted comments are tagged — a manual `default_comment` or a hand-written note (`submit_on_behalf`) is left alone.
+- New architectural commitment in the README: **AI disclosure, no opt-out.**
+
+### Changed
+- README "Why this exists" / "What changes" reworked: the differentiator is now *honest disclosure of AI-assisted grading*, not who appears as the author.
+
+---
+
 ## [1.7.11] — 2026-07-15
 
 **`syllabus_audit`: comprehensive, evidence-grounded late-work detection.** (#140, by @thiebaudr-lab)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![CI](https://github.com/chaz-clark/canvas-toolbox/actions/workflows/ci.yml/badge.svg)](https://github.com/chaz-clark/canvas-toolbox/actions/workflows/ci.yml) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Python 3.14+](https://img.shields.io/badge/python-3.14+-blue.svg)](https://www.python.org/downloads/)
 
-**FERPA-safe AI-assisted Canvas LMS toolkit. Your voice, your choice, you're always in the loop. Your students' privacy is #1.**
+**FERPA-safe AI-assisted Canvas LMS toolkit. Your voice, your judgment, honestly disclosed — you're always in the loop. Your students' privacy is #1.**
 
 > **This is** how an instructor uses AI as a *tool* — staying the author of everything in Canvas including grades and every word the student reads.
 >
@@ -176,7 +176,7 @@ Three core jobs — jump straight in, or skim the full workflow list further dow
 
 | 🏗️ **Build & revise** | 🔍 **Audit & improve** | ✅ **Grade** |
 |:-:|:-:|:-:|
-| Add or revise modules, assessments, and rubrics in a course you already teach — or design a new one from scratch. Built backward from outcomes, guided by 20+ pedagogical knowledge files. | Run read-only health audits — alignment, accessibility, workload, Title IV UW/UF — and get a prioritized fix list. Nothing changes without your say-so. | Fetch → de-identify → 3-pass consensus → edit in your voice → push, gated end-to-end. The AI never signs its name; you do. |
+| Add or revise modules, assessments, and rubrics in a course you already teach — or design a new one from scratch. Built backward from outcomes, guided by 20+ pedagogical knowledge files. | Run read-only health audits — alignment, accessibility, workload, Title IV UW/UF — and get a prioritized fix list. Nothing changes without your say-so. | Fetch → de-identify → 3-pass consensus → edit in your voice → push, gated end-to-end. You own the judgment; every comment is tagged AI-assisted, human-reviewed. |
 | [Build or improve a course →](#architecting-a-course-with-ai-assistance) | [Audit your course →](#auditing-your-course) | [Grade an assignment →](#grading-an-assignment) |
 
 ---
@@ -240,7 +240,7 @@ The wedge moment is grading. Two faculty teaching the same Canvas course shouldn
 1. **AI does the grading and signs the AI's name to it.** Students see "AI Grader" as the comment author.
 2. **The instructor does every comment by hand.** Doesn't scale past 30 students.
 
-Canvas Toolbox is the third option: **AI-assisted everything where the instructor stays the author.** The agent does the legwork. The instructor reviews and approves. The student sees their professor — not "AI Grader" — as the author of the grade and the words.
+Canvas Toolbox is the third option: **AI-assisted grading you train, review, and disclose.** You train the agent on your own voice, set its boundaries, and review and edit every word — you own the judgment. And students are told plainly that grading is AI-assisted: every comment is tagged as such, so the AI's help is acknowledged, never passed off as solely your own. Personal *and* scalable *and* honest.
 
 ### What changes
 
@@ -248,7 +248,7 @@ Canvas Toolbox is the third option: **AI-assisted everything where the instructo
 |---|---|---|
 | **Editing course content** | Click through Canvas one item at a time | Pull to your computer; edit in any text editor; push back |
 | **Auditing your course** | Hope nothing's broken | 11 read-only audits compose one health report (PDF + MD) |
-| **Grading at scale** | Manual click-through SpeedGrader | FERPA-safe AI-assisted; you stay the author of every word |
+| **Grading at scale** | Manual click-through SpeedGrader | FERPA-safe AI-assisted in your voice; you review and edit every word, and every comment is tagged AI-assisted for students |
 | **Title IV UW/UF reporting** | Manually trawl SpeedGrader + Discussions + Quizzes per student at term-end | One command → classified report in `~/Downloads/`; compliant with 34 CFR 668.22 |
 | **Sharing with another faculty teaching the same course** | Email files; lose track of versions | Bundle + import with voice-preservation built in |
 | **Rolling out a new semester** | Manually copy modules + fix broken IDs | Sync master to Blueprint; Canvas handles section distribution |
@@ -264,6 +264,7 @@ Canvas Toolbox is the third option: **AI-assisted everything where the instructo
 
 - **FERPA two-zone** — the cloud sees opaque keys (`KC1-A1B2C3`). Only the local zone has names. The AI never reads a student name. Files on disk are keyed by `user_id`, never by name.
 - **Voice-preservation** — per-instructor voice files are NEVER copied, exported, or shared between faculty. Your voice is yours alone.
+- **AI disclosure, no opt-out** — every AI-drafted feedback comment posts with `— AI drafted, instructor reviewed` appended. You own the judgment and review/edit the words, but the disclosure itself has no off switch. Students are never led to believe feedback was solely yours when AI drafted it — honesty runs both directions (the tag is only added to AI-drafted comments, never to your own hand-written notes).
 - **Brain-agnostic LLM** — Claude, GPT, Gemini, or local Ollama. You're not locked into a vendor.
 - **Read-only by default for audits** — every audit reports findings; none of them change anything in your Canvas course.
 - **Local files are source of truth** — Canvas is the sync target, not the source. Nothing pushes without your explicit approval.

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -25,6 +25,8 @@ from grader_push import (  # noqa: E402
     validate_grade_for_grading_type,
     is_group_mirror_row,
     filter_group_mirror_rows,
+    append_disclosure_tag,
+    DISCLOSURE_TAG,
 )
 
 
@@ -759,3 +761,31 @@ def test_filter_group_mirror_whitespace_final_grade_treated_as_blank():
     kept, dropped = filter_group_mirror_rows(rows, ctx)
     assert {r["key"] for r in kept} == {"REP"}
     assert {r["key"] for r in dropped} == {"M"}
+
+
+# ---------------------------------------------------------------------------
+# append_disclosure_tag — the no-opt-out AI-disclosure tag on every comment
+# ---------------------------------------------------------------------------
+
+def test_disclosure_tag_appended_to_a_comment():
+    out = append_disclosure_tag("Great work on the SQL joins.")
+    assert out.endswith(DISCLOSURE_TAG)
+    assert out.startswith("Great work on the SQL joins.")
+
+
+def test_disclosure_tag_is_idempotent():
+    """Re-pushing an already-tagged comment must not double-tag it."""
+    once = append_disclosure_tag("Nice analysis.")
+    assert append_disclosure_tag(once) == once
+    assert once.count(DISCLOSURE_TAG) == 1
+
+
+def test_disclosure_tag_not_added_to_empty_or_whitespace():
+    """Never invent a tag-only comment (a grade-only push has no comment)."""
+    assert append_disclosure_tag("") == ""
+    assert append_disclosure_tag("   ") == "   "
+
+
+def test_disclosure_tag_wording_is_honest():
+    """It must say AI *drafted* (not 'assisted') + instructor *reviewed*."""
+    assert DISCLOSURE_TAG == "— AI drafted, instructor reviewed"

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -151,6 +151,25 @@ def comment_for(feedback_file: str) -> str:
     return t.split("## Comment to student", 1)[1].strip()
 
 
+# Transparency disclosure (default, no opt-out): every AI-drafted feedback
+# comment carries this tag so a student always knows the words were drafted by
+# AI and reviewed by their instructor — never passed off as solely the
+# instructor's own. Applied at send-time to the AI-drafted comment only; a
+# manual default_comment (not AI-drafted) is left alone by callers.
+DISCLOSURE_TAG = "— AI drafted, instructor reviewed"
+
+
+def append_disclosure_tag(comment: str) -> str:
+    """Append DISCLOSURE_TAG to an AI-drafted comment. Empty -> unchanged (never
+    invents a tag-only comment); already-tagged -> unchanged (idempotent on
+    re-push)."""
+    if not comment or not comment.strip():
+        return comment
+    if comment.rstrip().endswith(DISCLOSURE_TAG):
+        return comment
+    return f"{comment.rstrip()}\n\n{DISCLOSURE_TAG}"
+
+
 # Issue #72: HOLD_<DIMENSION> grade-hold pattern (lifted from itm327's
 # build_mid_letter_comments + push_mid_letter). When a per-student
 # feedback file's top-of-file heading carries a trailing `· HOLD_<TOKEN>`
@@ -1259,7 +1278,7 @@ def main() -> int:
         key = r.get("key", "")
         grade = (r.get("final_grade") or "").strip() or (r.get("recommended_score") or "").strip()
         comment = "" if args.grade_only else (
-            comment_for(r.get("feedback_file", "")) or args.default_comment)
+            append_disclosure_tag(comment_for(r.get("feedback_file", ""))) or args.default_comment)
         uid = resolve_user_id(r.get("submission_file", ""), subs)
         done = key in pushed_keys and not args.force
         ok = bool(grade and uid and (comment or args.grade_only)) and not done

--- a/lib/tools/grader_push_comments.py
+++ b/lib/tools/grader_push_comments.py
@@ -98,6 +98,7 @@ except ImportError:
 # Reuse the existing write-path guards rather than reimplementing them
 # (issues #61 / #62 / #63 / #65).
 from grader_push import (  # noqa: E402
+    append_disclosure_tag,
     fetch_active_filter,
     fetch_assignment_lock_state,
     comment_has_resubmit_language,
@@ -405,7 +406,7 @@ def main() -> int:
     failed: list[int] = []
     with log.open("a", encoding="utf-8") as lg:
         for row in pushable:
-            data = {"comment[text_comment]": row["comment"]}
+            data = {"comment[text_comment]": append_disclosure_tag(row["comment"])}
             resp = requests.put(
                 f"{base}/api/v1/courses/{cid}/assignments/{args.assignment_id}"
                 f"/submissions/{row['uid']}",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.11"
+version = "1.7.12"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Honest AI disclosure in grading — README reframe + a no-opt-out tag

Reframes how the toolkit positions AI-assisted grading, from *"the instructor stays the author"* (which can read as passing AI-drafted feedback off as solely the instructor's own) to **honest disclosure** — and backs it with a real mechanism so the claim is true, not just stated.

### The tag
Every AI-drafted feedback comment now posts with **`— AI drafted, instructor reviewed`** appended.
- **`append_disclosure_tag()`** in `grader_push.py`, applied at **send-time** by both `grader_push` and `grader_push_comments`, so it can't be edited out during review — **default, no opt-out**.
- **Idempotent** — never double-tags on a re-push.
- **Never invents a comment** — a grade-only push with no comment stays comment-less.
- **Honesty both ways** — only AI-*drafted* comments are tagged. A manual `default_comment` or a hand-written note (`submit_on_behalf`) is left alone: we don't label a human's own words as AI's, and we don't pass AI's words off as solely the human's.

### The wording
`— AI drafted, instructor reviewed` was chosen deliberately over "AI assisted": "drafted" is honest that the AI produced the words (not merely helped), and "instructor reviewed" reflects the pipeline's review gate — without over-claiming.

### README
- "Why this exists" / "What changes" reworked: the differentiator is now honest disclosure, not authorship.
- New architectural commitment: **AI disclosure, no opt-out.**

### Tests
4 new tests (`test_grader_push_helpers.py`): tag appended, idempotent, not-on-empty, wording pinned. **Full suite green (832).**

`1.7.12`. Opening for review, not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
