### PR TITLE
docs(knowledge): grader_hybrid_architecture — layer-routed NLP + LLM grading

### DIFF
--- a/lib/agents/knowledge/README.md
+++ b/lib/agents/knowledge/README.md
@@ -31,6 +31,7 @@ The twelve files cover overlapping but distinct ground. Quick routing:
 | Per-instructor comment voice for the grading pipeline | [`grader_voice_knowledge.md`](grader_voice_knowledge.md) |
 | Coaching a new faculty on feedback style — research-grounded WHAT/HOW split + first-time voice articulation | [`voice_coaching_knowledge.md`](voice_coaching_knowledge.md) |
 | Onboarding a new instructor / assignment to the grader (6-step interview) | [`grader_setup_knowledge.md`](grader_setup_knowledge.md) |
+| The layer-routed NLP + LLM hybrid grading architecture (which layer owns which rubric row; priors never score) | [`grader_hybrid_architecture.md`](grader_hybrid_architecture.md) |
 | Title IV course-engagement audit — classifying students into UW/UF/Never-Participated/Active by last engagement date for R2T4 reporting (NEW FERPA tier 3 — Downloads-folder named report) | [`course_engagement_audit_knowledge.md`](course_engagement_audit_knowledge.md) |
 
 ---
@@ -239,6 +240,17 @@ The twelve files cover overlapping but distinct ground. Quick routing:
 **Audit tag:** none (operational reference, not an audit producer).
 **Status:** ✅ **v1.0** (ds460 KC1 alpha 2026-06-10: 20/22 within 0.5 on the medium criterion; cohort mean within 0.09 of the original push).
 **Consumed by:** `canvas_grader.md`. **Pairs with:** [`grader_voice_knowledge.md`](grader_voice_knowledge.md), [`grader_setup_knowledge.md`](grader_setup_knowledge.md), [`rubrics_knowledge.md`](rubrics_knowledge.md), [`canvas_api_knowledge.md`](canvas_api_knowledge.md), [`canvas_api_lessons_learned.md`](canvas_api_lessons_learned.md), [`assessments_knowledge.md`](assessments_knowledge.md), [`backwards_design_knowledge.md`](backwards_design_knowledge.md).
