### PR TITLE
fix(sync): POST late_policy when the course has none, don't 404 on PATCH (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.13] — 2026-07-22
+
+**`sync --push` now creates a late policy when the course has none, instead of 404-ing on every push.** (#205)
+
+`cmd_push` always sent `PATCH /courses/:id/late_policy` when `_course.json`'s `late_policy` hash differed from the stored index hash. Canvas only accepts `PATCH` once a late-policy record exists; a course that never configured one returns `The specified resource does not exist.` (404). #189 narrowed the `_course.json` hash to `late_policy`, which made an untouched course register as "changed" on the very next `--push` — so any operator who pulled #189 and pushed against a policy-free course hit that 404, and it recurred on every subsequent push because the hash never got to update. Non-blocking (the rest of the push proceeds), but persistent.
+
+### Fixed
+- **`canvas_sync.py`** — a new `_push_late_policy` helper `GET`s the late policy first and picks the verb: `PATCH` to update when one exists (200), `POST` to create when it doesn't (non-200). The success message reads `created` vs `updated` accordingly, and the accept check widened to `< 400` (matching the sibling homepage/syllabus handlers) so a `POST`-create isn't misread as a failure. Two unit tests cover both the update and create paths.
+
+---
+
 ## [1.7.12] — 2026-07-15
 
 **Transparency: every AI-drafted feedback comment is now tagged `— AI drafted, instructor reviewed` — default, no opt-out.**

--- a/lib/tests/test_canvas_sync_late_policy_push.py
+++ b/lib/tests/test_canvas_sync_late_policy_push.py
@@ -1,0 +1,82 @@
+"""cmd_push must not PATCH a late policy that doesn't exist yet.
+
+Canvas only accepts PATCH /courses/:id/late_policy once a late-policy record
+exists; a course that never configured one returns 404 ("The specified resource
+does not exist."). #189 narrowed the _course.json hash to late_policy, which made
+an untouched course register as "changed" on the next --push — so every operator
+who pulled #189 and pushed against a policy-free course hit that 404 on every
+push, with the hash never updating (#205).
+
+_push_late_policy GETs first: PATCH to update when a policy exists (200), POST to
+create when it doesn't (non-200).
+"""
+import importlib.util
+import sys
+from pathlib import Path
+
+TOOLS = Path(__file__).resolve().parents[1] / "tools"
+sys.path.insert(0, str(TOOLS))
+spec = importlib.util.spec_from_file_location("canvas_sync", TOOLS / "canvas_sync.py")
+canvas_sync = importlib.util.module_from_spec(spec)
+sys.modules["canvas_sync"] = canvas_sync
+spec.loader.exec_module(canvas_sync)
+
+
+class _Resp:
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.text = text
+
+
+class _FakeRequests:
+    """Records which verb the push used and with what payload."""
+
+    def __init__(self, get_status):
+        self._get_status = get_status
+        self.calls = []  # list of (verb, url, json)
+
+    def get(self, url, headers=None, timeout=None):
+        self.calls.append(("get", url, None))
+        return _Resp(self._get_status)
+
+    def patch(self, url, headers=None, json=None, timeout=None):
+        self.calls.append(("patch", url, json))
+        return _Resp(200)
+
+    def post(self, url, headers=None, json=None, timeout=None):
+        self.calls.append(("post", url, json))
+        return _Resp(200)
+
+
+def _install(monkeypatch, get_status):
+    fake = _FakeRequests(get_status)
+    monkeypatch.setattr(canvas_sync, "requests", fake)
+    return fake
+
+
+def test_patches_when_a_policy_already_exists(monkeypatch):
+    fake = _install(monkeypatch, get_status=200)
+    lp = {"late_submission_deduction": 10.0}
+
+    resp, created = canvas_sync._push_late_policy(lp)
+
+    verbs = [c[0] for c in fake.calls]
+    assert verbs == ["get", "patch"]           # GET probes, then PATCH updates
+    assert created is False
+    assert resp.status_code == 200
+    assert fake.calls[1][2] == {"late_policy": lp}
+
+
+def test_posts_to_create_when_none_exists(monkeypatch):
+    """The #205 bug: a 404-on-GET course must POST-create, never PATCH-404."""
+    fake = _install(monkeypatch, get_status=404)
+    lp = {"late_submission_deduction": 10.0}
+
+    resp, created = canvas_sync._push_late_policy(lp)
+
+    verbs = [c[0] for c in fake.calls]
+    assert verbs == ["get", "post"]            # GET 404s, so POST creates
+    assert "patch" not in verbs                # the old unconditional PATCH is gone
+    assert created is True
+    assert resp.status_code == 200
+    assert fake.calls[1][2] == {"late_policy": lp}

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -194,6 +194,24 @@ def _course_late_policy_hash(path: Path) -> str:
     return hashlib.sha256(json.dumps(lp, sort_keys=True).encode("utf-8")).hexdigest()[:16]
 
 
+def _push_late_policy(lp: dict) -> tuple:
+    """Create or update the course's Gradebook late policy, picking the verb by
+    whether one already exists.
+
+    Canvas only accepts PATCH /courses/:id/late_policy once a late-policy record
+    exists; a course that never had one configured 404s on PATCH ("The specified
+    resource does not exist."). So GET first, then POST to create when absent
+    (non-200) or PATCH to update when present (200). Returns (response, created)
+    where `created` is True on the POST path. (#205)
+    """
+    base = f"{CANVAS_BASE_URL}/api/v1/courses/{CANVAS_COURSE_ID}/late_policy"
+    existing = requests.get(base, headers=_headers(), timeout=20)
+    created = existing.status_code != 200
+    verb = requests.post if created else requests.patch
+    resp = verb(base, headers=_headers(), json={"late_policy": lp}, timeout=20)
+    return resp, created
+
+
 def _slug(text: str) -> str:
     """Convert a title to a filesystem-safe slug."""
     text = text.lower()
@@ -1501,15 +1519,12 @@ def cmd_push(target: Optional[str] = None):
             data = json.loads(course_path.read_text(encoding="utf-8"))
             lp = data.get("late_policy", {})
             if lp:
-                resp = requests.patch(
-                    f"{CANVAS_BASE_URL}/api/v1/courses/{CANVAS_COURSE_ID}/late_policy",
-                    headers=_headers(),
-                    json={"late_policy": lp}, timeout=20)
-                if resp.status_code in (200, 204):
+                resp, created = _push_late_policy(lp)
+                if resp.status_code < 400:
                     index["course_hash"] = course_hash
                     index["course"] = data
                     pushed_course_level.append("Course")
-                    print(f"    OK (late_policy updated)")
+                    print(f"    OK (late_policy {'created' if created else 'updated'})")
                 else:
                     print(f"    FAILED late_policy: {resp.text[:200]}")
                 _save_index(index)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.12"
+version = "1.7.13"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.12"
+version = "1.7.13"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Fixes #205.

## The bug
`cmd_push` always sent `PATCH /courses/:id/late_policy` when `_course.json`'s `late_policy` hash differed from the stored index hash. Canvas only accepts `PATCH` once a late-policy record already exists; a course that never configured one returns:

```
FAILED late_policy: {"errors":[{"message":"The specified resource does not exist."}]}
```

`#189` narrowed the `_course.json` hash to `late_policy`, which made an **untouched** course register as "changed" on the very next `--push` (the stored `course_hash` was computed under the old scheme). So any operator who pulls `#189` and then pushes against a policy-free course hits that 404 — and it recurs on every push after, because the hash never gets to update. Non-blocking (the rest of the push proceeds), but persistent.

## The fix
A new `_push_late_policy` helper `GET`s the late policy first and picks the verb:
- **200** → `PATCH` to update the existing policy
- **non-200** (404) → `POST` to create it

The `OK` message now reads `created` vs `updated`, and the accept check widened from `(200, 204)` to `< 400` (matching the sibling homepage/syllabus handlers in the same function) so a `POST`-create isn't misread as a failure.

This is the approach the reporter suggested and patched locally to unblock themselves.

## Tests
`lib/tests/test_canvas_sync_late_policy_push.py` — two unit tests (monkeypatched `requests`):
- existing policy (GET 200) → `get` then `patch`, `created=False`
- no policy (GET 404) → `get` then `post`, `patch` never called, `created=True`

Both pass; full suite green except 12 pre-existing `ModuleNotFoundError: markdownify` failures in unrelated `test_json_to_markdown.py` / `test_sprint2.py` (missing optional dep in this env, fails identically on `main`).

Bumps version `1.7.12` → `1.7.13` + CHANGELOG entry, per the repo's per-fix release convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
