### PR TITLE
feat(syllabus_audit): syllabus-vs-Canvas late-policy check, guarded (#185)

### DIFF
--- a/lib/tests/test_syllabus_audit.py
+++ b/lib/tests/test_syllabus_audit.py
@@ -188,3 +188,76 @@ def test_render_image_warning_only_when_grade_scale_missing():
     ok = _render_output(secs, {**_BASE_ADVISORY, "embedded_images": 2,
                                "grade_scale_in_text": True})
     assert "invisible to screen readers" not in ok        # text scale present -> quiet
+
+
+# ---------------------------------------------------------------------------
+# late-policy mismatch check (#185) — detection, guards, and the three render
+# states. Online-only; masters/sandboxes (no enrolled students) are skipped.
+# ---------------------------------------------------------------------------
+
+def test_mentions_late_policy_only_penalty_language():
+    # penalty-grade / auto-deduction language -> True
+    assert S.mentions_late_policy("10% is deducted per day late")
+    assert S.mentions_late_policy("a penalty applies for late work")
+    assert S.mentions_late_policy("your grade is reduced by 5% per day")
+    # soft timeliness mentions -> False (the naive false-positive #185 fixed)
+    assert not S.mentions_late_policy("late work as a sign of professionalism; "
+                                      "complete your work on time")
+    assert not S.mentions_late_policy("please submit assignments by the due date")
+
+
+def test_late_policy_enabled():
+    assert S.late_policy_enabled({"late_submission_deduction_enabled": True})
+    assert S.late_policy_enabled({"missing_submission_deduction_enabled": True})
+    assert not S.late_policy_enabled({"late_submission_deduction_enabled": False,
+                                      "missing_submission_deduction_enabled": False})
+    assert not S.late_policy_enabled(None)  # course has no late policy configured
+
+
+def test_fetch_late_policy_unwraps_api_nesting(monkeypatch):
+    monkeypatch.setattr(S, "_get", lambda ep, params=None:
+                        {"late_policy": {"late_submission_deduction_enabled": True}})
+    assert S.fetch_late_policy("1") == {"late_submission_deduction_enabled": True}
+    monkeypatch.setattr(S, "_get", lambda ep, params=None: None)
+    assert S.fetch_late_policy("1") is None
+
+
+def test_course_has_enrolled_students(monkeypatch):
+    monkeypatch.setattr(S, "_get", lambda ep, params=None: {"total_students": 30})
+    assert S.course_has_enrolled_students("1")
+    monkeypatch.setattr(S, "_get", lambda ep, params=None: {"total_students": 0})
+    assert not S.course_has_enrolled_students("1")   # master/sandbox -> skip the check
+    monkeypatch.setattr(S, "_get", lambda ep, params=None: None)
+    assert not S.course_has_enrolled_students("1")   # fetch failed -> skip, don't crash
+
+
+def test_detect_advisory_includes_late_policy_keys():
+    adv = S.detect_advisory("10% is deducted per day late", "<p>x</p>")
+    assert adv["syllabus_states_late_policy"] is True
+    assert adv["late_policy_configured"] is None      # set only online + enrolled
+    adv2 = S.detect_advisory("welcome to the course", "<p>x</p>")
+    assert adv2["syllabus_states_late_policy"] is False
+
+
+def test_render_flags_late_policy_mismatch():
+    """Syllabus states an auto-deduction but Canvas's Late Policy is off -> warn."""
+    secs = detect_sections("10% is deducted per day late")
+    out = _render_output(secs, {**_BASE_ADVISORY, "syllabus_states_late_policy": True,
+                                "late_policy_configured": False})
+    assert "Gradebook Late Policy" in out and "OFF" in out
+
+
+def test_render_confirms_when_policy_on():
+    secs = detect_sections("10% is deducted per day late")
+    out = _render_output(secs, {**_BASE_ADVISORY, "syllabus_states_late_policy": True,
+                                "late_policy_configured": True})
+    assert "on to enforce it" in out
+    assert "OFF, so Canvas" not in out
+
+
+def test_render_silent_when_late_policy_not_checked():
+    """None = skipped (offline or non-enrolled master) -> NO late-policy line at all."""
+    secs = detect_sections("10% is deducted per day late")
+    out = _render_output(secs, {**_BASE_ADVISORY, "syllabus_states_late_policy": True,
+                                "late_policy_configured": None})
+    assert "Late-work policy" not in out

--- a/lib/tools/syllabus_audit.py
+++ b/lib/tools/syllabus_audit.py
@@ -167,6 +167,33 @@ def fetch_syllabus(course_id: str) -> tuple[str, str | None]:
     return name, ("" if body is None else str(body))
 
 
+def fetch_late_policy(course_id: str) -> dict | None:
+    """The course's Gradebook Late Policy (GET /courses/:id/late_policy) — the auto
+    missing/late-submission deduction from Gradebook → Settings → Late Policies.
+    None if the course has none set or the request fails. Online only; this setting
+    is not part of a `.imscc` export or a `--pull` mirror (#185)."""
+    resp = _get(f"/courses/{course_id}/late_policy")
+    if isinstance(resp, dict):
+        return resp.get("late_policy", resp)  # API nests under "late_policy"
+    return None
+
+
+def late_policy_enabled(lp: dict | None) -> bool:
+    """True if Canvas is set to auto-enforce a late and/or missing deduction."""
+    return bool(lp and (lp.get("late_submission_deduction_enabled")
+                        or lp.get("missing_submission_deduction_enabled")))
+
+
+def course_has_enrolled_students(course_id: str) -> bool:
+    """True if the course has enrolled students. Masters/sandboxes/templates have
+    none — and legitimately leave the Gradebook Late Policy unset (it lives in the
+    derived teaching sections), so the late-policy mismatch check skips them to
+    avoid nagging loudest where an unset policy is expected (#185)."""
+    course = _get(f"/courses/{course_id}", {"include[]": "total_students"})
+    total = course.get("total_students") if isinstance(course, dict) else None
+    return isinstance(total, int) and total > 0
+
+
 # ---------------------------------------------------------------------------
 # HTML → text
 # ---------------------------------------------------------------------------
@@ -569,6 +596,28 @@ def has_text_grade_scale(text: str) -> bool:
     return bool(_GRADE_SCALE_RE.search(text))
 
 
+# A syllabus "states an enforceable late penalty" only if it uses penalty-grade
+# (auto-deduction) language — NOT any soft "late work" mention. The naive first cut
+# nagged on courses that merely encourage timeliness ("late work as a sign of
+# professionalism, complete your work on time"). #185: tightened to deduction
+# vocabulary, which is exactly what the Gradebook Late Policy automates. Hard
+# cutoffs like "not accepted late" are intentionally excluded — Canvas's Late Policy
+# models auto-deduction, not non-acceptance (that's a lock-date concern).
+_LATE_PENALTY_PATTERNS = [
+    "deduct",                      # deduct / deducted / deduction
+    "penalty", "penaliz",          # penalty / penalized / penalize
+    "% per day", "percent per day", "points per day", "per day late",
+    "lose points", "grade reduction", "reduced by", "marked down",
+    "late deduction",
+]
+
+
+def mentions_late_policy(text: str) -> bool:
+    """True if the syllabus describes an enforceable late-work *penalty* (auto-
+    deduction grade language) — not just a soft mention of timeliness (#185)."""
+    return _any(text, _LATE_PENALTY_PATTERNS)
+
+
 def detect_advisory(text: str, body: str) -> dict:
     wc = word_count(text)
     return {
@@ -580,6 +629,12 @@ def detect_advisory(text: str, body: str) -> dict:
         # detects the outcomes SECTION (heading/stem), not a bare keyword hit.
         "outcomes_present": detect_outcomes_section(body) is not None,
         "learning_model_present": _any(text, _LEARNING_MODEL_PATTERNS),
+        # #185 late-policy check: whether the syllabus states an auto-deduction, and
+        # (set online for enrolled courses in main()) whether Canvas's Gradebook Late
+        # Policy is actually configured to enforce it. None = not checked (offline or
+        # a non-enrolled master/sandbox — an unset policy is expected there).
+        "syllabus_states_late_policy": mentions_late_policy(text),
+        "late_policy_configured": None,
     }
 
 
@@ -686,6 +741,23 @@ def _render(course_id: str, course_name: str, verdict: str, missing: list[str],
                     "was found — if the scale is shown only as an image it's invisible "
                     "to screen readers AND to this audit; add a text equivalent"
                     if image_only_risk else ""))
