### PR TITLE
docs(knowledge): migrate the 8 no-json files to YAML frontmatter (batch 1)

### DIFF
--- a/lib/agents/knowledge/course_engagement_audit_knowledge.md
+++ b/lib/agents/knowledge/course_engagement_audit_knowledge.md
@@ -1,3 +1,22 @@
+---
+name: course_engagement_audit_knowledge
+version: "1.0"
+last_updated: 2026-06-26
+description: The Title IV last-date-of-academic-engagement audit — classifies enrolled students into UF / UW / Never-Participated / Active for R2T4 reporting.
+skill_type: knowledge
+shape: reference
+scope: "Title IV academic-engagement definition (34 CFR 668.22), the UF/UW/Never-Participated/Active classification, the Downloads-folder FERPA pattern, re-verification cadence. Out of scope: the financial-aid office's R2T4 calculation."
+consumed_by:
+  - canvas_grader.md
+  - canvas_course_expert.md
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+provenance:
+  sources:
+    - "34 CFR 668.22 (Title IV); local snapshots in sources/title_iv/ (verified 2026-06-26)"
+runtime_strategy: read_at_runtime
+metadata: { knowledge_id: course_engagement_audit_knowledge }
+---
+
 # Course Engagement Audit — Title IV last-date-of-engagement classifier
 
 > Reference. The Title IV federal-compliance audit that classifies enrolled students by their last date of academic engagement against an operator-provided UF cutoff date.

--- a/lib/agents/knowledge/course_homepage_knowledge.md
+++ b/lib/agents/knowledge/course_homepage_knowledge.md
@@ -1,16 +1,19 @@
 ---
 name: course_homepage_knowledge
-description: Pure-HTML/CSS Canvas course home page generator — DesignPLUS-free replacement. Reads a schedule.yml (one per course-section) + today's date; renders a static home page with the current week's section pre-expanded. Auto-tracks the semester via regenerate-on-cadence rather than runtime JS. Promotes the canvas-toolbox pattern used in `course_homepage_build.py`.
 version: "0.1"
-author: chaz-clark
-license: MIT
+last_updated: 2026-06-22
+description: Pure-HTML/CSS Canvas course home page generator (DesignPLUS-free) — reads a schedule.yml + today's date and renders a static home page with the current week pre-expanded, auto-tracked via regenerate-on-cadence rather than runtime JS.
+skill_type: knowledge
+shape: reference
+scope: "Design rationale + when-to-use for course_homepage_build.py — the HTML/CSS-native, DesignPLUS-free, regenerate-on-cadence home-page pattern."
+consumed_by:
+  - lib/tools/course_homepage_build.py
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+runtime_strategy: read_at_runtime
 metadata:
+  knowledge_id: course_homepage_knowledge
   topic: canvas-page-generation
-  precipitating-event: 2026-06-22 — BYUI moving off DesignPLUS for cost savings; need an HTML/CSS-native course-home-page tool
-  affects: any course wanting an interactive home page without DesignPLUS or JS injection
-  consumed_by:
-    - lib/tools/course_homepage_build.py
-read_at_runtime: selective_load
+  precipitating_event: "2026-06-22 — BYUI moving off DesignPLUS for cost savings; need an HTML/CSS-native course-home-page tool"
 ---
 
 # Course-homepage generation — pure HTML/CSS, DesignPLUS-free

--- a/lib/agents/knowledge/deid_master_knowledge.md
+++ b/lib/agents/knowledge/deid_master_knowledge.md
@@ -1,3 +1,21 @@
+---
+name: deid_master_knowledge
+version: "1.0"
+last_updated: 2026-06-26
+description: The de-identification master — the foundational primitive underneath every keyed / FERPA workflow; a stable user_id <-> deid_code surface.
+skill_type: knowledge
+shape: reference
+scope: "The deid master primitive (build_deid_master.py), the FERPA rule (agents never read .deid_master.csv), and how user_id / deid_code are used across keyed tools."
+consumed_by:
+  - student_late_accommodation.py
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+provenance:
+  sources:
+    - "issue #109 (v0.70.0, 2026-06-26)"
+runtime_strategy: read_at_runtime
+metadata: { knowledge_id: deid_master_knowledge }
+---
+
 # De-identification master — the foundational primitive
 
 **The missing primitive that sits underneath every keyed / FERPA workflow.**

