### PR TITLE
docs: state the trusted-operator token model

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Canvas Toolbox is the third option: **AI-assisted grading you train, review, and
 - **Brain-agnostic LLM** — Claude, GPT, Gemini, or local Ollama. You're not locked into a vendor.
 - **Read-only by default for audits** — every audit reports findings; none of them change anything in your Canvas course.
 - **Local files are source of truth** — Canvas is the sync target, not the source. Nothing pushes without your explicit approval.
+- **Trusted-operator token model** — cb reads `CANVAS_API_TOKEN` from your environment and calls Canvas directly; it assumes *you* run it. If an autonomous agent runs cb, keep the token out of the agent's environment and isolate it at the deployment layer — cb can't (and won't pretend to) hide a secret from a process that can read files.
 
 ### Grading safety gates (the highest-stakes workflow)
 


### PR DESCRIPTION
## What

Adds one architectural-commitment bullet to README's **"What you can trust"** list, making cb's token trust model explicit:

> **Trusted-operator token model** — cb reads `CANVAS_API_TOKEN` from your environment and calls Canvas directly; it assumes *you* run it. If an autonomous agent runs cb, keep the token out of the agent's environment and isolate it at the deployment layer — cb can't (and won't pretend to) hide a secret from a process that can read files.

## Why

Settles the direction discussed around #170. cb's average user is a trusted human operator running the CLI by hand — for them, `.env` + direct API is the correct, zero-friction interface, not a weakness. The agent-exfiltration threat only exists when an autonomous agent runs cb (the ngai-n8n context), and the right fix for that lives in the **deployment/orchestration layer** (don't put the token in the agent's environment), not baked into the toolkit.

This bullet documents that stance honestly — pairing naturally with the existing **"AI disclosure, no opt-out"** commitment: both are "we won't pretend" promises.

Docs-only. No code, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