+
+    # #185 late-policy: only rendered when actually checked (online + enrolled).
+    # `late_policy_configured` is None when skipped (offline / non-enrolled master)
+    # — we stay silent then rather than nag where an unset policy is expected.
+    states_late = advisory.get("syllabus_states_late_policy")
+    configured = advisory.get("late_policy_configured")
+    if states_late and configured is False:
+        lines.append("  • ⚠️ Late-work policy: your syllabus describes an auto-deduction, "
+                     "but the course's Gradebook Late Policy (Settings → Late Policies) is "
+                     "OFF, so Canvas won't apply it automatically. That's fine IF you deduct "
+                     "manually or per-student (student_late_accommodation); otherwise turn the "
+                     "Late Policy on so the syllabus and Canvas agree.")
+    elif states_late and configured is True:
+        lines.append("  • Late-work policy: stated in the syllabus and the Gradebook Late "
+                     "Policy is on to enforce it ✅  (note: a per-student late accommodation "
+                     "that drops lock_at but keeps due_at is still auto-deducted — shift due_at "
+                     "too, or handle that student's penalty manually)")
     lines.append("")
 
     if missing:
@@ -842,6 +914,13 @@ def main() -> None:
     sections = detect_sections(text)
     ai_policy = detect_ai_policy(text)
     advisory = detect_advisory(text, body)
