### PR TITLE
feat(grader): grade-guardian PreToolUse hook — grades only via grader_push.py (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.15] — 2026-07-22
+
+**Grades can now only reach Canvas through `grader_push.py` — a harness hook blocks direct API writes an agent can't be talked out of.** (#213)
+
+The #207/#214 gates live *inside* `grader_push.py`, so they share one bypass: not calling the tool. In the KC1/KC2 incident an agent hand-wrote a `/tmp/push_grades.py` that hit the Canvas API directly and every gate was moot. In-tool enforcement can't catch "the tool was never used" — only a seam above the tools can. See [docs/grading-enforcement-a3.md](docs/grading-enforcement-a3.md).
+
+### Added
+- **`grade_guardian.py`** — a Claude Code `PreToolUse` hook (harness-enforced; the model cannot disable it). Denies: a direct Canvas grade write in a Bash command (`requests.put/post` / `curl -X PUT/POST` to a submissions endpoint), the *creation* of a file whose contents carry that signature (the bypass script caught at write-time — a Bash hook can't see inside `python x.py`), and Reads of FERPA Zone-2 files (`.deid_master.csv` et al., #212). Invoking `lib/tools/*.py`, editing the toolkit source, and doc files are exempt; the denial redirects the agent to `grader_push.py`. Fails open on malformed input — a guardrail must never brick the session.
+- **`cb-init`** — step 14 now also wires the guardian hook into the course root `.claude/settings.json` (idempotent, non-clobbering, points at the vendored hook so it stays current on `git pull`). Existing course repos: run `cb-init` to pick it up.
+
+Honest limit: regex over a command/file body is not a semantic firewall — a determined agent can obfuscate past it. This decisively raises the bar against the actual failure mode (pattern-matching a `/tmp` push script); true closure needs the capability layer (read-scoped token + write-proxy), recorded as the north-star in the A3.
+
+---
+
 ## [1.7.14] — 2026-07-22
 
 **HG-5 enforced in code: an agent can no longer autonomously push AI-drafted grades to a live course.** (#207)

--- a/docs/grading-enforcement-a3.md
+++ b/docs/grading-enforcement-a3.md
@@ -1,0 +1,116 @@
+# A3 — Deterministic enforcement of the grade-push review gate
+
+**Owner:** grading toolkit · **Date:** 2026-07-22 · **Issues:** #207, #212, #213
+**Status:** countermeasures landing across two PRs (A: harness hook · B: precheck + spec)
+
+---
+
+## 1. Background
+
+AI-assisted grading is **decision support, not autonomy** — principle **HG-5**
+([grader_hybrid_architecture.md](../lib/agents/knowledge/grader_hybrid_architecture.md)):
+a human decides every grade that reaches a student, and every AI-drafted comment is
+tagged `— AI drafted, instructor reviewed`. That tag is only *true* if review
+actually happened. Three incidents say it didn't.
+
+## 2. Current condition (the seam problem)
+
+We have real enforcement in `grader_push.py` — the `.reviewed` marker, mtime
+auto-invalidation, 3-pass consensus gate (#95), and, after #207/#214, refusal of
+`--yes` on the AI-drafted push path plus disclosure-tag validation. We also have
+`canvas_course_guard` as a standing write-safety bar.
+
+**Every one of those lives *inside* a tool.** They share exactly one bypass:
+
+```
+Agent: "push grades" → writes /tmp/push_kc_grades.py → requests.put(.../submissions/...)
+```
+
+In the KC1/KC2 incident (#213) an agent did exactly this — 46 grades pushed via a
+hand-written script. None of the in-tool gates ran, because the tool was never
+called. `grader_knowledge.md §4` already states the principle — *"enforced at the
+push seam, not by memory"* — but the seam is inside the tool, and the tool is
+skippable.
+
+## 3. Root cause (5 Whys)
+
+1. Grades posted without review → 2. Agent used a custom API script → 3. It
+pattern-matched the sprint workaround (direct-API push) to all grading → 4. Nothing
+*outside* the tool stops a direct Canvas write → 5. **All enforcement is at a seam
+the agent can route around by not using the tool.**
+
+Corollary: none of the three issues proposed the mechanism that closes this.
+#212 Option 2 suggested a hook that blocks `grader_push.py --push` — backwards; that
+is the *safe* path. #213's fixes (precheck tool, agent instructions) all rely on the
+agent *choosing* to run them — the exact failure mode.
+
+## 4. Target condition
+
+Grades can reach Canvas **only** through `grader_push.py`. A direct Canvas write, or
+the creation of a script that would do one, is refused at a seam the model cannot
+disable — and the refusal *redirects* the agent to the safe path.
+
+## 5. Countermeasures — defense in depth across `AGENT_LAYERS.md`
+
+No single mechanism is complete; robustness is layering mechanisms whose gaps don't
+overlap.
+
+| Layer | Mechanism | Catches | Residual gap |
+|---|---|---|---|
+| Spec (L3) | AGENTS.md HG-5 pointer (#214) + tool-discovery rule (#213 Fix 1/3/4, **PR B**) | cooperative agents | ignorable |
+| Tool (L0) | grader_push gates (#207/#214) + `push_precheck()` internal (**PR B**) | misuse *of* the tool | not using it |
+| **Harness (L1)** | **`grade_guardian.py` PreToolUse hook (PR A)** | direct API writes, bypass-script **creation**, FERPA reads | heavy obfuscation |
+| Capability | Canvas token scoping / write-proxy | **all** direct writes | infra weight; **north-star, not now** |
+
+### The hook (PR A) — [lib/tools/grade_guardian.py](../lib/tools/grade_guardian.py)
+
+Claude Code `PreToolUse` hooks are **harness-enforced** — the model cannot disable,
+edit, or prompt-inject around them; a hook `deny` beats any permission `allow`; they
+fire in headless `-p` and cron. The hook receives the tool call as JSON on stdin and
+exits `2` to block, with the stderr message fed back to the agent as redirection.
+
+It denies:
+- **Bash** — a write verb (`requests.put/post`, `curl -X PUT/POST`) aimed at a Canvas
+  submissions endpoint / grade payload. Invoking `lib/tools/*.py` is exempt (the safe path).
+- **Write/Edit** — creating/editing a file (outside `lib/tools/`, excluding `.md`
+  docs) whose contents carry that signature. **This is the key catch:** a Bash hook
+  can't see inside `python /tmp/push.py`, but the Write hook sees the script *as it's
+  created*.
+- **Read** — FERPA Zone-2 files (`.deid_master.csv`, `.keymap.json`, `submissions_raw/`,
+  …), enforcing the AGENTS.md discipline deterministically (#212's parallel ask).
+
+Wiring: `cb_init` merges a `PreToolUse` entry into the **course root**
+`.claude/settings.json` pointing at the vendored hook
+(`${CLAUDE_PROJECT_DIR}/canvas-toolbox/lib/tools/grade_guardian.py`) — idempotent,
+non-clobbering, and auto-current on `git pull`.
+
+## 6. Honest limits (Genchi Genbutsu)
+
+Regex over a command / file body is **not** a semantic firewall. A determined agent
+can obfuscate — `eval`, base64, variable indirection, staging the payload in a
+non-`.py`/`.md` file — and slip past. The hook **decisively raises the bar against
+the actual failure mode** (pattern-matching a `/tmp` push script) but does not make
+bypass impossible. The only closure is the **capability layer**: give the agent a
+read-scoped Canvas token and route writes through a proxy that enforces review. That
+is real infrastructure (Canvas tokens inherit full user permissions, so it needs a
+limited-permission API user or a mediating service) and is recorded here as the
+north-star, not this sprint.
+
+## 7. Verification
+
+`grade_guardian.evaluate()` is a pure function with unit coverage for every deny/allow
+case (curl-PUT, inline `python -c` requests, bypass-script **creation**, FERPA reads →
+deny; grader_push invocation, ordinary bash, toolkit-source edits, doc examples,
+non-FERPA reads → allow), plus subprocess tests that drive the real hook exactly as
+Claude Code does (exit 2 + redirect; exit 0 on allowed; fail-open on garbage stdin).
+
+## 8. Follow-up / parking lot
+
+- **PR B** — refactor grader_push gates into `push_precheck()` (internal defense in
+  depth, #213 Fix 2); fold #213 Fix 1/3/4 into the AGENTS.md protocol (tool-discovery
+  rule, "never hand-write a Canvas script," sprint-exception note).
+- **FERPA Bash discipline** — extend the hook to `cat`/`head`/`grep` on `.deid_master.csv`
+  without the `cut` column filter (AGENTS.md already documents the safe form).
+- **Capability layer** — read-scoped token + write-proxy. North-star.
+- **Not doing:** #212 Option 3 (`--stage` rename — churn, no guarantee); #212's
+  "N-minute freshness" (we already do stronger content-based mtime invalidation).

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -1,0 +1,160 @@
+"""Unit + integration tests — grade_guardian PreToolUse hook (issue #213).
+
+The hook is the harness-level seam that catches what in-tool gates can't: a direct
+Canvas grade write that never goes through grader_push.py. These tests pin the two
+things that matter — it DENIES the bypass paths, and it does NOT get in the way of
+the sanctioned tools / ordinary work (a guardrail that cries wolf gets disabled).
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grade_guardian import evaluate, ensure_hook  # noqa: E402
+
+HOOK = _TOOLS_DIR / "grade_guardian.py"
+
+
+# --- ensure_hook: idempotent, non-clobbering settings.json merge -----------
+
+def test_ensure_hook_adds_to_empty_settings():
+    new, changed = ensure_hook({})
+    assert changed is True
+    cmds = [h["command"] for e in new["hooks"]["PreToolUse"] for h in e["hooks"]]
+    assert any("grade_guardian" in c for c in cmds)
+
+
+def test_ensure_hook_is_idempotent():
+    once, _ = ensure_hook({})
+    twice, changed = ensure_hook(once)
+    assert changed is False
+    assert twice == once  # no duplicate entry
+
+
+def test_ensure_hook_preserves_existing_settings():
+    """Must not clobber a course repo's existing permissions/other hooks."""
+    existing = {"permissions": {"allow": ["Bash(git status)"]},
+                "hooks": {"PreToolUse": [{"matcher": "Read",
+                                          "hooks": [{"type": "command", "command": "other.sh"}]}]}}
+    new, changed = ensure_hook(existing)
+    assert changed is True
+    assert new["permissions"] == existing["permissions"]          # untouched
+    cmds = [h["command"] for e in new["hooks"]["PreToolUse"] for h in e["hooks"]]
+    assert "other.sh" in cmds and any("grade_guardian" in c for c in cmds)
+
+
+def test_ensure_hook_does_not_mutate_input():
+    original = {}
+    ensure_hook(original)
+    assert original == {}  # deepcopy, not in-place
+
+
+# --- DENY: the paths the #213 incident used --------------------------------
+
+def test_denies_curl_put_to_submissions():
+    cmd = ("curl -X PUT https://byui.instructure.com/api/v1/courses/1/assignments/"
+           "2/submissions/3 -d submission[posted_grade]=90")
+    assert evaluate("Bash", {"command": cmd}) is not None
+
+
+def test_denies_inline_python_requests_put():
+    cmd = ("python -c 'import requests; requests.put(\"https://x.instructure.com/"
+           "api/v1/courses/1/assignments/2/submissions/3\", "
+           "data={\"submission[posted_grade]\": \"90\"})'")
+    assert evaluate("Bash", {"command": cmd}) is not None
+
+
+def test_denies_writing_the_bypass_script_at_creation():
+    """The core catch: a Bash hook can't see inside `python /tmp/push.py`, but the
+    Write hook sees the file contents as the script is created."""
+    body = ('import requests\n'
+            'requests.put("https://x.instructure.com/api/v1/courses/1/assignments/2/'
+            'submissions/3", data={"submission[posted_grade]": "90"})\n')
+    reason = evaluate("Write", {"file_path": "/tmp/push_kc_grades.py", "file_contents": body})
+    assert reason is not None
+    assert "grader_push.py" in reason  # the denial redirects to the safe path
+
+
+def test_denies_edit_that_introduces_a_canvas_write():
+    body = 'requests.post("https://x.instructure.com/api/v1/courses/1/assignments/2/submissions/3")'
+    assert evaluate("Edit", {"file_path": "grading/kc3/hack.py", "new_string": body}) is not None
+
+
+def test_denies_reading_ferpa_zone2_files():
+    for p in ("grading/.deid_master.csv", "grading/kc3/.keymap.json",
+              "grading/kc3/submissions_raw/foo.ipynb"):
+        assert evaluate("Read", {"file_path": p}) is not None, p
+
+
+# --- ALLOW: the sanctioned tool + ordinary work ----------------------------
+
+def test_allows_running_grader_push():
+    for cmd in (
+        "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --push",
+        "python lib/tools/grader_push.py --challenge-dir grading/kc3 --mark-reviewed",
+    ):
+        assert evaluate("Bash", {"command": cmd}) is None, cmd
+
+
+def test_allows_ordinary_bash():
+    for cmd in ("git status", "ls grading/", "curl https://api.github.com/repos/x/y",
+                "uv run pytest lib/tests/ -q"):
+        assert evaluate("Bash", {"command": cmd}) is None, cmd
+
+
+def test_allows_editing_the_toolkit_source():
+    """The tools legitimately contain requests.put to Canvas — editing them is the
+    reviewed path, not a bypass."""
+    body = 'requests.put(f"{base}/api/v1/courses/{cid}/assignments/{aid}/submissions/{uid}")'
+    assert evaluate("Write", {"file_path": "/repo/lib/tools/grader_push.py",
+                              "file_contents": body}) is None
+
+
+def test_allows_docs_with_example_code():
+    """A design doc that shows the bad pattern as an EXAMPLE is prose, not a script."""
+    body = "Bad: `requests.put('.../submissions/3', data={'submission[posted_grade]':'90'})`"
+    assert evaluate("Write", {"file_path": "docs/grading_enforcement_A3.md",
+                              "file_contents": body}) is None
+
+
+def test_allows_feedback_and_non_ferpa_reads():
+    for p in ("grading/kc3/feedback/KC3-ABC.md", "README.md", "grading/kc3/config.json"):
+        assert evaluate("Read", {"file_path": p}) is None, p
+
+
+def test_payload_mention_without_a_write_verb_is_allowed():
+    """Guard against over-blocking: prose/config that merely names `posted_grade`
+    without an actual write call must pass."""
+    assert evaluate("Bash", {"command": "grep posted_grade grading/kc3/config.json"}) is None
+
+
+# --- Integration: drive the real hook exactly as Claude Code does ----------
+
+def _run_hook(payload: dict) -> subprocess.CompletedProcess:
+    return subprocess.run([sys.executable, str(HOOK)],
+                          input=json.dumps(payload), capture_output=True, text=True)
+
+
+def test_hook_exits_2_and_redirects_on_a_bypass_write():
+    r = _run_hook({"tool_name": "Write",
+                   "tool_input": {"file_path": "/tmp/push.py",
+                                  "file_contents": 'requests.put("https://x.instructure.com/'
+                                  'api/v1/courses/1/assignments/2/submissions/3")'}})
+    assert r.returncode == 2
+    assert "grader_push.py" in r.stderr
+
+
+def test_hook_exits_0_on_allowed_call():
+    r = _run_hook({"tool_name": "Bash", "tool_input": {"command": "git status"}})
+    assert r.returncode == 0
+
+
+def test_hook_fails_open_on_garbage_stdin():
+    """A guardrail must never brick the session — malformed input → allow (exit 0)."""
+    r = subprocess.run([sys.executable, str(HOOK)], input="not json",
+                       capture_output=True, text=True)
+    assert r.returncode == 0

--- a/lib/tools/cb_init.py
+++ b/lib/tools/cb_init.py
@@ -41,7 +41,9 @@ WHAT IT DOES — 14 idempotent steps
  11. Run canvas-sync --pull to populate course/ (subdirectory mode only)
  12. Generate course-specific AGENTS.md stub (subdirectory mode only)
  13. Create handoffs/ directory (opt-in via --with-handoffs; dev feature)
- 14. Copy slash commands to .claude/commands/ (always; makes tools discoverable)
+ 14. Copy slash commands to .claude/commands/ + wire the grade-guardian
+     PreToolUse hook into .claude/settings.json (blocks direct Canvas grade
+     writes so grades must go through grader_push.py — #213)
 
 Every step is idempotent: re-running cb-init after the first complete
 pass is a fast no-op that prints "✓ already done — skipping" for each
@@ -119,6 +121,13 @@ try:
     from __toolbox_version__ import __version__
 except ImportError:
     __version__ = "0.0.0+unknown"
+
+try:
+    # Idempotent installer for the grade-guardian PreToolUse hook (#213), single-
+    # sourced in grade_guardian.py so the wiring never drifts from the hook.
+    from grade_guardian import ensure_hook as _ensure_guardian_hook
+except ImportError:
+    _ensure_guardian_hook = None
 
 try:
     # Single source of truth for the HG-5 grading-protocol pointer (#207), shared
@@ -867,7 +876,39 @@ def step_14_slash_commands(*, course_root: Path, check_only: bool) -> bool:
         copied_count += 1
 
     print(f"  ✓ Copied {copied_count} slash commands to {target_dir}")
+
+    _install_guardian_hook(course_root=course_root, check_only=check_only)
     return True
+
+
+def _install_guardian_hook(*, course_root: Path, check_only: bool) -> None:
+    """Wire the grade-guardian PreToolUse hook into the course repo's
+    `.claude/settings.json` (issue #213). Idempotent + non-clobbering: merges into
+    an existing settings.json, leaves it alone if the hook is already present, and
+    refuses to overwrite a settings.json it can't parse."""
+    if _ensure_guardian_hook is None:
+        return  # pre-sync / partial vendored env — skip quietly
+
+    settings_path = course_root / ".claude" / "settings.json"
+    try:
+        existing = json.loads(settings_path.read_text(encoding="utf-8")) if settings_path.exists() else {}
+    except (OSError, json.JSONDecodeError):
+        print(f"  ⚠  {settings_path} exists but isn't valid JSON — not touching it. "
+              "Add the grade_guardian PreToolUse hook manually (see docs/grading_enforcement_A3.md).")
+        return
+
+    new_settings, changed = _ensure_guardian_hook(existing)
+    if not changed:
+        print("  ✓ grade-guardian hook already present in .claude/settings.json")
+        return
+    if check_only:
+        print(f"  would wire the grade-guardian PreToolUse hook into {settings_path}")
+        return
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(new_settings, indent=2) + "\n", encoding="utf-8")
+    print(f"  ✓ Wired grade-guardian PreToolUse hook into {settings_path} (blocks direct "
+          "Canvas grade writes; grades must go through grader_push.py — #213)")
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""PreToolUse guardrail — grades reach Canvas ONLY through grader_push.py (#213).
+
+WHY THIS EXISTS
+  Every in-tool safeguard (grader_push.py's HG-5 gate from #207/#214, and
+  canvas_course_guard) lives INSIDE the tools, so they share one bypass: not
+  calling the tool. In the KC1/KC2 incident an agent hand-wrote a
+  `/tmp/push_kc_grades.py` that hit the Canvas API directly and every gate was
+  moot. In-tool enforcement cannot catch "the tool was never used" — only a seam
+  ABOVE the tools can. Claude Code PreToolUse hooks are that seam: harness-
+  enforced, the model cannot disable them.
+
+WHAT IT DENIES
+  - Bash: a direct Canvas grade/comment write in the command string (a write verb
+    — requests.put/post, curl/wget -X PUT/POST — aimed at a Canvas submissions
+    endpoint or grade payload). Invocations of the sanctioned tools under
+    lib/tools/ are exempt.
+  - Write/Edit: creating/editing a file (outside lib/tools/) whose contents carry
+    that same Canvas-write signature — this catches the bypass SCRIPT at creation,
+    which is the only reliable catch (a Bash hook can't see inside `python x.py`).
+  - Read: FERPA Zone-2 files (.deid_master.csv et al.) — the AGENTS.md discipline,
+    enforced deterministically instead of by instruction (#212).
+
+WHAT IT DOES NOT DO (honest limits)
+  Regex on a command / file body is not a semantic firewall. A determined agent
+  can obfuscate (eval, base64, variable indirection) past it. This decisively
+  raises the bar against the ACTUAL failure mode (pattern-matching a /tmp push
+  script), but true closure needs the capability layer (a read-scoped agent token
+  + a write-proxy). See docs/grading_enforcement_A3.md.
+
+HOW CLAUDE CODE INVOKES IT
+  Registered as a PreToolUse hook (matcher `Bash|Write|Edit|Read`). Claude Code
+  pipes the tool call as JSON on stdin; exit 2 blocks the call and the stderr text
+  is fed back to the agent (so the denial redirects it to grader_push.py). Fails
+  OPEN on any internal error — a guardrail must never brick the session.
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+
+# A write verb: an HTTP mutation, however the script spells it.
+_WRITE_VERB = re.compile(
+    r"requests\.(put|post)\b"
+    r"|httpx?\.(put|post)\b"
+    r"|\b(curl|wget)\b[^\n]*-X\s*(PUT|POST)"
+    r"|\.(put|post)\(",  # generic client.put(/.post(
+    re.IGNORECASE,
+)
+
+# Canvas grade-write context: the submissions endpoint or a grade/comment payload.
+_CANVAS_CTX = re.compile(
+    r"/api/v1/courses/\d+/assignments/\d+/submissions"
+    r"|/submissions/\d+"
+    r"|posted_grade"
+    r"|submission\[submission\]"
+    r"|comment\[text_comment\]"
+    r"|canvas.*submission",
+    re.IGNORECASE,
+)
+
+# The sanctioned tool source. Writing Canvas-write code here is legitimate — this
+# IS the reviewed tooling; running these scripts is the safe path.
+_TOOLS_PATH = re.compile(r"/lib/tools/[^/\\]+\.py$")
+
+# Prose/doc files — a code example inside a design doc is not an executable bypass.
+_DOC_PATH = re.compile(r"\.(md|markdown|rst|txt)$", re.IGNORECASE)
+
+# FERPA Zone-2 files — never surface to an LLM (AGENTS.md → FERPA discipline, #212).
+_FERPA_PATH = re.compile(
+    r"\.deid_master\.csv$"
+    r"|\.known_names\.txt$"
+    r"|\.keymap\.json$"
+    r"|\.fetch_log\.json$"
+    r"|\.review\.csv$"
+    r"|/submissions_raw/"
+    r"|feedback/_grader.*\.csv$"
+)
+
+
+def _redirect(what: str) -> str:
+    return (
+        f"⛔ Blocked {what}. Grades reach Canvas ONLY through grader_push.py, which "
+        "enforces the HG-5 instructor-review gate (issue #213).\n"
+        "   Do this instead:\n"
+        "     uv run python <toolkit>/lib/tools/grader_push.py --challenge-dir <dir> --mark-reviewed\n"
+        "     uv run python <toolkit>/lib/tools/grader_push.py --challenge-dir <dir> --push\n"
+        "   If grader_push.py is genuinely blocking you, surface that to the instructor — "
+        "do NOT hand-write a Canvas API script to get around it."
+    )
+
+
+def evaluate(tool_name: str, tool_input: dict) -> str | None:
+    """Return a denial reason if the tool call must be blocked, else None.
+
+    Pure function — the whole decision, unit-testable without Claude Code.
+    """
+    tool_input = tool_input or {}
+
+    if tool_name == "Bash":
+        cmd = tool_input.get("command", "") or ""
+        if _TOOLS_PATH.search(cmd):
+            return None  # invoking the sanctioned tools is the safe path
+        if _WRITE_VERB.search(cmd) and _CANVAS_CTX.search(cmd):
+            return _redirect("a direct Canvas grade write in a shell command")
+        return None
+
+    if tool_name in ("Write", "Edit"):
+        path = tool_input.get("file_path", "") or ""
+        if _TOOLS_PATH.search(path):
+            return None  # editing the reviewed tooling is allowed
+        if _DOC_PATH.search(path):
+            return None  # prose/docs — a code example is not an executable bypass
+        # Write carries file_contents; Edit carries new_string.
+        body = tool_input.get("file_contents") or tool_input.get("new_string") or ""
+        if _WRITE_VERB.search(body) and _CANVAS_CTX.search(body):
+            target = path or "a new file"
+            return _redirect(f"Canvas grade-write code being written into {target}")
+        return None
+
+    if tool_name == "Read":
+        path = tool_input.get("file_path", "") or ""
+        if _FERPA_PATH.search(path):
+            return (
+                "⛔ FERPA Zone-2 file — do not Read it (AGENTS.md → FERPA discipline). "
+                "Trust the tool's summary output; for verification use `wc -l` or `ls`, "
+                "never Read/cat/grep on the name-bearing files."
+            )
+        return None
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Installer helpers — cb_init wires this hook into a course repo's settings.json.
+# Single-sourced here so the matcher/command never drift from the hook itself.
+# ---------------------------------------------------------------------------
+
+HOOK_MATCHER = "Bash|Write|Edit|Read"
+
+
+def hook_command(toolkit_subdir: str = "canvas-toolbox") -> str:
+    """The PreToolUse `command` for a course repo. ${CLAUDE_PROJECT_DIR} is the
+    course root; the toolkit is vendored under it at <toolkit_subdir>/."""
+    return f'python3 "${{CLAUDE_PROJECT_DIR}}/{toolkit_subdir}/lib/tools/grade_guardian.py"'
+
+
+def ensure_hook(settings: dict) -> tuple:
+    """Idempotently add the grade_guardian PreToolUse hook to a settings dict.
+
+    Returns (new_settings, changed). If any PreToolUse hook already references
+    grade_guardian, returns the settings unchanged. Never mutates the input.
+    """
+    import copy
+    settings = copy.deepcopy(settings) if settings else {}
+    pre = settings.setdefault("hooks", {}).setdefault("PreToolUse", [])
+    for entry in pre:
+        for h in entry.get("hooks", []):
+            if "grade_guardian" in (h.get("command") or ""):
+                return settings, False
+    pre.append({
+        "matcher": HOOK_MATCHER,
+        "hooks": [{"type": "command", "command": hook_command()}],
+    })
+    return settings, True
+
+
+def main() -> int:
+    if "--help" in sys.argv[1:]:
+        print("PreToolUse hook (issue #213). Reads a tool call as JSON on stdin; "
+              "exits 2 to block a direct Canvas grade write. Not an operator CLI.")
+        return 0
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, ValueError, OSError):
+        return 0  # fail open — never break the session on bad/empty input
+    reason = evaluate(data.get("tool_name", ""), data.get("tool_input", {}))
+    if reason:
+        print(reason, file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.14"
+version = "1.7.15"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.14"
+version = "1.7.15"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Addresses #213 (and #212's Option 2, reframed). **PR A of two** — the harness hook that closes the tool-bypass hole; PR B adds the internal precheck + spec hardening.

## The seam problem
The #207/#214 gates and `canvas_course_guard` all live **inside** the tools, so they share one bypass: **not calling the tool.** In the KC1/KC2 incident (#213) an agent hand-wrote a `/tmp/push_kc_grades.py` that hit the Canvas API directly — 46 grades, zero gates run. In-tool enforcement can't catch "the tool was never used." Only a seam **above** the tools can, and Claude Code `PreToolUse` hooks are that seam: **harness-enforced — the model cannot disable, edit, or prompt-inject around them.**

Full reasoning + honest limits: [docs/grading-enforcement-a3.md](docs/grading-enforcement-a3.md).

## What the hook denies — [lib/tools/grade_guardian.py](lib/tools/grade_guardian.py)
- **Bash** — a write verb (`requests.put/post`, `curl -X PUT/POST`) aimed at a Canvas submissions endpoint / grade payload. Invoking `lib/tools/*.py` is exempt (the safe path).
- **Write/Edit** — creating/editing a file (outside `lib/tools/`, excluding `.md` docs) whose contents carry that signature. **The key catch:** a Bash hook can't see inside `python /tmp/push.py`, but the Write hook sees the script *as it's created*.
- **Read** — FERPA Zone-2 files (`.deid_master.csv`, `.keymap.json`, `submissions_raw/`, …) — the AGENTS.md discipline enforced deterministically (#212's parallel ask).

The denial exits 2 with a message that **redirects the agent** to `grader_push.py`. Fails **open** on malformed input — a guardrail must never brick the session.

## Wiring
`cb-init` step 14 now merges the hook into the **course root** `.claude/settings.json` (idempotent, non-clobbering, points at the vendored hook so `git pull` keeps it current). Existing course repos pick it up by re-running `cb-init`. Not activated in this toolkit repo itself (the toolkit's own source legitimately contains Canvas writes; those edits are exempt anyway).

## Honest limit
Regex over a command/file body is **not** a semantic firewall — a determined agent can obfuscate (`eval`, base64, variable indirection) past it. This decisively raises the bar against the **actual** failure mode (pattern-matching a `/tmp` push script); true closure needs the capability layer (read-scoped token + write-proxy), recorded as the north-star in the A3.

## Tests
18 tests, all green under `uv run pytest`: `evaluate()` deny cases (curl-PUT, inline `python -c` requests, bypass-script **creation**, FERPA reads) and allow cases (grader_push invocation, ordinary bash, toolkit-source edits, doc examples, non-FERPA reads); subprocess tests driving the real hook as Claude Code does (exit 2 + redirect, exit 0 allowed, fail-open on garbage); and `ensure_hook` idempotency / non-clobbering / no-input-mutation.

Bumps `1.7.14` → `1.7.15` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