--- a/lib/agents/knowledge/grader_hybrid_architecture.md
+++ b/lib/agents/knowledge/grader_hybrid_architecture.md
@@ -1,3 +1,28 @@
+---
+name: grader_hybrid_architecture
+version: "1.0"
+last_updated: 2026-07-16
+description: How to think about AI-assisted grading as a layer-routed NLP + LLM hybrid.
+skill_type: knowledge
+shape: identity
+scope: "Design philosophy for hybrid NLP+LLM grading — the four-layer routing + guardrails. Consumed by the grading agent and grader_signals.py / grader_grade.py / grader_consensus.py."
+consumed_by:
+  - canvas_grader.md
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+provenance:
+  sources:
+    - "issue #192 design thread"
+    - "prior art: hybrid AES, feature-augmented LLM grading, LLM-as-judge, RAG-for-grading"
+runtime_strategy: read_at_runtime
+principles:
+  - { id: HG-1, name: Route by checkability, compact_statement: "NLP owns mechanical/coverage rows; the LLM owns judgment. Never force regex onto 'insight'." }
+  - { id: HG-2, name: Priors never score, compact_statement: "NLP produces evidence; the grade is LLM consensus confirmed by the instructor." }
+  - { id: HG-3, name: Evidence not verdict, compact_statement: "Every NLP feature is evidence to verify against the text, never met/unmet — defeats keyword-stuffing." }
+  - { id: HG-4, name: Audit stays semi-independent, compact_statement: "NLP audits the consensus and routes conflicts to a human; a signal fed into the passes is a weaker auditor." }
+  - { id: HG-5, name: Instructor is the top layer, compact_statement: "Decision support, not autonomy — the human decides." }
+metadata: { knowledge_id: grader_hybrid_architecture }
+---
+
 # Hybrid grading architecture — layer-routed NLP + LLM
 
 **Consumed by:** the grading agent + `grader_signals.py`, `grader_grade.py`,

--- a/lib/agents/knowledge/imscc_format_knowledge.md
+++ b/lib/agents/knowledge/imscc_format_knowledge.md
@@ -1,3 +1,21 @@
+---
+name: imscc_format_knowledge
+version: "1.0"
+last_updated: 2026-07-12
+description: Technical reference for the Canvas .imscc format (IMS Common Cartridge v1.1 + Canvas extensions) — archive structure, manifest, XML, and parsing.
+skill_type: knowledge
+shape: reference
+scope: "The .imscc archive structure, imsmanifest.xml, course_settings/ Canvas extensions, and how to parse them — for .imscc import/export implementation."
+consumed_by:
+  - canvas_content_sync.md
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+provenance:
+  sources:
+    - "Canvas LMS docs, IMS Global Common Cartridge spec, canvas-imscc examples"
+runtime_strategy: read_at_runtime
+metadata: { knowledge_id: imscc_format_knowledge }
+---
+
 # Canvas .imscc Format - Technical Reference
 
 **Purpose**: Knowledge base for Sprint 4 (.imscc import/export) implementation

--- a/lib/agents/knowledge/sas_accommodations_knowledge.md
+++ b/lib/agents/knowledge/sas_accommodations_knowledge.md
@@ -1,3 +1,21 @@
+---
+name: sas_accommodations_knowledge
+version: "1.0"
+last_updated: 2026-07-16
+description: Catalog + dispatch knowledge for BYUI SAS accommodation types — the stable standardized asks and how apply_sas_accommodations.py dispatches each.
+skill_type: knowledge
+shape: reference
+scope: "The SAS accommodation catalog (canvas / proctoring / policy tiers) and the canvas-tier key -> tool dispatch. The catalog itself stays as body tables (reads better there)."
+consumed_by:
+  - apply_sas_accommodations.py
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+provenance:
+  sources:
+    - "life-pm SAS accommodation handoffs from BYUI Accessibility Services notification letters (byui.as@accessiblelearning.com)"
+runtime_strategy: read_at_runtime
+metadata: { knowledge_id: sas_accommodations_knowledge, facts_location: body }
+---
+
 # SAS accommodations — catalog + dispatch knowledge
 
 **Source:** life-pm produces SAS accommodation handoffs from BYUI

--- a/lib/agents/knowledge/voice_coaching_knowledge.md
+++ b/lib/agents/knowledge/voice_coaching_knowledge.md
@@ -1,3 +1,21 @@
+---
+name: voice_coaching_knowledge
+version: "1.0"
+last_updated: 2026-06-25
+description: Upstream coaching layer for the per-instructor voice file — research grounding for effective feedback, the voice-preservation contract, and first-time voice articulation.
+skill_type: knowledge
+shape: reference   # self-labeled "Reference"; arguably identity (coaching principles/contract) — CONFIRM
+scope: "The WHAT/HOW boundary, research-grounded WHAT criteria, voice dimensions faculty position on, and the articulation interview for new faculty. Out of scope: comment structure + edit roundtrip (grader_voice_knowledge)."
+consumed_by:
+  - canvas_grader.md
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+provenance:
+  sources:
+    - "8 pedagogical frameworks (Hattie/Wiggins/Dweck/Brookhart/CLT/warm-demander/Black-Wiliam/AI-voice-preservation); handoffs/2026-06-25_voice-coaching-research.md"
+runtime_strategy: read_at_runtime
+metadata: { knowledge_id: voice_coaching_knowledge }
+---
+
 # Voice Coaching — Upstream Scaffolding for the Per-Instructor Voice File
 
 > Reference. **Companion to [`grader_voice_knowledge.md`](grader_voice_knowledge.md).** That file is the structural framework + the per-instructor voice file CONTRACT. This file is the **upstream coaching layer** — research grounding for what makes feedback effective, voice-preservation contract that protects faculty identity, and scaffolding for first-time voice articulation BEFORE the existing edit roundtrip can refine it.