+
+---
+
+### [`grader_hybrid_architecture.md`](grader_hybrid_architecture.md)
+
+**Source:** the #192 design thread — a real 23-submission prose-methodology grading run (off-Canvas, Brightspace) plus prior art across hybrid AES, feature-augmented LLM grading, LLM-as-judge, and RAG-for-grading.
+**Core idea:** The *how to think* for AI-assisted grading as a **layer-routed hybrid**. NLP owns the deterministic layers (lexical/pattern + syntactic/structural) as *evidence*; the LLM owns the semantic + holistic-judgment layers; a deterministic pass audits the LLM consensus; the instructor is the top layer. Route each rubric row by **checkability** (mechanical/coverage → NLP authoritative; judgment → LLM). Guardrails: priors never score, evidence-not-verdict, the audit stays (semi-)independent, route by checkability. **Enrichment** (corpus + features — quality lever) vs **token-reduction** (densify-not-truncate — cost lever) are opposite uses; never conflate. Decision support, not autonomy.
+**When to use:** Designing or running any hybrid NLP+LLM grading (esp. prose/methodology). Read alongside `grader_knowledge.md` (workflow) and `critical_thinking_knowledge.md` (rubric grounding).
+**Audit tag:** none (architecture reference, not an audit producer).
+**Status:** 🔧 design (issue #192).
+**Consumed by:** the grading agent + `grader_signals.py`, `grader_grade.py`, `grader_consensus.py`. **Pairs with:** [`grader_knowledge.md`](grader_knowledge.md), [`critical_thinking_knowledge.md`](critical_thinking_knowledge.md).
 
 ---
 

--- a/lib/agents/knowledge/grader_hybrid_architecture.md
+++ b/lib/agents/knowledge/grader_hybrid_architecture.md
@@ -1,0 +1,131 @@
+# Hybrid grading architecture — layer-routed NLP + LLM
+
+**Consumed by:** the grading agent + `grader_signals.py`, `grader_grade.py`,
+`grader_consensus.py`. Tracks issue #192.
+
+**Why this file exists:** canvas-toolbox grades *with* an LLM, but the LLM is not the
+whole grader. The defensible, reproducible way to grade prose, code, and methodology is a
+**layer-routed hybrid** — deterministic NLP owns the observable layers, the LLM owns the
+semantic/judgment layers, a deterministic pass audits the LLM, and the instructor decides.
+This file is the *how to think*, so grading follows the architecture by default rather than
+only when a human steers it. Read alongside `grader_knowledge` (the workflow) and
+`critical_thinking_knowledge` / `byui_ai_agency` (the rubric grounding).
+
+---
+
+## The core principle
+
+Route every rubric criterion and every quality signal to the layer that is *authoritative*
+for it — and never let a layer overreach. Regex must not pretend to judge insight; the LLM
+must not be trusted to count deterministically. The originality of good AI-assisted grading
+is not any one trick — it is the **disciplined refusal to let a layer do another layer's job.**
+
+## The four layers (cheapest/most-deterministic → richest/most-semantic)
+
+| # | Layer | Examples | Owner |
+|---|---|---|---|
+| 1 | **Lexical / pattern** | regex, counts, term-banks, citation detection, required-item coverage | **NLP** — deterministic evidence |
+| 2 | **Syntactic / structural** | sectioning, code-vs-prose split, AST, readability | **NLP** — deterministic structure |
+| 3 | **Semantic** | does the argument cohere, is this really addressing the prompt, is the reasoning sound | **LLM** |
+| 4 | **Holistic judgment** | insight, synthesis, the rubric's quality bands, feedback prose | **LLM** |
+
+Above all four sits **the instructor** — the top layer, who decides. The stack is
+**decision support, not autonomy** (see "The ceiling" below).
+
+## Routing rubric criteria by checkability
+
+The single decision that makes "put rubric knowledge in the script" robust instead of brittle:
+
+| Criterion type | Example | NLP can produce | Authoritative layer |
+|---|---|---|---|
+| **Mechanical / binary** | "includes a thesis", "≥3 citations", "defines the term", "code runs" | regex / count / AST → **hard evidence** | **NLP** (LLM confirms) |
+| **Coverage** | "addresses all 5 prompts", "discusses each of the 3 regulations" | per-item presence → **strong evidence, watch paraphrase** | **shared** — NLP flags, LLM verifies |
+| **Judgment / quality** | "demonstrates critical insight", "synthesizes sources", "clarity" | weak proxies only (readability, quote:analysis ratio) → **hints** | **LLM** (NLP contributes little) |
+
+Let NLP own the mechanical and coverage rows; leave the judgment rows to the LLM. Forcing
+regex onto "critical insight" is the fastest way to build an extractor that *fights* the LLM.
+
+## The guardrails (non-negotiable)
+
+1. **Priors never score.** NLP produces evidence and priors; it never sets the grade. The
+   grade is LLM judgment (consensus) confirmed by the instructor.
+2. **Evidence, not verdict.** Present every NLP feature to the LLM as evidence *to verify
+   against the text* — e.g. `citations: literal match 0 — check for paraphrase` — never as
+   "criterion met/unmet." This keeps the corpus in the loop and defeats keyword-stuffing (a
+   stuffed term-bank inflates the count, but the LLM reading the corpus catches the emptiness
+   — only if the feature is framed as evidence, not a met criterion).
+3. **Route by checkability.** NLP is authoritative only on mechanical/coverage rows.
+4. **The audit stays (semi-)independent.** NLP audits the LLM consensus against the evidence
+   and routes conflicts to a human; it never auto-moves a score. Feeding a signal *into* the
+   pass prompt reduces that signal's power *as an auditor* (the passes were nudged toward it),
+   so decide per signal whether it **grounds**, **audits**, or **both**.
+5. **The instructor is the top layer.** The stack surfaces evidence + judgment + conflicts;
+   the human decides.
+
+## Signal taxonomy — tag every signal in `grader_signals.py`
+
+- **`structural`** — reorganizes/parses the input (HTML → sections, code vs comments). Pure
+  feature engineering, **zero leakage**. Always inject.
+- **`evaluative`** — an observable property tied to a rubric row (citation count, coverage,
+  term-bank hits). Inject to ground **and/or** hold for the audit — operator choice per signal.
+- **`judgment-hint`** — a weak proxy for a soft row (readability, quote:analysis ratio).
+  Provide as a hint at most; never let it approach a score.
+
+The "leakage" worry scales with how *answer-like* a signal is: structural = none;
+observable-property = low (legitimate feature engineering); answer-proximity (similarity to a
+key) = high — that one makes the audit circular and invites parroting, so handle with care.
+
+## Enrichment vs token-reduction — know which lever you're pulling
+
+Two **opposite** uses of NLP. Both valid; never conflate them:
+
+- **Enrichment (quality lever):** corpus **+** computed features → the LLM grades better with
+  evidence pre-surfaced. Spends *more* tokens to buy accuracy and defensibility.
+- **Token-reduction (cost lever):** **densify, do not truncate.** Reorganize and surface the
+  relevant evidence so the same signal fits in fewer tokens; route pass-count by difficulty
+  (clear-cut → 1 pass, borderline → N); skip trivial cases. **Trimming the corpus blindly cuts
+  signal and lowers grade quality** — remove noise, never signal.
+
+On local Ollama tokens are ~free → prefer **enrichment**. On the cloud path → token-reduction pays.
+
+## The rubric is the source of truth
+
+Encode rubric knowledge as **data derived from the rubric** (term banks, required-item lists,
+thresholds), not hardcoded in the script. A rubric edit must update the extractors, or you
+silently grade last term's rubric.
+
+## The audit loop
+
+N independent **blind** LLM passes (temperature-varied, tier-shuffled) → **majority consensus**
+→ deterministic **conflict check** (majority tier vs its own evidence prior: tier-above-threshold
+but prior-below-floor, and vice-versa) → `conflict_needs_review` routed to a human. Consensus
+tames single-pass drift (one pass defaults conservatively to the middle tier); the audit catches
+where the holistic read diverged from the mechanical evidence. **Never auto-moves a score.**
+
+## How it maps to cb tools
+
+- **`grader_signals.py`** — the NLP layer: `structural` + `evaluative` + `judgment-hint`
+  signals, rubric-derived, each tagged. Prose set (length, citations, per-criterion term-banks,
+  coverage) alongside the existing code/notebook set.
+- **`grader_grade.py --with-signals`** — inject the evidence block into each pass prompt,
+  labeled "priors, NOT the score."
+- **`grader_consensus.py`** — emit `conflict_needs_review` from the prior-vs-tier rule table;
+  respect each signal's inject/audit/both tag.
+
+## The ceiling (build at the right altitude)
+
+"Rounds out the grader" is true for **decision support**, not autonomy. The stack is only as
+complete as the rubric decomposes, the extractors are good, and the LLM's soft-row judgment
+holds — and some dimensions (factual correctness of a domain claim, genuine originality)
+*neither* layer nails reliably. So the human stays in the loop not as a fallback but as the top
+layer. This is the same line cb draws everywhere: *your voice, your judgment.* The honest claim
+is the **most complete, most defensible decision-support grader** — it makes the human's call
+better and more auditable; it does not replace it.
+
+## Anti-patterns
+
+- **Regex on a judgment row** (insight, synthesis) — misleads; that's the LLM's job.
+- **A feature presented as a verdict** — invites over-trust and rewards keyword-stuffing.
+- **Hardcoded rubric knowledge** — drifts from the rubric silently.
+- **Trimming the corpus to save tokens** — cuts signal, lowers quality. Densify instead.
+- **Letting a prior set the score** — the entire architecture exists so it never does.

--- a/lib/agents/knowledge/grader_hybrid_architecture.md
+++ b/lib/agents/knowledge/grader_hybrid_architecture.md
@@ -88,11 +88,44 @@ Two **opposite** uses of NLP. Both valid; never conflate them:
 
 On local Ollama tokens are ~free → prefer **enrichment**. On the cloud path → token-reduction pays.
 
+## Stage 0 — when there is no rubric, elicit one first
+
+Everything above assumes a rubric with rows exists. Often it does not — the "rubric" lives in
+an assignment spec (e.g. a `challenge.md`), a few exemplars, or only in the professor's head.
+**Grading cannot start until that intent is made explicit.** Stage 0 is the precondition:
+co-create a structured rubric from the unstructured source *before* the layer-routed pipeline
+runs. (DS460 is the canonical case — the `challenge.md` *is* the rubric source.)
+
+It is itself a hybrid:
+- **Extract candidate criteria** — NLP/LLM pulls the explicit deliverables, requirements, and
+  constraints out of the spec (structural work).
+- **Elicit the quality bands** — the LLM proposes tiers / what-good-looks-like per criterion
+  and the professor refines them. This is the "tease out what they're looking for" step, and
+  the judgment is the professor's, not the model's.
+- **Tag each criterion by checkability** as you go (mechanical / coverage / judgment) with its
+  term-banks / required-items — so the output is already in the shape the pipeline consumes.
+
+Two Stage-0 guardrails:
+- **The professor owns the rubric.** The LLM proposes; the professor approves. Same "instructor
+  is the top layer" principle applied to the rubric itself — never grade against criteria the
+  professor didn't intend.
+- **Freeze the agreed rubric as a versioned artifact.** A teased-out rubric re-improvised each
+  run destroys reproducibility and defensibility (you'd grade against a moving target). A
+  `challenge.md`-derived rubric becomes a **checked-in** rubric the grading run reads, not a
+  fresh improvisation — that is what lets "the rubric is the source of truth" (below) hold even
+  when the rubric started life as prose.
+
+Existing cb tooling: the `grader_setup_knowledge` 6-step interview is where the elicitation
+happens; `rubrics_knowledge` / `rubric_recommender` help draft criteria. Stage 0 is those,
+aimed at producing a **hybrid-ready (checkability-tagged), frozen** rubric. After it, the full
+architecture applies unchanged.
+
 ## The rubric is the source of truth
 
 Encode rubric knowledge as **data derived from the rubric** (term banks, required-item lists,
 thresholds), not hardcoded in the script. A rubric edit must update the extractors, or you
-silently grade last term's rubric.
+silently grade last term's rubric. When the rubric came from Stage 0, "the rubric" means the
+**frozen artifact**, not the original prose spec.
 
 ## The audit loop
 


### PR DESCRIPTION
Companion to #192 — the *how to think*, so the grading agent follows the architecture by default (not only when steered).

## What
A new agent-facing knowledge file, `lib/agents/knowledge/grader_hybrid_architecture.md`, crystallizing the layer-routed hybrid grading design:

- **Four layers, routed to whoever's authoritative** — NLP owns lexical/pattern + syntactic/structural (deterministic *evidence*); the LLM owns semantic + holistic judgment; a deterministic pass audits the consensus; the **instructor is the top layer**.
- **Route rubric rows by checkability** — mechanical/coverage → NLP authoritative; judgment → LLM (never force regex onto "insight").
- **Guardrails** — priors never score; evidence-not-verdict (defeats keyword-stuffing); the audit stays (semi-)independent.
- **Signal taxonomy** — `structural` (zero-leakage feature engineering, always inject) / `evaluative` (inject and/or hold for audit) / `judgment-hint` (weak proxy, never a score).
- **Enrichment vs token-reduction** — opposite levers; densify, don't truncate (trimming the corpus cuts signal and lowers grade quality).
- **The ceiling** — decision support, not autonomy; the human stays the top layer (cb's "your voice, your judgment" line).
- Anti-patterns + how it maps to `grader_signals.py` / `grader_grade.py --with-signals` / `grader_consensus.py`.

Registered in the knowledge README (summary table + detailed entry). Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
