### PR TITLE
feat(grader): enforce HG-5 in code — no autonomous push of AI-drafted grades (#207)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,26 @@ Accommodation tools (`student_late_accommodation.py`, `student_quiz_time_extensi
 
 ---
 
+## ⚠️ AI Grading Protocol — HG-5: the instructor is the top layer
+
+**Grading with AI is decision support, not autonomy. A human decides every grade that reaches a student.** This is principle **HG-5** of the [hybrid grading architecture](lib/agents/knowledge/grader_hybrid_architecture.md) (`HG-1..HG-5`). The agent drafts; the instructor reviews and confirms; only then does anything post to Canvas.
+
+**The push protocol (never skip a step):**
+
+1. **Grade** — `grader_fetch.py` → 3-pass consensus (`grader_grade.py --bulk` → `grader_consensus.py`). Single-pass LLM grading drifts; consensus is the default.
+2. **Review** — a human reads `feedback/_all_comments.md` + each per-student `<KEY>.md`. This is the gate, not a formality.
+3. **Attest** — `grader_push.py --challenge-dir grading/<name> --mark-reviewed`. The human types `reviewed`. The marker auto-invalidates if any feedback file changes afterward.
+4. **Push** — `grader_push.py --challenge-dir grading/<name> --push`. The human types `push` at the confirmation.
+
+**What the code enforces (so the protocol isn't docs-only):**
+
+- **`--yes` cannot bypass human review on the AI-drafted path.** On any run with per-student comment files (the LLM-comment path), `--yes` is refused at *both* `--mark-reviewed` (#97) *and* the final `--push` confirmation (#207, HG-5). An agent can pass `--yes`; a human must physically type `reviewed` then `push`. The value-only / human-graded path (no comment files) keeps `--yes` — there the human *is* the grader.
+- **Disclosure is mandatory and canonical.** Every AI-drafted comment ships with `— AI drafted, instructor reviewed`, appended automatically at send-time. Deprecated tag formats (older emoji/underscore variants) refuse the push (#207); override with `--allow-bad-disclosure-tags` only if you truly mean to.
+
+**Do not** run `grader_push.py --yes --push` to "just get the grades in." That is the exact HG-5 breach an [RCA](https://github.com/chaz-clark/canvas-toolbox/issues/207) was written about — 12 students received AI-drafted grades with no instructor review. If a gate blocks you, the fix is to *do the review*, not to reach for an override flag.
+
+---
+
 ## Common Tasks Quick Reference
 
 **When the instructor asks you to:**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.14] — 2026-07-22
+
+**HG-5 enforced in code: an agent can no longer autonomously push AI-drafted grades to a live course.** (#207)
+
+Closes the gap behind the KC3 grading-protocol RCA — 12 students received AI-drafted grades with no instructor review. HG-5 ("the instructor is the top layer — decision support, not autonomy") was a documented principle that nothing enforced past `--mark-reviewed`. Now it's enforced end-to-end, and the protocol is a single-sourced pointer in every course repo instead of prose that drifts.
+
+### Changed
+- **`grader_push.py`** — on the AI-drafted (LLM-comment) push path, `--yes` no longer bypasses the final `--push` confirmation. #97 closed this on `--mark-reviewed`; the same collapse of "grade" and "push" was still possible at the push step. An agent can pass `--yes`, but a human must physically type `push`. **Behavior change:** `grader_push.py --yes --push` on a run with per-student comment files now refuses and exits non-zero. The value-only / human-graded path (no comment files) keeps `--yes` — there the human is the grader.
+
+### Added
+- **`grader_push.py`** — a disclosure-tag validator refuses the push when a per-student comment file carries a deprecated tag format (older emoji/underscore variants), which would otherwise get the canonical `— AI drafted, instructor reviewed` tag stacked on top of it at send-time. Override: `--allow-bad-disclosure-tags`.
+- **`sync_grading_protocol.py`** — new tool that injects the canonical HG-5 grading-protocol pointer into a course repo's `AGENTS.md`, idempotently (sentinel-marked) and dry-run-by-default. Retrofits repos initialized before #207, which `cb-init` never updates in place.
+- **`AGENTS.md`** — a canonical "AI Grading Protocol — HG-5" section (the single source of truth the course-repo pointers link to). `cb-init` now emits that pointer into new course stubs, sharing one block with `sync_grading_protocol.py` so a fresh repo and a retrofitted one never disagree.
+
+---
+
 ## [1.7.13] — 2026-07-22
 
 **`sync --push` now creates a late policy when the course has none, instead of 404-ing on every push.** (#205)

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -27,6 +27,8 @@ from grader_push import (  # noqa: E402
     filter_group_mirror_rows,
     append_disclosure_tag,
     DISCLOSURE_TAG,
+    find_deprecated_disclosure_tags,
+    DEPRECATED_DISCLOSURE_TAGS,
     assignment_posts_manually,
     post_assignment_grades,
 )
@@ -477,6 +479,61 @@ def test_yes_refused_does_not_depend_on_file_count():
     assert is_yes_refused_on_review(one_file, yes_flag=True) is True
     many_files = [Path(f"/tmp/KC1-XXX{i}.md") for i in range(10)]
     assert is_yes_refused_on_review(many_files, yes_flag=True) is True
+
+
+# ---------------------------------------------------------------------------
+# find_deprecated_disclosure_tags — issue #207 (HG-5 disclosure validation)
+# ---------------------------------------------------------------------------
+
+def _write_fb(tmp_path, name, body):
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return p
+
+
+def test_canonical_tag_is_not_flagged(tmp_path):
+    """The false-positive guard: a comment carrying ONLY the canonical
+    DISCLOSURE_TAG must pass — otherwise every legitimate push is blocked."""
+    fb = _write_fb(tmp_path, "KC1-A1B2C3.md", f"Nice work.\n\n{DISCLOSURE_TAG}\n")
+    assert find_deprecated_disclosure_tags([fb]) == []
+
+
+def test_emoji_tag_is_flagged(tmp_path):
+    """The exact format from the RCA (emoji, underscore-wrapped) is caught."""
+    fb = _write_fb(tmp_path, "KC3-D4E5F6.md",
+                   "Feedback body.\n\n_🤖 AI-drafted feedback, instructor-reviewed_\n")
+    violations = find_deprecated_disclosure_tags([fb])
+    assert len(violations) == 1
+    assert violations[0][0] == "KC3-D4E5F6.md"
+
+
+def test_generated_with_claude_code_is_flagged(tmp_path):
+    fb = _write_fb(tmp_path, "KC1-XYZ.md", "text\n\n🤖 Generated with Claude Code\n")
+    assert [v[0] for v in find_deprecated_disclosure_tags([fb])] == ["KC1-XYZ.md"]
+
+
+def test_only_offending_files_are_reported(tmp_path):
+    """Mixed batch: clean files pass, stale-tagged files are named."""
+    good = _write_fb(tmp_path, "KC1-GOOD.md", f"ok\n\n{DISCLOSURE_TAG}\n")
+    bad = _write_fb(tmp_path, "KC1-BAD.md", "ok\n\nAI-generated feedback\n")
+    reported = [v[0] for v in find_deprecated_disclosure_tags([good, bad])]
+    assert reported == ["KC1-BAD.md"]
+
+
+def test_untagged_file_is_not_flagged(tmp_path):
+    """A file with no disclosure tag at all isn't a deprecated-tag violation —
+    append_disclosure_tag adds the canonical one at send-time. This validator
+    only catches WRONG tags, not MISSING ones."""
+    fb = _write_fb(tmp_path, "KC1-PLAIN.md", "Just feedback, no tag.\n")
+    assert find_deprecated_disclosure_tags([fb]) == []
+
+
+def test_every_deprecated_tag_constant_is_detected(tmp_path):
+    """Guard the constant list itself: each entry in DEPRECATED_DISCLOSURE_TAGS
+    must actually trigger a violation when present (no dead/typo entries)."""
+    for i, dep in enumerate(DEPRECATED_DISCLOSURE_TAGS):
+        fb = _write_fb(tmp_path, f"KC1-{i}.md", f"body\n\n{dep}\n")
+        assert find_deprecated_disclosure_tags([fb]), f"not detected: {dep!r}"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tests/test_sync_grading_protocol.py
+++ b/lib/tests/test_sync_grading_protocol.py
@@ -1,0 +1,80 @@
+"""Unit tests — sync_grading_protocol pointer injection (issue #207).
+
+The retrofit tool must be idempotent (safe to re-run against every course repo)
+and non-destructive (course-specific content around the pointer is preserved).
+It shares POINTER_BLOCK with cb_init, so a freshly-init'd stub and a retrofitted
+file must agree — that agreement is what keeps the tool from double-injecting.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from sync_grading_protocol import (  # noqa: E402
+    inject_grading_pointer,
+    process_agents_file,
+    POINTER_MARKER,
+    POINTER_BLOCK,
+)
+
+
+def test_injects_after_the_first_title():
+    text = "# DS460\n\nSome intro.\n\n## Structure\n\ndetails\n"
+    new, changed = inject_grading_pointer(text)
+    assert changed is True
+    assert POINTER_MARKER in new
+    # inserted AFTER the title, BEFORE the first real section
+    assert new.index("# DS460") < new.index(POINTER_MARKER) < new.index("## Structure")
+    # original content is preserved verbatim
+    assert "Some intro." in new and "## Structure" in new and "details" in new
+
+
+def test_idempotent_when_marker_present():
+    """Re-running against an already-pointed file is a no-op — the core safety
+    property for a tool run across every course repo."""
+    once, _ = inject_grading_pointer("# DS250\n\nbody\n")
+    twice, changed = inject_grading_pointer(once)
+    assert changed is False
+    assert twice == once
+    assert twice.count(POINTER_MARKER) == 1  # not doubled
+
+
+def test_prepends_when_no_title():
+    text = "just some notes, no heading\n"
+    new, changed = inject_grading_pointer(text)
+    assert changed is True
+    assert new.startswith(POINTER_MARKER)
+    assert new.rstrip().endswith("just some notes, no heading")
+
+
+def test_cb_init_stub_block_is_recognized():
+    """A file already carrying the shared POINTER_BLOCK (as cb_init emits into a
+    fresh stub) must be treated as present — otherwise new repos double-inject."""
+    stub = f"---\n\n{POINTER_BLOCK}\n\n---\n"
+    _, changed = inject_grading_pointer(stub)
+    assert changed is False
+
+
+def test_process_reports_missing_file(tmp_path, capsys):
+    status = process_agents_file(tmp_path / "AGENTS.md", apply=False)
+    assert status == "missing"
+
+
+def test_process_dry_run_does_not_write(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text("# Course\n\nbody\n", encoding="utf-8")
+    status = process_agents_file(p, apply=False)
+    assert status == "would-inject"
+    assert POINTER_MARKER not in p.read_text(encoding="utf-8")  # untouched
+
+
+def test_process_apply_writes_once(tmp_path):
+    p = tmp_path / "AGENTS.md"
+    p.write_text("# Course\n\nbody\n", encoding="utf-8")
+    assert process_agents_file(p, apply=True) == "injected"
+    assert POINTER_MARKER in p.read_text(encoding="utf-8")
+    # second apply is a no-op
+    assert process_agents_file(p, apply=True) == "present"
+    assert p.read_text(encoding="utf-8").count(POINTER_MARKER) == 1

--- a/lib/tools/cb_init.py
+++ b/lib/tools/cb_init.py
@@ -120,6 +120,23 @@ try:
 except ImportError:
     __version__ = "0.0.0+unknown"
 
+try:
+    # Single source of truth for the HG-5 grading-protocol pointer (#207), shared
+    # with sync_grading_protocol.py so a freshly-init'd repo and a retrofitted one
+    # carry the identical, sentinel-marked block.
+    from sync_grading_protocol import POINTER_BLOCK as GRADING_POINTER_BLOCK
+except ImportError:
+    # Fallback for pre-sync / partial vendored environments. Keeps the same
+    # sentinel marker so sync_grading_protocol stays idempotent against it.
+    GRADING_POINTER_BLOCK = (
+        "<!-- canvas-toolbox:grading-protocol-pointer -->\n\n"
+        "## ⚠️ Grading — HG-5: the instructor decides\n\n"
+        "AI-assisted grading is decision support, not autonomy. Never push AI-drafted "
+        "grades without human review. Full protocol: canvas-toolbox/AGENTS.md → "
+        '"AI Grading Protocol — HG-5".\n\n'
+        "<!-- /canvas-toolbox:grading-protocol-pointer -->"
+    )
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -760,6 +777,10 @@ When you find a defect:
 1. **Fix it** (Jidoka - stop and correct)
 2. **Verify the fix** (Genchi Gembutsu - test with real data)
 3. **Prevent recurrence** (Poka-yoke - add automated check)
+
+---
+
+{GRADING_POINTER_BLOCK}
 
 ---
 

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -22,7 +22,11 @@ WHAT IT DOES
 GUARDRAILS (no override on the first three)
   1. --mark-reviewed REQUIRED before --push. Marker auto-invalidates if any
      comment file mtime > marker mtime (you can't approve a state and then
-     mutate it).
+     mutate it). **Issue #207 (HG-5)** — on the AI-drafted (LLM-comment)
+     push path, --yes does NOT bypass the final "type 'push'" confirmation:
+     an agent can pass --yes, but the instructor is the top layer and must
+     decide the write. A deprecated disclosure tag in any comment file
+     refuses the push (override: --allow-bad-disclosure-tags).
   2. canvas_course_guard refuses live-course writes unless --allow-enrolled
      is passed. The toolkit's standing safety bar.
   3. Per-assignment idempotency. Keys already in the .push_log.md scoped to
@@ -168,6 +172,43 @@ def append_disclosure_tag(comment: str) -> str:
     if comment.rstrip().endswith(DISCLOSURE_TAG):
         return comment
     return f"{comment.rstrip()}\n\n{DISCLOSURE_TAG}"
+
+
+# Deprecated disclosure-tag formats that predate the canonical DISCLOSURE_TAG.
+# A feedback file carrying one of these was drafted/edited under an older
+# convention; because it doesn't end with the canonical tag, append_disclosure_tag
+# would STACK the canonical tag on top of the stale one at send-time — two tags in
+# one comment. So the push is refused until the operator fixes it (issue #207).
+DEPRECATED_DISCLOSURE_TAGS = (
+    "_🤖 AI-drafted feedback, instructor-reviewed_",
+    "🤖 AI-drafted feedback, instructor-reviewed",
+    "_AI drafted, instructor reviewed_",          # underscore-wrapped canonical
+    "🤖 Generated with Claude Code",
+    "AI-generated feedback",
+)
+
+
+def find_deprecated_disclosure_tags(comment_files: list) -> list:
+    """Issue #207: scan per-student comment files for deprecated disclosure-tag
+    formats. Returns [(filename, deprecated_tag), ...] — empty if all are clean.
+
+    The canonical tag is DISCLOSURE_TAG, appended automatically at send-time. A
+    file carrying an older format would get the canonical tag stacked on top of
+    the stale one, so the push refuses (override: --allow-bad-disclosure-tags)
+    until the operator removes it. Files with only the canonical tag pass.
+    """
+    violations: list = []
+    for fb in comment_files:
+        p = Path(fb)
+        try:
+            content = p.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        for dep in DEPRECATED_DISCLOSURE_TAGS:
+            if dep in content:
+                violations.append((p.name, dep))
+                break
+    return violations
 
 
 # Issue #72: HOLD_<DIMENSION> grade-hold pattern (lifted from itm327's
@@ -419,6 +460,13 @@ def is_yes_refused_on_review(comment_files: list, yes_flag: bool) -> bool:
     The value-only / human-graded path keeps `--yes` (the human IS the
     grader; `--yes` there is a script convenience, not an attestation
     bypass).
+
+    Issue #207 (HG-5): the same helper also gates the FINAL push
+    confirmation. #97 closed the bypass on `--mark-reviewed`, but `--yes`
+    still skipped the "type 'push'" prompt afterward — so an agent that
+    re-marks reviewed could chain `--push --yes` and post AI-drafted
+    feedback with no human keystroke. On the LLM-comment path, the
+    instructor (the top layer) must physically confirm the write.
 
     Returns True if the caller should refuse the command and exit.
     """
@@ -1024,6 +1072,13 @@ def main() -> int:
                          "passes, not a stale prior run). Pass this flag for the rare intentional "
                          "case (e.g. a calibration cohort already gated by --mark-calibrated, or "
                          "a one-off where the operator has explicitly accepted single-pass risk).")
+    ap.add_argument("--allow-bad-disclosure-tags", action="store_true",
+                    help="Issue #207: explicit opt-out from the disclosure-tag validator. By "
+                         "default, grader_push refuses to push when a per-student comment file "
+                         "carries a deprecated disclosure tag (an older emoji/underscore format), "
+                         "because the canonical tag would get stacked on top of it at send-time. "
+                         "Pass this flag to push anyway (rare; the stale tag stays in the "
+                         "student-visible comment).")
     ap.add_argument("--allow-lower", action="store_true",
                     help="Issue #96: explicit opt-out from the regression-direction gate. By "
                          "default, grader_push refuses to LOWER an existing non-empty Canvas grade "
@@ -1508,6 +1563,38 @@ def main() -> int:
     if stale:
         print(f"\n⛔ {len(stale)} review-surface file(s) changed since you marked reviewed "
               f"(e.g. {stale[0]}). Re-review, then re-run --mark-reviewed.")
+        return 1
+
+    # --- HG-5 GATE: instructor is the top layer on the AI-drafted push path ---
+    # Issue #207: the presence of per-student comment files marks the LLM-comment
+    # (AI-drafted) path. On that path --yes must not bypass the final push
+    # confirmation — an agent can pass --yes, but a human must decide to write
+    # AI-drafted feedback to a live course (HG-5: decision support, not autonomy).
+    # The value-only / human-graded path (no comment files) keeps --yes.
+    ai_comment_files = list(fbdir.glob(f"{prefix}-*.md"))
+    if is_yes_refused_on_review(ai_comment_files, args.yes):
+        print("\n⛔ --yes is refused on the AI-drafted push path (issue #207, HG-5).",
+              file=sys.stderr)
+        print("   Pushing AI-drafted feedback to a live course requires the instructor",
+              file=sys.stderr)
+        print("   to confirm the write — the instructor is the top layer and decides.",
+              file=sys.stderr)
+        print("   Fix: re-run WITHOUT --yes; type 'push' at the confirmation prompt.",
+              file=sys.stderr)
+        return 1
+
+    # Issue #207: refuse deprecated disclosure-tag formats before writing. A stale
+    # tag would get the canonical DISCLOSURE_TAG stacked on top of it at send-time.
+    tag_violations = find_deprecated_disclosure_tags(ai_comment_files)
+    if tag_violations and not args.allow_bad_disclosure_tags:
+        print(f"\n⛔ {len(tag_violations)} feedback file(s) carry a deprecated disclosure "
+              f"tag (issue #207).", file=sys.stderr)
+        for fname, dep in tag_violations:
+            print(f"     {fname}: {dep[:40]}", file=sys.stderr)
+        print(f"   The canonical tag is {DISCLOSURE_TAG!r} (appended automatically at "
+              f"send-time).", file=sys.stderr)
+        print("   Fix: remove the stale tag from those files, or pass "
+              "--allow-bad-disclosure-tags to override.", file=sys.stderr)
         return 1
 
     if locked_resubmit_keys and not args.allow_locked_resubmit and not args.yes:

--- a/lib/tools/sync_grading_protocol.py
+++ b/lib/tools/sync_grading_protocol.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+"""Ensure a course repo's AGENTS.md carries the canonical HG-5 grading-protocol
+pointer (issue #207).
+
+WHY THIS EXISTS
+  cb_init generates the pointer into NEW course AGENTS.md stubs, but it never
+  overwrites an EXISTING AGENTS.md (`if agents_md_path.exists(): skipping`). So
+  every course repo initialized before #207 has no pointer, and each has diverged
+  independently — there's no way to push a protocol update out to them. The KC3
+  grading incident (issue #207) was exactly a "policy in docs, not enforced,
+  docs out of sync" failure. This tool closes the docs half: it injects (or
+  reports) the pointer idempotently so the safety protocol is discoverable in
+  every course repo, without clobbering the course-specific content around it.
+
+WHAT IT IS (and isn't)
+  A POINTER, not a copy. The canonical protocol lives once in
+  canvas-toolbox/AGENTS.md; this drops a short sentinel-delimited block that
+  links to it. That keeps N course repos from drifting on the wording — a
+  protocol revision updates one file, and this tool re-points the rest.
+
+USAGE
+  Dry-run (default) against the current course root:
+    uv run python canvas-toolbox/lib/tools/sync_grading_protocol.py
+  Apply to several course repos at once:
+    uv run python .../sync_grading_protocol.py ../ds460-master ../ds250-onln-master --apply
+
+  Idempotent: re-running is a no-op once the sentinel marker is present.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+POINTER_MARKER = "<!-- canvas-toolbox:grading-protocol-pointer -->"
+POINTER_END = "<!-- /canvas-toolbox:grading-protocol-pointer -->"
+
+# The canonical pointer block. Single source of truth — cb_init imports this so a
+# freshly-init'd repo and a retrofitted one carry the identical, marker-delimited
+# block (the marker is how this tool detects "already present").
+POINTER_BLOCK = f"""{POINTER_MARKER}
+
+## ⚠️ Grading — HG-5: the instructor decides
+
+AI-assisted grading here is **decision support, not autonomy**. Never push AI-drafted
+grades to Canvas without human review: grade → review the feedback →
+`grader_push.py --mark-reviewed` (type `reviewed`) → `--push` (type `push`). `--yes` does
+**not** bypass review on the AI-drafted path — that's enforced in code, not just
+documented (issue #207).
+
+Full protocol + rationale (principle HG-5): see
+**canvas-toolbox/AGENTS.md → "AI Grading Protocol — HG-5"**. When a gate blocks you, the
+fix is to do the review, not to reach for an override flag.
+
+{POINTER_END}"""
+
+
+def inject_grading_pointer(text: str) -> tuple[str, bool]:
+    """Return (new_text, changed).
+
+    Idempotent: if POINTER_MARKER is already present, returns text unchanged.
+    Otherwise inserts POINTER_BLOCK just after the file's first top-level `# `
+    heading (so it's discoverable near the top), or prepends it if the file has
+    no such heading. Course-specific content around it is left untouched.
+    """
+    if POINTER_MARKER in text:
+        return text, False
+
+    block = POINTER_BLOCK.strip("\n")
+    lines = text.splitlines(keepends=True)
+    idx = next((i for i, ln in enumerate(lines) if ln.startswith("# ")), None)
+
+    if idx is None:
+        return f"{block}\n\n{text}", True
+
+    head = lines[: idx + 1]
+    tail = lines[idx + 1 :]
+    if head and not head[-1].endswith("\n"):
+        head[-1] += "\n"
+    return "".join(head) + f"\n{block}\n\n" + "".join(tail), True
+
+
+def process_agents_file(path: Path, apply: bool) -> str:
+    """Inject the pointer into one AGENTS.md. Returns a one-word status:
+    'missing' (no file), 'present' (already has the pointer), 'injected'
+    (written), or 'would-inject' (dry-run)."""
+    if not path.is_file():
+        print(f"  ✗ {path} — no AGENTS.md here")
+        return "missing"
+
+    text = path.read_text(encoding="utf-8")
+    new, changed = inject_grading_pointer(text)
+    if not changed:
+        print(f"  ✓ {path} — pointer already present")
+        return "present"
+
+    if apply:
+        path.write_text(new, encoding="utf-8")
+        print(f"  ＋ {path} — pointer INJECTED")
+        return "injected"
+
+    print(f"  ~ {path} — pointer MISSING (dry-run; pass --apply to write). Would insert:")
+    for ln in POINTER_BLOCK.strip("\n").splitlines():
+        print(f"      | {ln}")
+    return "would-inject"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Ensure course AGENTS.md files carry the HG-5 grading-protocol "
+                    "pointer (issue #207). Dry-run by default; --apply to write.")
+    ap.add_argument("course_roots", nargs="*", default=["."],
+                    help="Course-root directories (each should contain an AGENTS.md). "
+                         "Default: the current directory.")
+    ap.add_argument("--apply", action="store_true",
+                    help="Write the injection. Without it, this is a dry-run that shows "
+                         "what would change.")
+    args = ap.parse_args()
+
+    roots = args.course_roots or ["."]
+    print(f"Grading-protocol pointer sync ({'APPLY' if args.apply else 'dry-run'}):")
+    statuses = [process_agents_file(Path(r) / "AGENTS.md", args.apply) for r in roots]
+
+    injected = statuses.count("injected")
+    would = statuses.count("would-inject")
+    present = statuses.count("present")
+    missing = statuses.count("missing")
+    print(f"\nSummary: {injected} injected, {would} would-inject, "
+          f"{present} already present, {missing} missing.")
+    if would and not args.apply:
+        print("Re-run with --apply to write the missing pointer(s).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.13"
+version = "1.7.14"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.13"
+version = "1.7.14"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Fixes #207.

Closes the gap behind the [KC3 grading-protocol RCA](https://github.com/chaz-clark/canvas-toolbox/issues/207): 12 students received AI-drafted grades with no instructor review. **HG-5** ("the instructor is the top layer — decision support, not autonomy") was a documented principle that nothing enforced past `--mark-reviewed`. This makes it enforced end-to-end, and turns the protocol into a single-sourced pointer in every course repo instead of prose that drifts.

## What #207 asked for → what shipped

| #207 solution | Implementation |
|---|---|
| `enforce_hg5_gate()` — refuse `--yes` autonomous push | Extended the #97-tested `is_yes_refused_on_review` to the **final `--push` confirmation**, not just `--mark-reviewed` |
| `validate_disclosure_tags()` | `find_deprecated_disclosure_tags()` — refuses the push on stale tag formats |
| `--allow-bad-disclosure-tags` | added, verbatim |

**Deliberate deviation:** #207's sketch allowed `--yes` on *re-grades* (keyed off `.push_log.md`). I went stricter — `--yes` is refused on *every* AI-drafted push. More defensible for HG-5, consistent with how #97 treats `--mark-reviewed`, and trivial to relax later. Easy to change if the re-grade friction bites.

## Code enforcement (`grader_push.py`)
- **`--yes` no longer bypasses the `--push` confirmation on the AI-drafted (LLM-comment) path.** An agent can pass `--yes`, but a human must type `push`. **Behavior change:** `grader_push.py --yes --push` on a run with per-student comment files now refuses (exit 1). The value-only / human-graded path (no comment files) keeps `--yes` — there the human *is* the grader.
- **Disclosure-tag validator** refuses the push when a comment file carries a deprecated tag format (older emoji/underscore variants), which `append_disclosure_tag` would otherwise stack the canonical `— AI drafted, instructor reviewed` tag on top of. Override: `--allow-bad-disclosure-tags`.

## Docs + retrofit (policy-as-code, not policy-as-prose)
The RCA's real lesson was "policy lived in docs, not code, and the docs drifted across N course repos." So:
- **`AGENTS.md`** gains a canonical *"AI Grading Protocol — HG-5"* section — the single source of truth.
- **`cb_init`** emits a *pointer* to it into new course stubs, sharing one sentinel-marked block with `sync_grading_protocol.py` (verified byte-identical) so a fresh repo and a retrofitted one never disagree.
- **`sync_grading_protocol.py`** — new idempotent, dry-run-by-default tool that injects the pointer into course repos initialized before #207 (which `cb-init` never updates in place). Dry-run against the real course repos correctly reports ds460 / ds250 / itm327 as "would-inject" and aol-student as "no AGENTS.md".

## Tests
13 new unit tests: disclosure validator (false-positive guard on the canonical tag, every deprecated-tag constant detected, mixed batches) + pointer injection (insert-after-title, idempotency, no-title prepend, cb_init-stub recognition, dry-run/apply). All green under `uv run pytest`.

> Note: a bare `python -m pytest` shows 12 "markdownify" failures — that's the system Python 3.12 lacking the repo's deps, **not** this change (`git diff --stat main -- lib/tools/canvas_sync.py` is empty). Under `uv run pytest` they pass. A conftest poka-yoke for that foot-gun is coming as a separate PR.

Bumps `1.7.13` → `1.7.14` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