+    # #185: online + enrolled courses only — compare the syllabus's stated late
+    # penalty against the actual Gradebook Late Policy. Only bother when the syllabus
+    # states one (else nothing to compare) and the course has students (masters/
+    # sandboxes legitimately leave it unset). Read-only; two cheap GETs.
+    if not use_local and advisory["syllabus_states_late_policy"] \
+            and course_has_enrolled_students(course_id):
+        advisory["late_policy_configured"] = late_policy_enabled(fetch_late_policy(course_id))
     verdict, missing = compute_verdict(sections, ai_policy, body_words,
                                        ai_policy_required=(institution == "byui"))
 


### PR DESCRIPTION
Closes #185.

Re-introduces the late-policy mismatch check (built + deferred out of #140) **with the guards the review asked for**, so it ships honestly.

## What it does
Flags when a syllabus **describes an auto-deduction** but the course's Gradebook Late Policy (`GET /courses/:id/late_policy`) isn't set to apply it. Verdict-neutral advisory, online-only.

## The guards (why the naive first cut was deferred)
- **Online + ENROLLED only.** Masters/sandboxes have no students and legitimately leave the policy unset (it lives in the derived teaching sections) → skipped, so it no longer nags loudest where an unset policy is expected.
- **Tightened detection** to penalty-grade / auto-deduction language (`deduct`, `penalty`, `% per day`, …) — not soft "late work" mentions that fired on courses merely encouraging timeliness.
- **Reframed honestly:** *"your syllabus describes an auto-deduction, but the Gradebook Late Policy is off"* — acknowledges per-student (`student_late_accommodation`) and manual enforcement as valid, instead of "you're not enforcing late work."
- **Silent when not checked** (offline / non-enrolled) — no late-policy line at all.
- **Surfaces the accommodation gotcha** (drop `lock_at` but keep `due_at` → still auto-deducted) in the policy-on confirmation.

Only fires two extra GETs when the syllabus actually states a penalty.

## Verification
- **25 unit tests** (17 existing + 8 new): detection (penalty vs soft mention), `late_policy_enabled`, fetch unwrap, the enrollment guard, advisory keys, and all three render states (warn / confirm / silent-when-skipped). ruff clean.
- **Live-validated against sandbox 427808:** 0 enrolled students → check correctly **skipped**, full CLI runs clean, no false nag. Probe confirmed `fetch_late_policy`/`late_policy_enabled` read real Canvas data correctly.

### Not yet live-tested: the WARN/CONFIRM paths
The sandbox has 0 students (guard skips it) and no penalty language, so it can't exercise the actual mismatch warning. Those paths are unit-covered; to see them against real Canvas we'd run read-only against an **enrolled** course (the audit writes nothing). Happy to do that before merge if you want to point me at one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
