### PR TITLE
feat: pluggable AI-engagement classifier (placeholder taxonomy)

### DIFF
--- a/docs/ai-engagement-classifier-design.md
+++ b/docs/ai-engagement-classifier-design.md
@@ -1,0 +1,184 @@
+# AI Engagement Classifier — Design
+
+> **Status: DESIGN DRAFT.** Defines a new cb tool, `ai_engagement_classifier`, and the
+> **pluggable engagement-taxonomy** it runs. cb owns this primitive; ngai-n8n consumes it.
+> The initial shipped taxonomy is a **placeholder** — our own working approximation of the
+> aimodes.ai structure (Dr. Mark Keith), *not* his validated instrument. See
+> `../../ngai-n8n/design/keith-collaboration-pitch.md`.
+
+## 1. The one design decision
+
+Do **not** hard-code any engagement framework into the classifier. The framework —
+tiers, modes, per-mode thresholds, transition model, archetypes — lives in a swappable
+**taxonomy profile** (a `.json` file). The classifier is a generic engine:
+
+```
+classify(transcript, profile)  ->  engagement report (stable JSON contract)
+```
+
+This buys everything the project needs:
+
+| Need | How the pluggable profile delivers it |
+|---|---|
+| Placeholder for dev **now** | Ship `aimodes_placeholder.json` (our definitions). |
+| Revert to a **3-tier** model | Swap in `three_tier.json`. Zero code change. |
+| Compare a **5-tier AI-use** model | Add `five_tier_aiuse.json`. Same engine, same data model. |
+| Plug in **Keith's validated** framework if he collaborates | His definitions/thresholds/routes become `aimodes_keith.json`, attributed to him. |
+| Don't waste dev-era data | Raw transcripts are stored; **re-classify history** under any new profile later. |
+
+The profile is the pluggable, attributable, swappable piece. The engine and the output
+contract stay stable across all of them.
+
+## 2. Taxonomy profile schema
+
+One file per framework, in `lib/agents/knowledge/engagement_taxonomy/<profile_id>.json`.
+
+```jsonc
+{
+  "profile_id": "aimodes_placeholder",
+  "schema_version": "1.0",
+  "version": "0.1.0-placeholder",
+  "display_name": "AI Modes (placeholder approximation)",
+  "status": "placeholder",              // placeholder | validated
+  "attribution": "Structure inspired by aimodes.ai (Dr. Mark Keith, BYU). Definitions are our own working drafts — NOT Keith's validated instrument. Do not represent as his model.",
+
+  "tiers": [
+    { "id": "passivity",   "order": 1, "label": "Passivity",   "agency_weight": 0,   "description": "Student outsources thinking; AI produces, student receives." },
+    { "id": "partnership", "order": 2, "label": "Partnership", "agency_weight": 50,  "description": "Student and AI think together; shared cognitive load." },
+    { "id": "agency",      "order": 3, "label": "Agency",      "agency_weight": 100, "description": "Student drives and checks the AI; AI serves the student's direction." }
+  ],
+
+  "modes": [
+    { "id": "oracle",              "tier": "passivity",   "label": "Oracle",                    "threshold": 0.10, "definition": "...", "signals": ["..."] },
+    { "id": "production_assistant","tier": "passivity",   "label": "Production Assistant",      "threshold": 0.10, "definition": "...", "signals": ["..."] },
+    { "id": "tutor",               "tier": "partnership", "label": "Tutor",                     "threshold": 0.20, "definition": "...", "signals": ["..."] },
+    { "id": "collab_solver",       "tier": "partnership", "label": "Collaborative Problem-Solver","threshold": 0.20, "definition": "...", "signals": ["..."] },
+    { "id": "verification_agent",  "tier": "agency",      "label": "Verification Agent",        "threshold": 0.10, "definition": "...", "signals": ["..."] },
+    { "id": "creative_expander",   "tier": "agency",      "label": "Creative Expander",         "threshold": 0.10, "definition": "...", "signals": ["..."] },
+    { "id": "critical_challenger", "tier": "agency",      "label": "Critical Challenger",       "threshold": 0.10, "definition": "...", "signals": ["..."] },
+    { "id": "problem_setter",      "tier": "agency",      "label": "Problem Setter",            "threshold": 0.10, "definition": "...", "signals": ["..."] }
+  ],
+
+  "archetypes": [
+    { "id": "delegator",  "label": "Delegator",  "rule": "passivity tier >= 0.50" },
+    { "id": "learner",    "label": "Learner",    "rule": "tutor is the modal mode" },
+    { "id": "partner",    "label": "Partner",    "rule": "partnership tier >= 0.50" },
+    { "id": "challenger", "label": "Challenger", "rule": "critical_challenger >= its threshold and agency tier >= 0.33" },
+    { "id": "explorer",   "label": "Explorer",   "rule": "creative_expander + problem_setter >= 0.25" },
+    { "id": "specialist", "label": "Specialist", "rule": "one agency mode >= 0.40" }
+  ],
+  "archetype_default": "partner"
+}
+```
+
+- **`threshold`** = target share of a student's turns that *should* fall in this mode
+  ("where a student should be" — Keith's per-mode thresholds). Placeholder values here;
+  Keith's validated numbers replace them when/if he's in.
+- **`agency_weight`** drives the 0–100 agency score (§4). Tier-level, so any tier count works
+  (3-tier aimodes, or a 5-tier scale that defines 5 tiers each with its own weight).
+- **`archetypes[].rule`** is a small, fixed DSL evaluated in code (§4) — not eval'd. Keeping
+  the rules *declarative in the profile* means a new framework ships its own archetypes.
+
+### Swap targets (revert / compare)
+
+- `three_tier.json` — 3 modes that ARE the 3 tiers (Passivity/Partnership/Agency), thresholds
+  only at tier granularity. Reverts to the coarse model.
+- `five_tier_aiuse.json` — 5 tiers/modes for the "5-level AI usage" research you're evaluating
+  (e.g. No-AI → AI-planned → AI-collaboration → AI-led → Full-AI). Fill definitions when chosen.
+
+## 3. Placeholder mode definitions (ours, working drafts)
+
+These are cb's own approximations for dev. Crisp, classifiable from a transcript.
+
+| Mode | Tier | The student is… |
+|---|---|---|
+| **Oracle** | Passivity | asking for a fact/answer and taking it as-is. "What's the answer to X?" |
+| **Production Assistant** | Passivity | delegating production of an artifact. "Write the code/essay for X." |
+| **Tutor** | Partnership | asking the AI to explain so *they* understand. "Explain why X works." |
+| **Collaborative Problem-Solver** | Partnership | iterating jointly — proposing, having the AI refine, pushing back. |
+| **Verification Agent** | Agency | checking *their own* work/reasoning. "Here's my solution — where's my error?" |
+| **Creative Expander** | Agency | broadening options beyond their own. "Give me 5 alternative approaches." (student selects) |
+| **Critical Challenger** | Agency | inviting adversarial pressure. "Argue against my thesis / find the holes." |
+| **Problem Setter** | Agency | framing/scoping the problem itself, setting the agenda, using AI as an instrument. |
+
+## 4. Output contract (the stable JSON cb emits)
+
+**Only student turns are classified** — the mode describes how the *student* is using the AI in
+that exchange; the AI turn is context. The **ordered** `sequence` is what makes route/transition
+mapping possible (a distribution alone can't).
+
+```jsonc
+{
+  "schema_version": "1.0",
+  "profile_id": "aimodes_placeholder",
+  "profile_version": "0.1.0-placeholder",
+  "conversation_id": "<caller-supplied>",
+  "message_count": 12,
+  "student_turn_count": 6,
+
+  "sequence": [                                 // ORDERED student turns → enables routes
+    { "index": 0, "mode": "oracle", "tier": "passivity", "confidence": 0.82, "evidence": "short quote/rationale" },
+    { "index": 1, "mode": "tutor",  "tier": "partnership","confidence": 0.71, "evidence": "..." }
+    // ...
+  ],
+
+  "tier_distribution":  { "passivity": 0.33, "partnership": 0.50, "agency": 0.17 },
+  "mode_distribution":  { "oracle": 0.17, "tutor": 0.33, "collab_solver": 0.17, "verification_agent": 0.17, "problem_setter": 0.16 },
+
+  "agency_score": 42,                           // 0–100, Σ(tier_share × agency_weight)
+
+  "threshold_gaps": [                           // actual vs. target per mode (where they should be)
+    { "mode": "problem_setter", "actual": 0.16, "target": 0.10, "gap": +0.06 },
+    { "mode": "critical_challenger", "actual": 0.0, "target": 0.10, "gap": -0.10 }
+  ],
+
+  "transitions": [                              // the ROUTE — consecutive student-mode hops
+    { "from": "oracle", "to": "tutor", "count": 1 },
+    { "from": "tutor",  "to": "collab_solver", "count": 1 }
+  ],
+
+  "archetype": { "id": "learner", "label": "Learner", "rationale": "tutor is the modal mode" }
+}
+```
+
+Everything below `sequence` is **computed in Python from `sequence`** (deterministic, testable) —
+the LLM only produces `sequence`. That keeps the LLM's job small (classify each turn) and makes
+distribution/score/gaps/transitions/archetype unit-testable without the model.
+
+## 5. How it plugs into ngai-n8n (the consumer)
+
+- **cb is the primitive.** `ai_engagement_classifier` is versioned + tested, emits the contract
+  above. ngai-n8n's qc-agent stops hand-rolling CT/CQ and calls this instead (n8n → Python CLI,
+  same pattern as the planned grade write-back).
+- **Storage.** Persist the full contract on `conversation_analysis`, keyed by
+  `canvas_user_id × course_id × term`. Minimal columns: `engagement_profile_id`,
+  `engagement_agency_score`, `engagement_archetype`, and the contract as JSONB
+  (`engagement_report`). Derive CT/CQ + the pass-gate *from* it (Keith's model subsumes CT/CQ).
+- **Retroactive re-classification.** Raw transcripts already live in `messages`. When a new
+  profile arrives (e.g. Keith's validated one), re-run the classifier over history → new report
+  rows with the new `profile_id`. The dev-era back-catalog becomes valid data in the new model.
+- **Longitudinal rollup.** Aggregate `agency_score` + `tier_distribution` + `threshold_gaps`
+  per student across conversations → per module → per course → per term → across terms. Join the
+  **project axis** (can-do, from grades) with this **knowledge axis** (how they engaged) → the
+  two-axis competency map: *can I do it* × *do I understand it*, tracked over time, with the
+  route showing how they moved mode-to-mode within a conversation.
+
+## 6. Non-goals / boundaries
+
+- The placeholder is **not** Keith's instrument and must never be presented as such (the profile
+  `attribution`/`status` fields enforce this in every output).
+- The classifier does not fetch conversations — it takes a normalized transcript (ngai-n8n has
+  the messages; cb's `grader_follow_share_url` can supply share-URL transcripts).
+- Thresholds/routes in the placeholder are provisional and exist to exercise the pipeline, not to
+  make claims about students.
+
+## 7. Build order (C)
+
+1. `lib/agents/knowledge/engagement_taxonomy/aimodes_placeholder.json` — full placeholder profile.
+2. `lib/agents/knowledge/engagement_taxonomy/three_tier.json` — proves swappability.
+3. `lib/tools/ai_engagement_classifier.py` — profile loader, prompt builder, LLM provider (reuse
+   grader_grade's `GraderLLM`/`make_provider` pattern), strict-JSON parse, the deterministic
+   Python aggregation (§4), CLI. `--dry-run` emits the assembled prompt + empty contract with no
+   LLM call.
+4. `lib/tests/test_ai_engagement_classifier.py` — profile-loads, swap works, aggregation math,
+   transition extraction, archetype rules, threshold gaps. All deterministic (no LLM in tests).

--- a/lib/agents/knowledge/engagement_taxonomy/aimodes_placeholder.json
+++ b/lib/agents/knowledge/engagement_taxonomy/aimodes_placeholder.json
@@ -1,0 +1,106 @@
+{
+  "profile_id": "aimodes_placeholder",
+  "schema_version": "1.0",
+  "version": "0.1.0-placeholder",
+  "display_name": "AI Modes (placeholder approximation)",
+  "status": "placeholder",
+  "attribution": "Structure inspired by aimodes.ai (Dr. Mark Keith, BYU). Definitions and thresholds are canvas-toolbox's own working drafts for development only — NOT Keith's validated instrument. Do not represent output as his model.",
+  "tiers": [
+    {
+      "id": "passivity",
+      "order": 1,
+      "label": "Passivity",
+      "agency_weight": 0,
+      "description": "Student outsources the thinking; AI produces, student receives."
+    },
+    {
+      "id": "partnership",
+      "order": 2,
+      "label": "Partnership",
+      "agency_weight": 50,
+      "description": "Student and AI think together; shared cognitive load."
+    },
+    {
+      "id": "agency",
+      "order": 3,
+      "label": "Agency",
+      "agency_weight": 100,
+      "description": "Student drives and checks the AI; the AI serves the student's direction."
+    }
+  ],
+  "modes": [
+    {
+      "id": "oracle",
+      "tier": "passivity",
+      "label": "Oracle",
+      "threshold": 0.10,
+      "definition": "Student asks for a fact or answer and takes it as-is, with no reasoning exchange.",
+      "signals": ["asks 'what is the answer to...'", "accepts the reply without questioning", "no attempt to reason through it themselves"]
+    },
+    {
+      "id": "production_assistant",
+      "tier": "passivity",
+      "label": "Production Assistant",
+      "threshold": 0.10,
+      "definition": "Student delegates production of an artifact and takes the output to use directly.",
+      "signals": ["'write the code/essay/email for...'", "'do X for me'", "receives a finished artifact to submit or use"]
+    },
+    {
+      "id": "tutor",
+      "tier": "partnership",
+      "label": "Tutor",
+      "threshold": 0.20,
+      "definition": "Student asks the AI to explain or teach a concept so that the student understands it.",
+      "signals": ["'explain why X works'", "'help me understand...'", "asks follow-ups that show they are trying to learn, not just get output"]
+    },
+    {
+      "id": "collab_solver",
+      "tier": "partnership",
+      "label": "Collaborative Problem-Solver",
+      "threshold": 0.20,
+      "definition": "Student and AI iterate jointly on a problem — the student proposes, the AI refines, the student pushes back and contributes.",
+      "signals": ["'here's my idea, what do you think'", "back-and-forth refinement", "student contributes substance, not just prompts"]
+    },
+    {
+      "id": "verification_agent",
+      "tier": "agency",
+      "label": "Verification Agent",
+      "threshold": 0.10,
+      "definition": "Student has done the work and uses the AI to check their own reasoning or find their own errors.",
+      "signals": ["'here is my solution — is it correct?'", "'where is my error?'", "the student's own work is present and central"]
+    },
+    {
+      "id": "creative_expander",
+      "tier": "agency",
+      "label": "Creative Expander",
+      "threshold": 0.10,
+      "definition": "Student directs the AI to broaden the option space beyond their own ideas, then selects among the results themselves.",
+      "signals": ["'give me 5 alternative approaches'", "'what haven't I considered'", "student retains selection/decision"]
+    },
+    {
+      "id": "critical_challenger",
+      "tier": "agency",
+      "label": "Critical Challenger",
+      "threshold": 0.10,
+      "definition": "Student invites adversarial pressure — asks the AI to critique, argue against, or find holes in the student's own position.",
+      "signals": ["'argue against my thesis'", "'find the holes in this'", "'steelman the opposing view'"]
+    },
+    {
+      "id": "problem_setter",
+      "tier": "agency",
+      "label": "Problem Setter",
+      "threshold": 0.10,
+      "definition": "Student frames and scopes the problem itself, sets the agenda, and uses the AI as an instrument toward a goal the student owns.",
+      "signals": ["defines what to solve and why", "directs the AI's role", "sequences sub-tasks toward a student-owned objective"]
+    }
+  ],
+  "archetypes": [
+    {"id": "delegator",  "label": "Delegator",  "rule": "tier:passivity >= 0.50"},
+    {"id": "learner",    "label": "Learner",    "rule": "modal_mode == tutor"},
+    {"id": "partner",    "label": "Partner",    "rule": "tier:partnership >= 0.50"},
+    {"id": "challenger", "label": "Challenger", "rule": "mode:critical_challenger >= threshold AND tier:agency >= 0.33"},
+    {"id": "explorer",   "label": "Explorer",   "rule": "mode:creative_expander + mode:problem_setter >= 0.25"},
+    {"id": "specialist", "label": "Specialist", "rule": "any_agency_mode >= 0.40"}
+  ],
+  "archetype_default": "partner"
+}

--- a/lib/agents/knowledge/engagement_taxonomy/three_tier.json
+++ b/lib/agents/knowledge/engagement_taxonomy/three_tier.json
@@ -1,0 +1,24 @@
+{
+  "profile_id": "three_tier",
+  "schema_version": "1.0",
+  "version": "1.0.0",
+  "display_name": "Three-tier agency (coarse)",
+  "status": "validated",
+  "attribution": "canvas-toolbox coarse agency model. The three modes ARE the three tiers — the revert target from the finer aimodes profile. No external attribution.",
+  "tiers": [
+    {"id": "passivity",   "order": 1, "label": "Passivity",   "agency_weight": 0,   "description": "Student outsources thinking; AI produces, student receives."},
+    {"id": "partnership", "order": 2, "label": "Partnership", "agency_weight": 50,  "description": "Student and AI think together; shared cognitive load."},
+    {"id": "agency",      "order": 3, "label": "Agency",      "agency_weight": 100, "description": "Student drives and checks the AI; AI serves the student's direction."}
+  ],
+  "modes": [
+    {"id": "passivity",   "tier": "passivity",   "label": "Passivity",   "threshold": 0.20, "definition": "Student takes AI output as-is — asks for answers or delegates production.", "signals": ["'what is the answer'", "'write it for me'", "accepts output without engaging"]},
+    {"id": "partnership", "tier": "partnership", "label": "Partnership", "threshold": 0.40, "definition": "Student learns with or works alongside the AI — explanation-seeking or joint iteration.", "signals": ["'explain why'", "'here's my idea, refine it'", "back-and-forth reasoning"]},
+    {"id": "agency",      "tier": "agency",      "label": "Agency",      "threshold": 0.40, "definition": "Student drives — verifies their own work, expands options, invites critique, or sets the problem.", "signals": ["'check my work'", "'argue against this'", "student owns problem definition"]}
+  ],
+  "archetypes": [
+    {"id": "delegator", "label": "Delegator", "rule": "tier:passivity >= 0.50"},
+    {"id": "partner",   "label": "Partner",   "rule": "tier:partnership >= 0.50"},
+    {"id": "driver",    "label": "Driver",    "rule": "tier:agency >= 0.50"}
+  ],
+  "archetype_default": "partner"
+}

--- a/lib/tests/test_ai_engagement_classifier.py
+++ b/lib/tests/test_ai_engagement_classifier.py
@@ -1,0 +1,183 @@
+"""Tier 1 unit tests — ai_engagement_classifier.py.
+
+All deterministic: the LLM only produces the ordered `sequence`; everything the tool
+reports (distributions, 0-100 agency score, threshold gaps, transitions/route, archetype)
+is computed in Python from that sequence, so it is tested here with no model call.
+
+Covers: profile load + validation, the revert/swap to a different taxonomy (three_tier),
+the aggregation math, transition (route) extraction, threshold gaps, the archetype rule
+DSL for every archetype, and prompt assembly (student-turn numbering + fenced-JSON parse).
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+import ai_engagement_classifier as C  # noqa: E402
+
+
+def _seq(*modes):
+    return [{"index": i, "mode": m, "confidence": 0.9, "evidence": ""} for i, m in enumerate(modes)]
+
+
+# ---------------------------------------------------------------------------
+# profile loading + swap
+# ---------------------------------------------------------------------------
+
+def test_profiles_present_and_swappable():
+    ids = C.list_profiles()
+    assert "aimodes_placeholder" in ids
+    assert "three_tier" in ids
+
+
+def test_placeholder_profile_loads_and_is_labeled_placeholder():
+    p = C.load_profile("aimodes_placeholder")
+    assert p["profile_id"] == "aimodes_placeholder"
+    assert p["status"] == "placeholder"
+    assert "NOT Keith" in p["attribution"]           # honest boundary carried in every output
+    assert len(p["modes"]) == 8
+    assert {t["id"] for t in p["tiers"]} == {"passivity", "partnership", "agency"}
+
+
+def test_profile_validation_rejects_dangling_tier(tmp_path, monkeypatch):
+    bad = tmp_path
+    (bad / "broken.json").write_text(
+        '{"profile_id":"broken","tiers":[{"id":"a","order":1,"agency_weight":0}],'
+        '"modes":[{"id":"m","tier":"NOPE","label":"M"}]}', encoding="utf-8")
+    monkeypatch.setattr(C, "PROFILE_DIR", bad)
+    with pytest.raises(SystemExit):
+        C.load_profile("broken")
+
+
+# ---------------------------------------------------------------------------
+# aggregation math
+# ---------------------------------------------------------------------------
+
+def test_distributions_and_agency_score():
+    p = C.load_profile("aimodes_placeholder")
+    # 2 passivity, 2 partnership, 2 agency  ->  score = 33%*0 + 33%*50 + 33%*100 = 50
+    body = C.aggregate(
+        _seq("oracle", "oracle", "tutor", "collab_solver", "verification_agent", "problem_setter"), p)
+    assert body["agency_score"] == 50
+    assert body["tier_distribution"] == {"passivity": 0.3333, "partnership": 0.3333, "agency": 0.3333}
+    assert body["mode_distribution"]["oracle"] == 0.3333
+    # sums to ~1 (per-value 4dp rounding leaves a small residual — not exactly 1.0)
+    assert abs(sum(body["mode_distribution"].values()) - 1.0) < 1e-3
+
+
+def test_agency_score_extremes():
+    p = C.load_profile("aimodes_placeholder")
+    assert C.aggregate(_seq("oracle", "oracle"), p)["agency_score"] == 0          # all passivity
+    assert C.aggregate(_seq("problem_setter", "critical_challenger"), p)["agency_score"] == 100  # all agency
+
+
+def test_empty_sequence_is_safe():
+    p = C.load_profile("aimodes_placeholder")
+    body = C.aggregate([], p)
+    assert body["agency_score"] == 0
+    assert body["mode_distribution"] == {}
+    assert body["transitions"] == []
+
+
+# ---------------------------------------------------------------------------
+# transitions (the route) + threshold gaps
+# ---------------------------------------------------------------------------
+
+def test_transitions_capture_ordered_route():
+    p = C.load_profile("aimodes_placeholder")
+    body = C.aggregate(_seq("oracle", "tutor", "oracle", "tutor"), p)
+    trans = {(t["from"], t["to"]): t["count"] for t in body["transitions"]}
+    assert trans[("oracle", "tutor")] == 2
+    assert trans[("tutor", "oracle")] == 1
+
+
+def test_threshold_gap_signed_correctly():
+    p = C.load_profile("aimodes_placeholder")
+    body = C.aggregate(_seq("oracle", "oracle", "oracle", "tutor"), p)  # oracle 0.75, target 0.10
+    gap = next(g for g in body["threshold_gaps"] if g["mode"] == "oracle")
+    assert gap["actual"] == 0.75 and gap["target"] == 0.10
+    assert round(gap["gap"], 2) == 0.65
+    # a mode never used shows a negative gap (below where the student should be)
+    ps = next(g for g in body["threshold_gaps"] if g["mode"] == "problem_setter")
+    assert ps["actual"] == 0.0 and ps["gap"] < 0
+
+
+# ---------------------------------------------------------------------------
+# archetype rule DSL — one case per archetype
+# ---------------------------------------------------------------------------
+
+def test_archetype_delegator():
+    p = C.load_profile("aimodes_placeholder")
+    assert C.aggregate(_seq("oracle", "oracle", "production_assistant"), p)["archetype"]["id"] == "delegator"
+
+
+def test_archetype_learner_by_modal_mode():
+    p = C.load_profile("aimodes_placeholder")
+    assert C.aggregate(_seq("tutor", "tutor", "oracle"), p)["archetype"]["id"] == "learner"
+
+
+def test_archetype_challenger():
+    p = C.load_profile("aimodes_placeholder")
+    assert C.aggregate(_seq("critical_challenger", "critical_challenger", "oracle"), p)["archetype"]["id"] == "challenger"
+
+
+def test_archetype_explorer():
+    p = C.load_profile("aimodes_placeholder")
+    assert C.aggregate(_seq("creative_expander", "problem_setter", "oracle"), p)["archetype"]["id"] == "explorer"
+
+
+def test_archetype_specialist():
+    p = C.load_profile("aimodes_placeholder")
+    # verification_agent 0.67 >= 0.40 but not challenger/explorer/learner/partner first
+    assert C.aggregate(_seq("verification_agent", "verification_agent", "oracle"), p)["archetype"]["id"] == "specialist"
+
+
+def test_archetype_falls_back_to_default_partner():
+    p = C.load_profile("aimodes_placeholder")
+    # balanced across tiers, no rule fires -> default
+    body = C.aggregate(_seq("oracle", "tutor", "verification_agent"), p)
+    assert body["archetype"]["id"] == "partner"
+    assert body["archetype"]["rationale"] == "default"
+
+
+# ---------------------------------------------------------------------------
+# revert / swap taxonomy — same engine, coarse profile
+# ---------------------------------------------------------------------------
+
+def test_three_tier_swap_runs_same_engine():
+    p = C.load_profile("three_tier")
+    body = C.aggregate(_seq("passivity", "partnership", "agency"), p)
+    assert body["agency_score"] == 50
+    assert set(body["tier_distribution"]) == {"passivity", "partnership", "agency"}
+    assert body["archetype"]["id"] in {"delegator", "partner", "driver"}
+
+
+# ---------------------------------------------------------------------------
+# prompt assembly + response parsing
+# ---------------------------------------------------------------------------
+
+def test_user_prompt_numbers_student_turns_only():
+    msgs = [{"role": "student", "text": "q1"}, {"role": "assistant", "text": "a1"},
+            {"role": "student", "text": "q2"}]
+    prompt, n = C.build_user_prompt(msgs)
+    assert n == 2
+    assert "[Student turn 0]" in prompt and "[Student turn 1]" in prompt
+    assert "[Student turn 2]" not in prompt
+
+
+def test_parse_response_tolerates_code_fences():
+    assert C._parse_response('```json\n{"sequence": []}\n```') == {"sequence": []}
+    assert C._parse_response('noise {"sequence": [{"index":0,"mode":"oracle"}]} tail') \
+        == {"sequence": [{"index": 0, "mode": "oracle"}]}
+    assert C._parse_response("not json at all") is None
+
+
+def test_system_prompt_lists_all_modes():
+    p = C.load_profile("aimodes_placeholder")
+    sysmsg = C.build_system_prompt(p)
+    for m in p["modes"]:
+        assert m["id"] in sysmsg

--- a/lib/tools/ai_engagement_classifier.py
+++ b/lib/tools/ai_engagement_classifier.py
@@ -1,0 +1,412 @@
+#!/usr/bin/env python3
+"""AI engagement classifier — pluggable engagement-taxonomy over a student↔AI transcript.
+
+cb owns this primitive; ngai-n8n consumes it (see docs/ai-engagement-classifier-design.md).
+
+The framework (tiers, modes, thresholds, archetypes) is NOT hard-coded — it lives in a
+swappable *taxonomy profile* JSON under lib/agents/knowledge/engagement_taxonomy/. Swap the
+profile to revert to a 3-tier model, compare a 5-tier model, or plug in a validated instrument;
+the engine and the output contract stay stable.
+
+The LLM's only job is to classify each STUDENT turn into one mode (the ordered `sequence`).
+Everything else — tier/mode distribution, 0-100 agency score, threshold gaps, transitions
+(the route), archetype — is computed deterministically in Python from that sequence, so it's
+unit-testable without the model.
+
+Usage:
+    ai_engagement_classifier.py --transcript conv.json [--profile aimodes_placeholder]
+    ai_engagement_classifier.py --list-profiles
+    ai_engagement_classifier.py --transcript conv.json --dry-run   # prints prompt, no LLM call
+
+Transcript JSON:
+    {"conversation_id": "abc", "messages": [{"role": "student", "text": "..."},
+                                            {"role": "assistant", "text": "..."}, ...]}
+
+ANTHROPIC_API_KEY must be set for a real run (the toolkit already ships `anthropic`).
+"""
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from pathlib import Path
+
+PROFILE_DIR = Path(__file__).resolve().parent.parent / "agents" / "knowledge" / "engagement_taxonomy"
+DEFAULT_PROFILE = "aimodes_placeholder"
+CONTRACT_SCHEMA_VERSION = "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Profile loading
+# ---------------------------------------------------------------------------
+
+def list_profiles() -> list[str]:
+    if not PROFILE_DIR.is_dir():
+        return []
+    return sorted(p.stem for p in PROFILE_DIR.glob("*.json"))
+
+
+def load_profile(profile_id: str) -> dict:
+    path = PROFILE_DIR / f"{profile_id}.json"
+    if not path.is_file():
+        avail = ", ".join(list_profiles()) or "(none found)"
+        print(f"Unknown profile '{profile_id}'. Available: {avail}", file=sys.stderr)
+        sys.exit(1)
+    profile = json.loads(path.read_text(encoding="utf-8"))
+    _validate_profile(profile)
+    return profile
+
+
+def _validate_profile(p: dict) -> None:
+    for key in ("profile_id", "tiers", "modes"):
+        if key not in p:
+            print(f"Profile missing required key '{key}'.", file=sys.stderr)
+            sys.exit(1)
+    tier_ids = {t["id"] for t in p["tiers"]}
+    for m in p["modes"]:
+        if m["tier"] not in tier_ids:
+            print(f"Mode '{m['id']}' references unknown tier '{m['tier']}'.", file=sys.stderr)
+            sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# LLM provider (same shape as grader_grade.py's GraderLLM; kept local + minimal)
+# ---------------------------------------------------------------------------
+
+class ClassifierLLM:
+    def complete(self, system: str, user: str, temperature: float = 0.0,
+                 max_tokens: int = 4096) -> str:
+        raise NotImplementedError
+
+
+class AnthropicClassifierLLM(ClassifierLLM):
+    """Lazy-imports `anthropic` so --help / --list-profiles / --dry-run work without the SDK."""
+
+    def __init__(self, model: str):
+        try:
+            from anthropic import Anthropic
+        except ImportError:
+            print("Missing dep: `anthropic`. Install via `uv add anthropic`.", file=sys.stderr)
+            sys.exit(1)
+        if not os.environ.get("ANTHROPIC_API_KEY"):
+            print("ANTHROPIC_API_KEY not set in .env.", file=sys.stderr)
+            sys.exit(1)
+        self.client = Anthropic()
+        self.model = model
+
+    def complete(self, system: str, user: str, temperature: float = 0.0,
+                 max_tokens: int = 4096) -> str:
+        last_err: Exception | None = None
+        for attempt in range(3):
+            try:
+                resp = self.client.messages.create(
+                    model=self.model, max_tokens=max_tokens, temperature=temperature,
+                    system=system, messages=[{"role": "user", "content": user}],
+                )
+                return "".join(b.text for b in resp.content if hasattr(b, "text"))
+            except Exception as e:
+                last_err = e
+                msg = str(e).lower()
+                if any(k in msg for k in ("rate", "overloaded", "timeout", "connection")):
+                    time.sleep(2 ** attempt)
+                    continue
+                raise
+        raise RuntimeError(f"LLM call failed after 3 attempts: {last_err}")
+
+
+def make_provider(name: str, model: str) -> ClassifierLLM:
+    if name == "anthropic":
+        return AnthropicClassifierLLM(model)
+    print(f"Unknown provider '{name}'. Supported: anthropic.", file=sys.stderr)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Prompt assembly
+# ---------------------------------------------------------------------------
+
+def build_system_prompt(profile: dict) -> str:
+    lines = [
+        "You classify how a STUDENT is engaging an AI in each of their turns, using the",
+        f"taxonomy below (profile: {profile.get('display_name', profile['profile_id'])}).",
+        "",
+        "TIERS (least to most intellectual agency):",
+    ]
+    for t in sorted(profile["tiers"], key=lambda x: x["order"]):
+        lines.append(f"  - {t['label']} ({t['id']}): {t['description']}")
+    lines += ["", "MODES (assign exactly one per student turn; use the mode id):"]
+    for m in profile["modes"]:
+        sig = "; ".join(m.get("signals", []))
+        lines.append(f"  - {m['id']} [{m['tier']}] {m['label']}: {m['definition']}"
+                     + (f"  Signals: {sig}" if sig else ""))
+    lines += [
+        "",
+        "Classify each student turn by what the student is DOING in that exchange, in order.",
+        "Return STRICT JSON, no prose, no code fences:",
+        '  {"sequence": [{"index": <student-turn number>, "mode": "<mode id>",',
+        '                 "confidence": <0..1>, "evidence": "<short quote or rationale>"}]}',
+        "One entry per student turn. `mode` MUST be one of the mode ids above.",
+    ]
+    return "\n".join(lines)
+
+
+def build_user_prompt(messages: list[dict]) -> tuple[str, int]:
+    """Render the transcript with student turns numbered; returns (prompt, student_turn_count)."""
+    parts = ["Conversation — classify each STUDENT turn:", ""]
+    student_n = 0
+    for msg in messages:
+        role = msg.get("role", "").lower()
+        text = (msg.get("text") or "").strip()
+        if role in ("student", "user", "human"):
+            parts.append(f"[Student turn {student_n}]")
+            parts.append(text)
+            student_n += 1
+        else:  # assistant / ai — context only
+            parts.append("[AI reply]")
+            parts.append(text)
+        parts.append("")
+    parts.append(f"There are {student_n} student turns (0..{student_n - 1}). "
+                 "Return one sequence entry per student turn.")
+    return "\n".join(parts), student_n
+
+
+def _parse_response(text: str) -> dict | None:
+    """Parse the LLM's JSON. Tolerant of stray markdown fencing (mirrors grader_grade)."""
+    t = text.strip()
+    if t.startswith("```"):
+        t = re.sub(r"^```(?:json)?\s*", "", t)
+        t = re.sub(r"\s*```$", "", t)
+    try:
+        return json.loads(t)
+    except json.JSONDecodeError:
+        start, end = t.find("{"), t.rfind("}")
+        if start >= 0 and end > start:
+            try:
+                return json.loads(t[start:end + 1])
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic aggregation (LLM produces `sequence`; everything here is pure)
+# ---------------------------------------------------------------------------
+
+def aggregate(sequence: list[dict], profile: dict) -> dict:
+    """Compute the full contract body from an ordered mode sequence + a profile."""
+    mode_to_tier = {m["id"]: m["tier"] for m in profile["modes"]}
+    tier_weight = {t["id"]: t.get("agency_weight", 0) for t in profile["tiers"]}
+    n = len(sequence)
+
+    # normalize + attach derived tier
+    seq: list[dict] = []
+    for i, e in enumerate(sequence):
+        mode = e.get("mode")
+        tier = mode_to_tier.get(mode)
+        seq.append({
+            "index": e.get("index", i),
+            "mode": mode,
+            "tier": tier,
+            "confidence": e.get("confidence"),
+            "evidence": e.get("evidence", ""),
+        })
+
+    mode_counts: dict[str, int] = {}
+    tier_counts: dict[str, int] = {}
+    for e in seq:
+        if e["mode"]:
+            mode_counts[e["mode"]] = mode_counts.get(e["mode"], 0) + 1
+        if e["tier"]:
+            tier_counts[e["tier"]] = tier_counts.get(e["tier"], 0) + 1
+
+    mode_distribution = {k: round(v / n, 4) for k, v in mode_counts.items()} if n else {}
+    tier_distribution = {k: round(v / n, 4) for k, v in tier_counts.items()} if n else {}
+
+    agency_score = round(sum(
+        (tier_counts.get(t["id"], 0) / n) * tier_weight[t["id"]] for t in profile["tiers"]
+    )) if n else 0
+
+    threshold_gaps = []
+    for m in profile["modes"]:
+        if "threshold" not in m:
+            continue
+        actual = mode_distribution.get(m["id"], 0.0)
+        threshold_gaps.append({
+            "mode": m["id"], "actual": actual, "target": m["threshold"],
+            "gap": round(actual - m["threshold"], 4),
+        })
+
+    transitions_counter: dict[tuple[str, str], int] = {}
+    for a, b in zip(seq, seq[1:]):
+        if a["mode"] and b["mode"]:
+            transitions_counter[(a["mode"], b["mode"])] = \
+                transitions_counter.get((a["mode"], b["mode"]), 0) + 1
+    transitions = [{"from": f, "to": t, "count": c}
+                   for (f, t), c in sorted(transitions_counter.items())]
+
+    archetype = classify_archetype(mode_distribution, tier_distribution, mode_counts, profile)
+
+    return {
+        "sequence": seq,
+        "tier_distribution": tier_distribution,
+        "mode_distribution": mode_distribution,
+        "agency_score": agency_score,
+        "threshold_gaps": threshold_gaps,
+        "transitions": transitions,
+        "archetype": archetype,
+    }
+
+
+def classify_archetype(mode_dist: dict, tier_dist: dict, mode_counts: dict, profile: dict) -> dict:
+    """Evaluate each archetype's declarative rule; return the first match, else the default."""
+    agency_mode_ids = [m["id"] for m in profile["modes"] if m["tier"] == "agency"]
+    thresholds = {m["id"]: m.get("threshold", 0.0) for m in profile["modes"]}
+    modal_mode = max(mode_counts, key=mode_counts.get) if mode_counts else None
+    ctx = {
+        "mode_dist": mode_dist, "tier_dist": tier_dist, "modal_mode": modal_mode,
+        "agency_mode_ids": agency_mode_ids, "thresholds": thresholds,
+    }
+    for arch in profile.get("archetypes", []):
+        if _eval_rule(arch.get("rule", ""), ctx):
+            return {"id": arch["id"], "label": arch["label"],
+                    "rationale": arch.get("rule", "")}
+    default_id = profile.get("archetype_default")
+    match = next((a for a in profile.get("archetypes", []) if a["id"] == default_id), None)
+    if match:
+        return {"id": match["id"], "label": match["label"], "rationale": "default"}
+    return {"id": default_id or "unknown", "label": default_id or "Unknown", "rationale": "default"}
+
+
+def _eval_rule(rule: str, ctx: dict) -> bool:
+    """Tiny, safe evaluator for the profile archetype DSL (no eval()).
+
+    Grammar:  rule := clause (' AND ' clause)*
+              clause := 'modal_mode == <mode_id>'  |  <sum> OP <rhs>
+              sum    := term (' + ' term)*
+              term   := 'tier:<id>' | 'mode:<id>' | 'any_agency_mode'
+              OP     := '>=' | '=='
+              rhs    := <float> | 'threshold' (the LHS mode's own threshold)
+    Any parse failure yields False (the rule simply doesn't fire).
+    """
+    try:
+        return all(_eval_clause(c.strip(), ctx) for c in rule.split(" AND ") if c.strip())
+    except Exception:
+        return False
+
+
+def _eval_clause(clause: str, ctx: dict) -> bool:
+    if clause.startswith("modal_mode"):
+        _, _, target = clause.partition("==")
+        return ctx["modal_mode"] == target.strip()
+
+    op = ">=" if ">=" in clause else ("==" if "==" in clause else None)
+    if op is None:
+        return False
+    lhs_raw, _, rhs_raw = clause.partition(op)
+    terms = [t.strip() for t in lhs_raw.split("+")]
+    lhs_val = sum(_resolve_term(t, ctx) for t in terms)
+
+    rhs_raw = rhs_raw.strip()
+    if rhs_raw == "threshold":
+        # single mode:<id> term on the LHS → use that mode's threshold
+        mid = terms[0].split(":", 1)[1] if terms[0].startswith("mode:") else None
+        rhs_val = ctx["thresholds"].get(mid, 0.0)
+    else:
+        rhs_val = float(rhs_raw)
+
+    return lhs_val >= rhs_val if op == ">=" else lhs_val == rhs_val
+
+
+def _resolve_term(term: str, ctx: dict) -> float:
+    if term.startswith("tier:"):
+        return ctx["tier_dist"].get(term.split(":", 1)[1], 0.0)
+    if term.startswith("mode:"):
+        return ctx["mode_dist"].get(term.split(":", 1)[1], 0.0)
+    if term == "any_agency_mode":
+        return max((ctx["mode_dist"].get(m, 0.0) for m in ctx["agency_mode_ids"]), default=0.0)
+    raise ValueError(f"unknown term '{term}'")
+
+
+# ---------------------------------------------------------------------------
+# Report assembly
+# ---------------------------------------------------------------------------
+
+def build_report(profile: dict, conversation_id: str, message_count: int,
+                 student_turn_count: int, body: dict) -> dict:
+    return {
+        "schema_version": CONTRACT_SCHEMA_VERSION,
+        "profile_id": profile["profile_id"],
+        "profile_version": profile.get("version"),
+        "profile_status": profile.get("status"),
+        "attribution": profile.get("attribution"),
+        "conversation_id": conversation_id,
+        "message_count": message_count,
+        "student_turn_count": student_turn_count,
+        **body,
+    }
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description="Classify AI engagement modes over a transcript.")
+    ap.add_argument("--transcript", help="Path to transcript JSON (see module docstring).")
+    ap.add_argument("--profile", default=DEFAULT_PROFILE, help=f"Taxonomy profile id (default {DEFAULT_PROFILE}).")
+    ap.add_argument("--list-profiles", action="store_true", help="List available profiles and exit.")
+    ap.add_argument("--dry-run", action="store_true", help="Print the assembled prompt; no LLM call.")
+    ap.add_argument("--provider", default="anthropic", help="LLM provider (currently: anthropic).")
+    ap.add_argument("--model", default="claude-sonnet-4-6", help="Model id.")
+    ap.add_argument("--out", help="Write the report JSON here (default: stdout).")
+    args = ap.parse_args()
+
+    if args.list_profiles:
+        for pid in list_profiles():
+            p = load_profile(pid)
+            print(f"{pid:24s} {p.get('status','?'):11s} {p.get('display_name','')}")
+        return 0
+
+    if not args.transcript:
+        ap.error("--transcript is required (or use --list-profiles)")
+
+    profile = load_profile(args.profile)
+    convo = json.loads(Path(args.transcript).read_text(encoding="utf-8"))
+    messages = convo.get("messages", [])
+    conversation_id = convo.get("conversation_id", Path(args.transcript).stem)
+
+    system = build_system_prompt(profile)
+    user, student_turn_count = build_user_prompt(messages)
+
+    if args.dry_run:
+        print("===== SYSTEM =====\n" + system)
+        print("\n===== USER =====\n" + user)
+        report = build_report(profile, conversation_id, len(messages), student_turn_count,
+                              aggregate([], profile))
+        print("\n===== EMPTY CONTRACT (no LLM call) =====\n"
+              + json.dumps(report, indent=2))
+        return 0
+
+    llm = make_provider(args.provider, args.model)
+    raw = llm.complete(system, user, temperature=0.0)
+    parsed = _parse_response(raw)
+    if not parsed or "sequence" not in parsed:
+        print("Model did not return a valid {'sequence': [...]} object.", file=sys.stderr)
+        print(raw, file=sys.stderr)
+        return 1
+
+    report = build_report(profile, conversation_id, len(messages), student_turn_count,
+                          aggregate(parsed["sequence"], profile))
+    out_text = json.dumps(report, indent=2)
+    if args.out:
+        Path(args.out).write_text(out_text + "\n", encoding="utf-8")
+        print(f"Wrote {args.out}  (agency_score={report['agency_score']}, "
+              f"archetype={report['archetype']['id']})")
+    else:
+        print(out_text)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What

A new cb primitive — `ai_engagement_classifier` — that classifies how a student engages an AI across a conversation, using a **swappable taxonomy profile** instead of a hard-coded framework.

Ships as a **placeholder** modeled on the aimodes.ai structure (Dr. Mark Keith, BYU) for dev/testing. It is **our own working approximation, not his validated instrument** — every output carries that attribution. If we collaborate with Keith, his validated definitions/thresholds/routes drop in as just another profile.

## The one design decision

The framework — tiers, modes, per-mode thresholds, archetypes — lives in a `.json` profile under `lib/agents/knowledge/engagement_taxonomy/`, not in code:

| Need | How |
|---|---|
| Placeholder now | `aimodes_placeholder.json` (8 modes / 3 tiers) |
| Revert to 3-tier | swap in `three_tier.json` — zero code change |
| Compare a 5-tier AI-use model | add one JSON |
| Plug in Keith's validated model | his definitions become a profile, attributed to him |
| Don't waste dev-era data | raw transcripts stored → re-classify history under any new profile |

## How it works

The LLM only produces the ordered per-turn `sequence` (one mode per student turn). Everything else — tier/mode distribution, the **0–100 agency score**, threshold gaps, **transitions (the route)**, and archetype — is computed deterministically in Python, so it's unit-tested with no model call.

`--dry-run` prints the assembled prompt + empty contract (no LLM). `--list-profiles` enumerates profiles.

## Files
- `lib/tools/ai_engagement_classifier.py` — engine + CLI (LLM provider mirrors `grader_grade`'s pattern)
- `lib/agents/knowledge/engagement_taxonomy/aimodes_placeholder.json` — placeholder profile
- `lib/agents/knowledge/engagement_taxonomy/three_tier.json` — revert target, proves the swap
- `lib/tests/test_ai_engagement_classifier.py` — 18 deterministic tests
- `docs/ai-engagement-classifier-design.md` — design + how ngai-n8n consumes it

## Consumer (ngai-n8n)
cb owns the primitive; ngai-n8n's qc-agent becomes a thin caller and stores the contract keyed by `canvas_user_id × course_id × term` for per-class → multi-class → longitudinal rollup (project "can-do" axis × knowledge "engagement" axis). Design doc has the details.

## Verification
- 18/18 new tests pass; **full suite 862/862**; ruff clean.
- Thresholds/mode definitions in the placeholder are provisional (exercise the pipeline, not make claims about students) — flagged in the profile + design doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
