### PR TITLE
feat(grader): push_precheck() + "never hand-write a Canvas script" spec (#213)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -112,6 +112,14 @@ Accommodation tools (`student_late_accommodation.py`, `student_quiz_time_extensi
 
 **Do not** run `grader_push.py --yes --push` to "just get the grades in." That is the exact HG-5 breach an [RCA](https://github.com/chaz-clark/canvas-toolbox/issues/207) was written about — 12 students received AI-drafted grades with no instructor review. If a gate blocks you, the fix is to *do the review*, not to reach for an override flag.
 
+**Never hand-write a Canvas write (issue #213).** Grades and comments reach Canvas **only** through `grader_push.py` — never a custom `requests`/`curl` script, an inline `python -c`, or a `/tmp/*.py`. Before implementing *any* Canvas operation:
+
+1. **Search `lib/tools/` first** for an existing tool; read its docstring for prerequisites. "Push grades" → `grader_push.py`, not a fresh API script.
+2. **If a tool exists, use it.** A direct API call skips every safety gate (`.reviewed`, consensus, `canvas_course_guard`, idempotency, disclosure) — that's how 46 grades once shipped un-reviewed.
+3. **If none exists, propose one and ask** — don't improvise a direct write.
+
+The `grade_guardian` PreToolUse hook enforces this deterministically; if it blocks you, use the tool or surface the blocker to the instructor — do **not** route around it. (The S1–S4 sprint direct-API push was a one-off workaround for a `submission_file` mapping bug — **not** the pattern for KCs / quizzes / reviews.)
+
 ---
 
 ## Common Tasks Quick Reference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.16] — 2026-07-22
+
+**Defense in depth for the grade-push gate: an internal precheck + the "never hand-write a Canvas script" rule in the agent spec.** (#213)
+
+PR B of two (PR A, #216/v1.7.15, added the harness hook). This consolidates the in-tool review gate and closes the spec gap that let an agent pattern-match a `/tmp` push script from the sprint workaround.
+
+### Changed
+- **`grader_push.py`** — the required review gate (`.reviewed` exists + mtime freshness) is now one testable checkpoint, `push_precheck()`, called by `cmd_push` before any Canvas write. Behavior-preserving refactor; adds a visibility warning when AI-drafted work lacks `feedback/_consensus.csv` (already gated at `--mark-reviewed` by #95).
+
+### Added
+- **`AGENTS.md`** — "Never hand-write a Canvas write" rule in the HG-5 protocol: search `lib/tools/` first, use the tool if it exists, propose one if it doesn't — never a custom `requests`/`curl`/`/tmp/*.py`. Clarifies the S1–S4 sprint direct-API push as a one-off workaround, not the pattern. (#213 systemic gaps.)
+
+---
+
 ## [1.7.15] — 2026-07-22
 
 **Grades can now only reach Canvas through `grader_push.py` — a harness hook blocks direct API writes an agent can't be talked out of.** (#213)

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -29,6 +29,7 @@ from grader_push import (  # noqa: E402
     DISCLOSURE_TAG,
     find_deprecated_disclosure_tags,
     DEPRECATED_DISCLOSURE_TAGS,
+    push_precheck,
     assignment_posts_manually,
     post_assignment_grades,
 )
@@ -534,6 +535,69 @@ def test_every_deprecated_tag_constant_is_detected(tmp_path):
     for i, dep in enumerate(DEPRECATED_DISCLOSURE_TAGS):
         fb = _write_fb(tmp_path, f"KC1-{i}.md", f"body\n\n{dep}\n")
         assert find_deprecated_disclosure_tags([fb]), f"not detected: {dep!r}"
+
+
+# ---------------------------------------------------------------------------
+# push_precheck — issue #213 Fix 2 (the review gate as one testable checkpoint)
+# ---------------------------------------------------------------------------
+
+def _setup_challenge(tmp_path, *, reviewed_mtime=None, files=None):
+    """Build a challenge dir. `files` maps relative path -> mtime (int)."""
+    import os
+    challenge = tmp_path / "kc3"
+    fbdir = challenge / "feedback"
+    fbdir.mkdir(parents=True)
+    for rel, mtime in (files or {}).items():
+        p = challenge / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text("x", encoding="utf-8")
+        if mtime is not None:
+            os.utime(p, (mtime, mtime))
+    reviewed = challenge / ".reviewed"
+    if reviewed_mtime is not None:
+        reviewed.write_text("reviewed\n", encoding="utf-8")
+        os.utime(reviewed, (reviewed_mtime, reviewed_mtime))
+    return challenge, fbdir, reviewed
+
+
+def test_precheck_blocks_without_reviewed_marker():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        challenge, fbdir, reviewed = _setup_challenge(
+            Path(d), files={"feedback/KC3-A.md": 100})
+        blockers, warnings = push_precheck(challenge, fbdir, "KC3", reviewed, "grading/kc3")
+        assert blockers and "Review required" in blockers[0]
+
+
+def test_precheck_passes_when_reviewed_and_fresh():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        challenge, fbdir, reviewed = _setup_challenge(
+            Path(d), reviewed_mtime=2000,
+            files={"feedback/KC3-A.md": 1000, "feedback/_consensus.csv": 1000})
+        blockers, warnings = push_precheck(challenge, fbdir, "KC3", reviewed, "grading/kc3")
+        assert blockers == [] and warnings == []
+
+
+def test_precheck_blocks_when_review_surface_edited_after_marker():
+    """The mtime re-lock: a comment file touched after .reviewed refuses the push."""
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        challenge, fbdir, reviewed = _setup_challenge(
+            Path(d), reviewed_mtime=1000,
+            files={"feedback/KC3-A.md": 5000, "feedback/_consensus.csv": 500})
+        blockers, warnings = push_precheck(challenge, fbdir, "KC3", reviewed, "grading/kc3")
+        assert blockers and "changed since you marked reviewed" in blockers[0]
+
+
+def test_precheck_warns_on_missing_consensus_but_does_not_block():
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        challenge, fbdir, reviewed = _setup_challenge(
+            Path(d), reviewed_mtime=2000, files={"feedback/KC3-A.md": 1000})
+        blockers, warnings = push_precheck(challenge, fbdir, "KC3", reviewed, "grading/kc3")
+        assert blockers == []
+        assert warnings and "_consensus.csv" in warnings[0]
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -211,6 +211,61 @@ def find_deprecated_disclosure_tags(comment_files: list) -> list:
     return violations
 
 
+def push_precheck(challenge: Path, fbdir: Path, prefix: str, reviewed: Path,
+                  challenge_dir_arg: str) -> tuple:
+    """Issue #213 (Fix 2): the required review gate as one testable checkpoint.
+
+    cmd_push calls this before any Canvas write — defense in depth. The
+    grade_guardian PreToolUse hook keeps an agent *in* grader_push.py; this keeps
+    grader_push.py from pushing an un-reviewed or stale state. Returns
+    (blockers, warnings), each a ready-to-print message; a non-empty `blockers`
+    means refuse the push.
+    """
+    blockers: list = []
+    warnings: list = []
+    comment_files = list(fbdir.glob(f"{prefix}-*.md"))
+
+    # 1. .reviewed marker must exist — the human attested review (#46).
+    if not reviewed.exists():
+        review_csvs = sorted(challenge.glob(".review*.csv"))
+        if comment_files:
+            surface = (f"   Review {fbdir}/_all_comments.md and the per-student "
+                       f"{prefix}-*.md justifications,")
+        elif review_csvs:
+            surface = (f"   Review the .review*.csv files in {challenge}/ + "
+                       f"{fbdir.name}/_gradebook_actuals.csv (value-only / human-graded path),")
+        else:
+            surface = (f"   Produce a review surface first (per-student {prefix}-*.md OR "
+                       f".review*.csv), then review it,")
+        blockers.append(
+            "\n⛔ Review required before pushing.\n" + surface +
+            "\n   then run:  uv run python lib/tools/grader_push.py --challenge-dir "
+            f"{challenge_dir_arg} --mark-reviewed")
+        return blockers, warnings  # staleness/consensus need .reviewed to exist
+
+    # 2. .reviewed must not be stale — any review-surface edit after it re-locks (#46).
+    rmt = reviewed.stat().st_mtime
+    watch = (
+        list(fbdir.glob(f"{prefix}-*.md"))
+        + [fbdir / "_all_comments.md"]
+        + list(challenge.glob(".review*.csv"))
+        + [fbdir / "_gradebook_actuals.csv"]
+    )
+    stale = [p.name for p in watch if p.exists() and p.stat().st_mtime > rmt]
+    if stale:
+        blockers.append(
+            f"\n⛔ {len(stale)} review-surface file(s) changed since you marked reviewed "
+            f"(e.g. {stale[0]}). Re-review, then re-run --mark-reviewed.")
+
+    # 3. Consensus presence (warning): AI-drafted work should carry _consensus.csv
+    #    (#95 gates this at --mark-reviewed; surfaced here for visibility on
+    #    --allow-single-pass runs).
+    if comment_files and not (fbdir / "_consensus.csv").exists():
+        warnings.append("No feedback/_consensus.csv — was this single-pass graded?")
+
+    return blockers, warnings
+
+
 # Issue #72: HOLD_<DIMENSION> grade-hold pattern (lifted from itm327's
 # build_mid_letter_comments + push_mid_letter). When a per-student
 # feedback file's top-of-file heading carries a trailing `· HOLD_<TOKEN>`
@@ -1529,40 +1584,18 @@ def main() -> int:
         print("Nothing to push.")
         return 1
 
-    # --- REQUIRED REVIEW GATE: --mark-reviewed must exist + not be stale ---
-    # Issue #46: the watch list is the union of EVERYTHING the operator might
-    # have reviewed — comment files (LLM-comment runs), the all-comments
-    # overview, AND the value-only review surface (.review*.csv +
-    # _gradebook_actuals.csv). The mtime auto-invalidation fires if ANY of
-    # these post-dates the .reviewed marker, regardless of which subset
-    # actually exists in this run. So value-only pushes keep a real
-    # "edited-after-review re-locks" guarantee.
-    if not reviewed.exists():
-        comment_files = list(fbdir.glob(f"{prefix}-*.md"))
-        review_csvs = sorted(challenge.glob(".review*.csv"))
-        print("\n⛔ Review required before pushing.")
-        if comment_files:
-            print(f"   Review {fbdir}/_all_comments.md and the per-student {prefix}-*.md justifications,")
-        elif review_csvs:
-            print(f"   Review the .review*.csv files in {challenge}/ + "
-                  f"{fbdir.name}/_gradebook_actuals.csv (value-only / human-graded path),")
-        else:
-            print(f"   Produce a review surface first (per-student {prefix}-*.md OR "
-                  f".review*.csv), then review it,")
-        print("   then run:  uv run python lib/tools/grader_push.py --challenge-dir "
-              f"{args.challenge_dir} --mark-reviewed")
-        return 1
-    rmt = reviewed.stat().st_mtime
-    watch = (
-        list(fbdir.glob(f"{prefix}-*.md"))
-        + [fbdir / "_all_comments.md"]
-        + list(challenge.glob(".review*.csv"))
-        + [fbdir / "_gradebook_actuals.csv"]
-    )
-    stale = [p.name for p in watch if p.exists() and p.stat().st_mtime > rmt]
-    if stale:
-        print(f"\n⛔ {len(stale)} review-surface file(s) changed since you marked reviewed "
-              f"(e.g. {stale[0]}). Re-review, then re-run --mark-reviewed.")
+    # --- REQUIRED REVIEW GATE (issue #213 Fix 2: push_precheck) ---
+    # Issue #46: .reviewed must exist AND be fresh — the watch list is the union
+    # of every review surface (comment files, _all_comments.md, .review*.csv,
+    # _gradebook_actuals.csv); any of them post-dating the marker re-locks. Now
+    # consolidated into one testable checkpoint (push_precheck) that cmd_push runs
+    # before any Canvas write.
+    pc_blockers, pc_warnings = push_precheck(challenge, fbdir, prefix, reviewed, args.challenge_dir)
+    for w in pc_warnings:
+        print(f"  ⚠  {w}")
+    if pc_blockers:
+        for b in pc_blockers:
+            print(b)
         return 1
 
     # --- HG-5 GATE: instructor is the top layer on the AI-drafted push path ---

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.15"
+version = "1.7.16"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.15"
+version = "1.7.16"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Addresses #213. **PR B of two** — defense in depth *inside* the tool + the spec gap. (PR A, #216, added the harness-level [grade_guardian hook](https://github.com/chaz-clark/canvas-toolbox/pull/216).)

## `push_precheck()` — the review gate as one testable checkpoint
The required review gate (`.reviewed` exists + mtime freshness) was inline in `cmd_push`. It's now `push_precheck()`, called before any Canvas write (#213 Fix 2 — "grader_push.py calls it internally, defense in depth"). Behavior-preserving extraction of the existing gate, plus a visibility warning when AI-drafted work lacks `feedback/_consensus.csv` (already gated at `--mark-reviewed` by #95). 4 unit tests lock the behavior (blocks without `.reviewed`; passes when reviewed + fresh; re-locks when a review-surface file is edited after the marker; warns-not-blocks on missing consensus).

## Spec: never hand-write a Canvas write
`AGENTS.md`'s HG-5 section now carries #213's Fix 1/3/4 — the root cause was the agent generalizing the S1–S4 sprint direct-API workaround to all grading:
> Grades reach Canvas **only** through `grader_push.py` — never a custom `requests`/`curl` script, inline `python -c`, or `/tmp/*.py`. Search `lib/tools/` first; use the tool if it exists; propose one if it doesn't. The `grade_guardian` hook enforces this; if it blocks you, use the tool — don't route around it.

## Why two PRs
The hook (A) is the deterministic seam that catches tool-bypass; this (B) makes the in-tool gate testable/reusable and closes the *instruction* gap so a cooperative agent doesn't reach for a custom script in the first place. Layered — neither replaces the other.

Full suite green under `uv run pytest`. Bumps `1.7.15` → `1.7.16` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