--- a/lib/agents/knowledge/voice_coaching_knowledge.md
+++ b/lib/agents/knowledge/voice_coaching_knowledge.md
@@ -4,7 +4,7 @@ version: "1.0"
 last_updated: 2026-06-25
 description: Upstream coaching layer for the per-instructor voice file — research grounding for effective feedback, the voice-preservation contract, and first-time voice articulation.
 skill_type: knowledge
-shape: reference   # self-labeled "Reference"; arguably identity (coaching principles/contract) — CONFIRM
+shape: reference   # settled reference; flip to identity later if coaching-principle issues surface
 scope: "The WHAT/HOW boundary, research-grounded WHAT criteria, voice dimensions faculty position on, and the articulation interview for new faculty. Out of scope: comment structure + edit roundtrip (grader_voice_knowledge)."
 consumed_by:
   - canvas_grader.md

--- a/lib/agents/knowledge/working_style_canvas_toolbox.md
+++ b/lib/agents/knowledge/working_style_canvas_toolbox.md
@@ -1,12 +1,18 @@
 ---
 name: canvas-toolbox-working-style
-description: Detailed working style guidelines for canvas-toolbox — project-specific rules with motivating cases
 version: "1.0"
-author: chaz-clark
-license: MIT
+last_updated: 2026-07-12
+description: Detailed working-style guidelines for canvas-toolbox — project-specific rules with the motivating cases behind each (bullet summaries live in AGENTS.md).
+skill_type: knowledge
+shape: identity
+scope: "Project-specific working-style rules for canvas-toolbox agents, with the motivating cases behind each. Quick-reference summaries live in AGENTS.md."
+consumed_by:
+  - AGENTS.md
+companion_json_deprecated: "2026-07-16 - authored as YAML frontmatter (JSON purge convention)"
+runtime_strategy: read_at_runtime
 metadata:
+  knowledge_id: canvas-toolbox-working-style
   repo: canvas-toolbox
-  last-updated: 2026-07-12
 ---
 
 # Canvas Toolbox Working Style (Detailed)


### PR DESCRIPTION
First batch of the knowledge-folder frontmatter migration (**Convention B**).

## Why
The `make_agent_knowledge` JSON companion was **deprecated system-wide 2026-07-07/08** ("consolidated into YAML frontmatter per JSON purge" — confirmed in every Make-AI-Agents skill file + the `behavioral-discipline` exemplar, whose `.json` is gone). So the compliant shape is a single `.md` with a YAML frontmatter spine, not an `.md`+`.json` pair. (Verified nothing in cb *reads* the `.json` at runtime.)

## This batch = the 8 files that had **no** `.json` (nothing to synthesize — pure retrofit)

| File | shape | note |
|---|---|---|
| `grader_hybrid_architecture` | identity | guardrails as `principles[]` in frontmatter |
| `sas_accommodations_knowledge` | reference | catalog **stays a body table** (`facts_location: body`) |
| `course_engagement_audit_knowledge` | reference | |
| `course_homepage_knowledge` | reference | already had partial frontmatter → upgraded |
| `deid_master_knowledge` | reference | |
| `imscc_format_knowledge` | reference | |
| `voice_coaching_knowledge` | reference | ⚠️ see below |
| `working_style_canvas_toolbox` | identity | already had partial frontmatter → upgraded |

**Depth A** applied: spine always in frontmatter; structured arrays go to frontmatter only when they *are* metadata (identity principles), otherwise stay in the body (the SAS catalog). All 8 parse as YAML with a complete spine.

## Flagged for your audit (judgment calls)
- **`voice_coaching` shape** — self-labels "> Reference" but reads like **identity** (coaching principles + voice-preservation contract). Left as `reference` with an inline `CONFIRM` comment. Your call.
- **`consumed_by` inferred** — `imscc_format` → `canvas_content_sync.md`; `working_style` → `AGENTS.md`. Confirm or correct.

## Next
**Batch 2** = the 26 files that have a `.json`: synthesize a new `.md` from **both** the `.md` and the `.json` (best form per set), delete the `.json`, and repoint any agent-spec `cross_references` from `.json` → `.md`. Separate PR.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
