### PR TITLE
test: poka-yoke wrong-interpreter runs — fail fast with `uv run pytest` hint

### DIFF
--- a/lib/tests/conftest.py
+++ b/lib/tests/conftest.py
@@ -31,6 +31,30 @@ MISSING = [k for k, v in {
 }.items() if not v]
 
 
+def pytest_configure(config):
+    """Poka-yoke: fail the session fast + loud when the tests run under an
+    interpreter that lacks the repo's dependencies.
+
+    The recurring foot-gun: `python -m pytest` uses the SYSTEM interpreter, which
+    has none of canvas-toolbox's deps. The failure surfaces as a confusing
+    `ModuleNotFoundError: markdownify` deep inside a `canvas_sync --pull`
+    subprocess (three separate incidents), with no hint that the real fix is to
+    run through uv. Catch it here, at session start, with the recovery hint.
+    `markdownify` is the canary — a declared dependency unlikely to be installed
+    system-wide, so its absence means "wrong environment."
+    """
+    import importlib.util
+    if importlib.util.find_spec("markdownify") is None:
+        raise pytest.UsageError(
+            f"canvas-toolbox test dependencies are not importable under this "
+            f"interpreter:\n    {sys.executable}\n\n"
+            f"You're almost certainly running bare `python -m pytest`. Run the "
+            f"tests through uv so the project venv (with all deps) is used:\n\n"
+            f"    uv run pytest\n\n"
+            f"If the venv is stale, run `uv sync` first."
+        )
+
+
 def _skip_if_sandbox_unset():
     """Skip the calling test if Canvas sandbox env vars aren't set.
 


### PR DESCRIPTION
## The recurring foot-gun

Three times now, a run has died with `ModuleNotFoundError: No module named 'markdownify'` — and every time it looked like a broken dependency. It isn't. `markdownify>=1.2.3` is declared in [pyproject.toml](pyproject.toml) and installed in the uv `.venv` (3.14). The failure only appears when the tests are run under a **bare `python -m pytest`** (the system interpreter, which has none of the repo's deps), and it surfaces deep inside a `canvas_sync --pull` subprocess — with zero hint that the fix is `uv run`.

The prior "fixes" declared the dependency. But declaring a dep does nothing to stop someone running the tests with the wrong interpreter — **that gap was never actually poka-yoked.** [conftest.py](lib/tests/conftest.py) guarded missing Canvas creds, but nothing caught "you're in the wrong environment."

## The fix

A `pytest_configure` guard checks for the `markdownify` canary at session start. If it's absent, the session aborts immediately with a `pytest.UsageError`:

```
ERROR: canvas-toolbox test dependencies are not importable under this interpreter:
    /Library/Frameworks/Python.framework/Versions/3.12/bin/python3

You're almost certainly running bare `python -m pytest`. Run the tests through uv
so the project venv (with all deps) is used:

    uv run pytest

If the venv is stale, run `uv sync` first.
```

This matches the repo's own Jidoka/poka-yoke principle ("loud error with recovery hint = best"): it converts a confusing deep-subprocess traceback into an immediate, actionable message before a single test runs.

## Safety

- **No-op in CI** — `ci.yml` runs `uv sync --group dev` then `uv run pytest`, so `markdownify` is present and the guard never fires.
- **No-op under any correct local run** (`uv run pytest`).
- Fires **only** on the wrong-interpreter mistake it exists to catch.
- **conftest.py only** — no version bump, no pyproject/CHANGELOG change, so it can't collide with #214 regardless of merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
