### PR TITLE
fix(sync): scope _course.json status/hash to late_policy (#182)

### DIFF
--- a/lib/tests/test_canvas_sync_status_course_level.py
+++ b/lib/tests/test_canvas_sync_status_course_level.py
@@ -29,6 +29,14 @@ def _write(path: Path, text: str) -> str:
     return canvas_sync._file_hash(path)
 
 
+def _write_course(path: Path, late_policy: dict, **fields) -> str:
+    """Write a realistic _course.json (late_policy + course-level fields) and
+    return its late_policy-ONLY hash — what --status/--push actually compare (#182)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"late_policy": late_policy, **fields}), encoding="utf-8")
+    return canvas_sync._course_late_policy_hash(path)
+
+
 def test_no_changes_on_a_freshly_pulled_mirror(tmp_path):
     home = tmp_path / "homepage.html"
     syl = tmp_path / "syllabus.html"
@@ -36,7 +44,7 @@ def test_no_changes_on_a_freshly_pulled_mirror(tmp_path):
     index = {
         "homepage": {"filepath": str(home), "hash": _write(home, "<p>home</p>")},
         "syllabus": {"filepath": str(syl), "hash": _write(syl, "<p>syllabus</p>")},
-        "course_hash": _write(course, json.dumps({"late_policy": {}})),
+        "course_hash": _write_course(course, {}),
     }
     assert canvas_sync._special_file_changes(index, course_path=course) == []
 
@@ -57,7 +65,7 @@ def test_detects_edited_homepage_and_course(tmp_path):
     course = tmp_path / "_course.json"
     index = {
         "homepage": {"filepath": str(home), "hash": _write(home, "<p>home</p>")},
-        "course_hash": _write(course, json.dumps({"late_policy": {"late_percent": 10}})),
+        "course_hash": _write_course(course, {"late_percent": 10}),
     }
     home.write_text("<p>EDITED</p>", encoding="utf-8")
     course.write_text(json.dumps({"late_policy": {"late_percent": 50}}), encoding="utf-8")
@@ -65,6 +73,34 @@ def test_detects_edited_homepage_and_course(tmp_path):
     labels = [label for label, _ in canvas_sync._special_file_changes(index, course_path=course)]
 
     assert labels == ["Homepage", "Course"]
+
+
+def test_name_edit_alone_is_not_flagged(tmp_path):
+    """#182: editing a non-pushable field (name) must NOT show as `[Course]`.
+    --push only round-trips late_policy, so surfacing a name edit as pending would
+    imply a sync that then gets silently dropped."""
+    course = tmp_path / "_course.json"
+    index = {"course_hash": _write_course(course, {"late_percent": 10}, name="BIO 101")}
+    # change ONLY the name; late_policy untouched
+    course.write_text(
+        json.dumps({"late_policy": {"late_percent": 10}, "name": "BIO 101 - Fall"}),
+        encoding="utf-8")
+
+    assert canvas_sync._special_file_changes(index, course_path=course) == []
+
+
+def test_late_policy_edit_is_flagged_even_with_other_fields(tmp_path):
+    """The flip side of #182: a real late_policy change IS flagged, even when the
+    file also carries name/dates that never push."""
+    course = tmp_path / "_course.json"
+    index = {"course_hash": _write_course(course, {"late_percent": 10}, name="BIO 101")}
+    course.write_text(
+        json.dumps({"late_policy": {"late_percent": 50}, "name": "BIO 101"}),
+        encoding="utf-8")
+
+    labels = [label for label, _ in canvas_sync._special_file_changes(index, course_path=course)]
+
+    assert labels == ["Course"]
 
 
 def test_absent_files_are_not_reported(tmp_path):

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -176,6 +176,24 @@ def _file_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
 
 
+def _course_late_policy_hash(path: Path) -> str:
+    """Hash ONLY the late_policy sub-object of _course.json.
+
+    cmd_push round-trips only late_policy (PATCH .../late_policy) — never name,
+    course_code, dates, or grading_standard_id. So status and the stored
+    course_hash must reflect exactly that. Hashing the whole file instead made an
+    edit to a non-pushable field (e.g. name) show as `M [Course]` in --status and
+    then get silently dropped by --push, which still reported OK (#182). Scoping
+    the hash to late_policy keeps status honest: [Course] appears only when
+    something push can actually write has changed.
+    """
+    try:
+        lp = json.loads(path.read_text(encoding="utf-8")).get("late_policy", {})
+    except (OSError, json.JSONDecodeError):
+        return ""
+    return hashlib.sha256(json.dumps(lp, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+
+
 def _slug(text: str) -> str:
     """Convert a title to a filesystem-safe slug."""
     text = text.lower()
@@ -651,7 +669,7 @@ def cmd_init():
     course_path = COURSE_DIR / "_course.json"
     course_path.write_text(json.dumps(course_meta, indent=2))
     index["course"] = course_meta  # summary in index for agent lookup
-    index["course_hash"] = _file_hash(course_path)
+    index["course_hash"] = _course_late_policy_hash(course_path)  # only late_policy pushes (#182)
     print(f"Course: {course.get('name')}")
 
     # Homepage (Canvas front_page — not a module item)
@@ -1251,6 +1269,11 @@ def _special_file_changes(index: dict, course_path: Optional[Path] = None) -> li
     guard. cmd_status must diff them too — a status that under-reports what push
     will do is the dangerous direction to be wrong in on a live course.
 
+    _course.json is diffed by its late_policy sub-object ONLY (via
+    _course_late_policy_hash), because that is the only field cmd_push writes.
+    Edits to name/dates/grading_standard_id are not pushable and must not show as
+    a pending [Course] change (#182).
+
     Returns a list of (label, filepath) for whatever is dirty.
     """
     course_path = Path(course_path) if course_path is not None else COURSE_DIR / "_course.json"
@@ -1264,7 +1287,7 @@ def _special_file_changes(index: dict, course_path: Optional[Path] = None) -> li
         if path.exists() and _file_hash(path) != meta.get("hash"):
             changes.append((label, str(path)))
 
-    if course_path.exists() and _file_hash(course_path) != index.get("course_hash"):
+    if course_path.exists() and _course_late_policy_hash(course_path) != index.get("course_hash"):
         changes.append(("Course", str(course_path)))
 
     return changes
@@ -1471,7 +1494,7 @@ def cmd_push(target: Optional[str] = None):
     # Check _course.json — late_policy and other course-level settings
     course_path = COURSE_DIR / "_course.json"
     if course_path.exists() and (not target or "_course" in target or "course" == target):
-        course_hash = _file_hash(course_path)
+        course_hash = _course_late_policy_hash(course_path)  # only late_policy pushes (#182)
         stored_hash = index.get("course_hash")
         if course_hash != stored_hash:
             print(f"  [Course] {course_path}")


### PR DESCRIPTION
Closes #182.

## Problem

`sync --status` flagged `_course.json` as `M [Course]` whenever **any** field changed, but `cmd_push` only ever writes `late_policy`. So editing a non-pushable field (name, course_code, start/end dates, grading_standard_id):
- `--status` showed `M _course.json [Course]` (looked pushable),
- `--push` printed `[Course] OK (late_policy updated)` and advanced `course_hash`,
- the edit was **silently discarded** — a false "success."

## Fix (Option 1 from the issue)

Hash **only the `late_policy` sub-object** (new `_course_late_policy_hash`) at all three compute sites — init, status, push. Status now flags `[Course]` exactly when push can act; a name edit correctly shows nothing (it isn't syncable — implying otherwise was the bug).

This aligns the code with `_special_file_changes`'s own docstring, which already said it tracks *"_course.json (late_policy)"* — the hash was just whole-file by mistake.

## Tests

- Repointed the two existing course tests to late_policy-scoped hashing.
- **New:** `test_name_edit_alone_is_not_flagged` (name-only edit → no `[Course]`) and `test_late_policy_edit_is_flagged_even_with_other_fields` (real late_policy change still flags, even alongside non-pushable fields). The old suite never varied a top-level field, so this gap was uncovered.
- Verified: 19 status tests + 54 across all `_course.json`-touching suites pass; ruff clean.

## One-time migration note

Existing mirrors carry a whole-file `course_hash`, so the **first** `--status` after upgrading shows `[Course]` once; a push re-bases it to the late_policy hash (the `late_policy` PATCH is idempotent). Harmless, one-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
