### PR TITLE
docs(readme): add note to follow your institution's AI policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 Built at BYU-Idaho. Designed for all instructors. Works with any Canvas institution. You don't have to be a developer — the agent handles the technical bits; you answer its questions.
 
+> **Follow your institution's AI policy** — refer to and abide by your university's generative-AI policy when using this tool.
+
 ---
 
 # Getting started


### PR DESCRIPTION
Adds a one-line callout to the README intro:

> **Follow your institution's AI policy** — refer to and abide by your university's generative-AI policy when using this tool.

Placed right under the intro (before "Getting started"), as its own callout so it doesn't disrupt the "This is / This is NOT" framing above it. Fits the toolkit's existing stance — it audits syllabi for a *required* AI policy (`syllabus_audit`) and discloses AI-drafted feedback — so pointing users at their institution's policy is consistent: the tool supports responsible, disclosed AI use; institutional policy governs.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
