### PR TITLE
fix(grader_push): detect manual posting policy + --post to release grades (#199)

### DIFF
--- a/lib/agents/knowledge/canvas_api_lessons_learned.md
+++ b/lib/agents/knowledge/canvas_api_lessons_learned.md
@@ -275,9 +275,23 @@ data = {"quiz[due_at]": new_due, "quiz[lock_at]": None, "quiz[unlock_at]": None}
 
 ---
 
+### L20 — Grades pushed under a MANUAL posting policy are entered but HIDDEN, not "stuck"
+
+**What Canvas does:** `PUT .../submissions/:user_id` with `submission[posted_grade]` sets the grade and transitions `workflow_state` to `graded` correctly — but if the assignment's posting policy is **manual** (`post_manually: true`), the grade is **not released**: `posted_at` stays `null`, the student can't see it, and the gradebook reads **"needs grading."** This looks like a workflow_state bug but is the posting policy. `submission[workflow_state]` is **not** a settable parameter — Canvas ignores it — so "force the state to graded" fixes are a no-op. Verified on the sandbox: the *identical* `posted_grade` call leaves `posted_at` set under an automatic policy and `null` under a manual one.
+
+**Why it matters:** a bulk API grading run against manual-posting assignments (e.g. pass/fail Core Tasks) leaves every grade entered-but-invisible — it reads as done to the script and as "needs grading" to the instructor. The naive "fixes" (a null→value double-PUT, or setting `workflow_state`) don't *post* the grade; only posting does.
+
+**The fix:** release grades with the GraphQL `postAssignmentGrades` mutation (`POST /api/graphql`) — the same action as the Gradebook "Post grades" button; there is no REST endpoint for it. `postAssignmentGrades(input: {assignmentId, gradedOnly: true})`. Detect the condition by reading the assignment's `post_manually`, or a pushed submission's `posted_at == null` while `grade` is set. Setting the posting policy itself via API is still only a feature request (canvas-lms#2517); posting after the fact is the supported path.
+
+**How the toolkit handles it:** `lib/tools/grader_push.py` — after a push, `assignment_posts_manually()` checks the policy; if manual it warns that grades are entered-but-hidden, and `--post` releases them via `post_assignment_grades()` (the GraphQL mutation). Never auto-posts without the flag (posting is student-facing).
+
+**Provenance:** issue #199 (DS460 run — grades across pass/fail sprints read "needs grading", 2026-07-15); root cause + fix reproduced end-to-end on sandbox 427808 (2026-07-16): auto policy posts, manual policy hides, `postAssignmentGrades` releases. Canvas dev docs confirm `workflow_state` is a response-only field.
+
+---
+
 ## Cross-Cutting Patterns
 
-These are the toolkit conventions that bake defenses against the 19 lessons into every new tool.
+These are the toolkit conventions that bake defenses against the 20 lessons into every new tool.
 
 ### P-LL1 — Form-encoded for nested writes (defends L1, L2, L16)
 

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -27,6 +27,8 @@ from grader_push import (  # noqa: E402
     filter_group_mirror_rows,
     append_disclosure_tag,
     DISCLOSURE_TAG,
+    assignment_posts_manually,
+    post_assignment_grades,
 )
 
 
@@ -789,3 +791,54 @@ def test_disclosure_tag_not_added_to_empty_or_whitespace():
 def test_disclosure_tag_wording_is_honest():
     """It must say AI *drafted* (not 'assisted') + instructor *reviewed*."""
     assert DISCLOSURE_TAG == "— AI drafted, instructor reviewed"
+
+
+# ---------------------------------------------------------------------------
+# #199 — manual posting policy detection + release. The push payload is correct
+# (verified on Canvas); a MANUAL policy enters grades but leaves posted_at null
+# (hidden -> reads "needs grading"). These mock the API layer.
+# ---------------------------------------------------------------------------
+
+import grader_push as _GP  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, status, payload=None, text=""):
+        self.status_code = status
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def test_assignment_posts_manually_true(monkeypatch):
+    monkeypatch.setattr(_GP.requests, "get", lambda *a, **k: _Resp(200, {"post_manually": True}))
+    assert assignment_posts_manually("b", "c", {}, 1) is True
+
+
+def test_assignment_posts_manually_false(monkeypatch):
+    monkeypatch.setattr(_GP.requests, "get", lambda *a, **k: _Resp(200, {"post_manually": False}))
+    assert assignment_posts_manually("b", "c", {}, 1) is False
+
+
+def test_assignment_posts_manually_defaults_false_on_error(monkeypatch):
+    """A failed lookup must not warn spuriously — default to False."""
+    monkeypatch.setattr(_GP.requests, "get", lambda *a, **k: _Resp(500, None, "err"))
+    assert assignment_posts_manually("b", "c", {}, 1) is False
+
+
+def test_post_assignment_grades_ok(monkeypatch):
+    monkeypatch.setattr(_GP.requests, "post", lambda *a, **k: _Resp(
+        200, {"data": {"postAssignmentGrades": {"progress": {"_id": "9", "state": "queued"},
+                                                "errors": None}}}))
+    ok, detail = post_assignment_grades("b", "c", {}, 1)
+    assert ok is True and "queued" in detail
+
+
+def test_post_assignment_grades_reports_graphql_error(monkeypatch):
+    monkeypatch.setattr(_GP.requests, "post", lambda *a, **k: _Resp(
+        200, {"data": {"postAssignmentGrades": {"progress": None,
+                                                "errors": [{"message": "not allowed"}]}}}))
+    ok, detail = post_assignment_grades("b", "c", {}, 1)
+    assert ok is False and "not allowed" in detail

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -890,6 +890,42 @@ def _retract_main(base: str, cid: str, headers: dict, args,
     return 0
 
 
+def assignment_posts_manually(base: str, cid: str, headers: dict, assignment_id) -> bool:
+    """True if the assignment uses a MANUAL posting policy. Under manual posting,
+    grades written via the API are ENTERED but not released — `posted_at` stays null,
+    students can't see them, and the gradebook reads 'needs grading' (issue #199).
+    Verified on Canvas: the push payload is correct; the posting policy is the gate."""
+    try:
+        r = requests.get(f"{base}/api/v1/courses/{cid}/assignments/{assignment_id}",
+                         headers=headers, timeout=_TIMEOUT)
+        if r.status_code < 400:
+            return bool(r.json().get("post_manually"))
+    except Exception:
+        pass
+    return False
+
+
+def post_assignment_grades(base: str, cid: str, headers: dict, assignment_id) -> tuple[bool, str]:
+    """Release entered grades to students via the GraphQL `postAssignmentGrades`
+    mutation — the same action as the Gradebook 'Post grades' button (Canvas has no
+    REST endpoint for it). Returns (ok, human-readable detail)."""
+    query = ("mutation ($a: ID!, $go: Boolean) { postAssignmentGrades("
+             "input: {assignmentId: $a, gradedOnly: $go}) "
+             "{ progress { _id state } errors { message } } }")
+    try:
+        r = requests.post(f"{base}/api/graphql", headers=headers,
+                          json={"query": query, "variables": {"a": str(assignment_id), "go": True}},
+                          timeout=_TIMEOUT)
+        payload = (r.json() or {}).get("data", {}).get("postAssignmentGrades") or {}
+        errs = payload.get("errors")
+        if r.status_code < 400 and not errs:
+            prog = payload.get("progress") or {}
+            return True, f"(progress {prog.get('_id')}, {prog.get('state')})"
+        return False, f"HTTP {r.status_code}: {errs or r.text[:120]}"
+    except Exception as e:
+        return False, str(e)
+
+
 def main() -> int:
     force_utf8_console()  # Fix issue #123 — Windows cp1252 console crash
 
@@ -907,6 +943,11 @@ def main() -> int:
                          "Default: uppercased basename of --challenge-dir.")
     ap.add_argument("--push", action="store_true",
                     help="Actually write to Canvas (default: dry-run). Refuses without --mark-reviewed.")
+    ap.add_argument("--post", action="store_true",
+                    help="After pushing, release grades to students via the Gradebook 'Post "
+                         "grades' action (GraphQL postAssignmentGrades). Needed when the assignment "
+                         "uses a MANUAL posting policy — otherwise grades are entered but hidden "
+                         "from students and read as 'needs grading' (issue #199).")
     ap.add_argument("--yes", action="store_true",
                     help="Skip the confirmation prompt. NOTE: REFUSED on the "
                          "LLM-comment --mark-reviewed path (issue #97) — a human "
@@ -1651,6 +1692,21 @@ def main() -> int:
         summary_line += (f"; {grade_type_skipped} grade-type row(s) skipped "
                          f"(see [HOLD] / [INVALID-GRADE] / [NOT-GRADED] above — issue #99)")
     print(f"\n{summary_line}. Logged to {log} (keyed, gitignored).")
+
+    # Issue #199: a MANUAL posting policy ENTERS grades but does not release them —
+    # posted_at stays null, students can't see them, and the gradebook reads "needs
+    # grading". The push payload is correct (verified on Canvas); the posting policy
+    # is the gate. Detect it so hidden grades are never silently shipped as done.
+    if pushed and args.push and assignment_posts_manually(base, cid, headers, args.assignment_id):
+        if args.post:
+            ok, detail = post_assignment_grades(base, cid, headers, args.assignment_id)
+            print(f"  ✅ Released grades to students {detail}" if ok
+                  else f"  ⚠️  Post-grades FAILED {detail} — use the Gradebook 'Post grades' action.")
+        else:
+            print(f"\n⚠️  MANUAL posting policy: the {pushed} grade(s) are ENTERED but NOT "
+                  "posted — students can't see them and the gradebook shows 'needs grading'. "
+                  "Release them via the Gradebook 'Post grades' action, or re-run with --post.")
+
     if failed:
         print(f"Failed: {failed}")
         return 2


### PR DESCRIPTION
Closes #199. **Root-caused and validated end-to-end on the sandbox before writing the fix.**

## The report was misdiagnosed
The push payload is **correct**. `submission[posted_grade]` sets the grade and transitions `workflow_state` to `graded` fine. The real cause is the **manual posting policy**: under `post_manually: true`, the grade is *entered* but *not released* — `posted_at` stays `null`, students can't see it, and the gradebook reads **"needs grading."**

| Report's claim | Verified reality |
|---|---|
| workflow_state stuck | it's `graded`; `posted_at` is null (hidden) |
| Fix: `submission[workflow_state]="graded"` | **not a settable param** — Canvas ignores it (dev docs) |
| Cause: posted_grade API bug | **manual posting policy** |
| — | Real fix: **`postAssignmentGrades`** GraphQL mutation |

## Sandbox proof (427808, Test Student, pass/fail)
- Auto policy + `posted_grade` → `graded`, `posted_at` **set** — no bug.
- Manual policy + same call → `graded`, `posted_at` **null** — the DS460 symptom, reproduced.
- `postAssignmentGrades` → `posted_at` **set** — released. ✅
- New `assignment_posts_manually()` returns False (auto) / True (manual) against live Canvas.

## The fix (`grader_push.py`)
- **`assignment_posts_manually()`** — after a push, check `post_manually`.
- If manual + grades pushed → **warn** the grades are entered-but-hidden (never silently ship hidden grades).
- **`--post`** → release via **`post_assignment_grades()`** (GraphQL `postAssignmentGrades`, the Gradebook "Post grades" action — no REST endpoint exists). Never auto-posts without the flag (student-facing).

## Verification
- 5 new mocked unit tests (detection true/false/error; post ok/graphql-error). **83 grader_push helper tests pass**, ruff clean.
- `canvas_api_lessons_learned` **L20** captures the gotcha + fix.

Note: the report's `push_grades.py` / `fix_canvas_grade_state.py` are DS460 consumer-repo scripts, not cb — cb's equivalent is `grader_push.py`, which had the same exposure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
