### PR TITLE
feat(grader): Stage 0 — per-criterion checkability tags in RUBRIC.md (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.18] — 2026-07-22
+
+**Stage 0 of the hybrid grader (#192): rubrics now carry a per-criterion `Checkability` tag — the foundation the NLP+LLM routing derives from.** (#192, Sprint 0)
+
+Every criterion is tagged `mechanical` / `coverage` / `judgment` so the hybrid grader routes it to the authoritative layer (HG-1). Tags live **inline in `RUBRIC.md`** — single source of truth, so a rubric edit updates the checks (no companion file to drift).
+
+### Added
+- **`grader_rubric.py`** — parses the checkability-tagged criteria table from a `RUBRIC.md` (tolerant of the other columns — `#`, tier descriptors — and of an optional `Evidence hint` column), validates the tags, and prints a `checkability_fingerprint` — the Stage-0 **freeze marker** (order-insensitive, changes the instant a criterion's routing changes, so drift from a frozen rubric is detectable). CLI + `parse_checkability()` / `checkability_fingerprint()` with unit coverage.
+- **Scaffold rubric templates** (`cohesive_narrative.md`, `ai_log.md`) — gain the `Checkability` column with sensible default tags + a validate-and-freeze note, so new cohorts start tagged.
+- **`grader_setup_knowledge.md`** — Step 2.5: tag each criterion's checkability (with the "could a careful non-expert verify by looking/counting, or does it take judgment?" test), then freeze. Applies to all three rubric paths.
+
+This is the precondition; the evidence extractor that consumes the tags lands in Sprint 1.
+
+---
+
 ## [1.7.17] — 2026-07-22
 
 **New grading principle HG-6: low grades get a benefit-of-the-doubt audit.** (#192)

--- a/lib/agents/knowledge/grader_setup_knowledge.md
+++ b/lib/agents/knowledge/grader_setup_knowledge.md
@@ -154,6 +154,20 @@ This is an open-ended conversation. The job is to extract from the instructor's 
 
 Don't promise this is fast. A new rubric for an assignment that's been graded by feel for years is **the work**. Plan 30–60 minutes for Path C. The output is permanent.
 
+#### Step 2.5 — Tag each criterion's checkability, then freeze (all three paths)
+
+Before leaving Step 2 — whichever path produced the rubric — tag **every criterion** in `RUBRIC.md` with a `Checkability` value, so the hybrid grader routes it to the layer that's authoritative for it (issue #192, HG-1). Add a `Checkability` column to the criteria table:
+
+| Tag | The criterion is… | Who's authoritative |
+|---|---|---|
+| `mechanical` | binary / countable — "includes a thesis", "≥3 citations", "code runs" | **NLP** (evidence); LLM confirms |
+| `coverage` | all-of-a-set present — "addresses all 5 prompts", "each regulation discussed" | **shared** — NLP flags, LLM verifies |
+| `judgment` | quality / insight — "critical insight", "synthesis", "clarity" | **LLM** only; NLP gives weak hints |
+
+**Ask, per criterion:** "Could a careful non-expert verify this by looking/counting, or does it take judgment?" Look/count → `mechanical` or `coverage`; takes judgment → `judgment`. When unsure, tag `judgment` (never force regex onto insight — HG-1). A single-dimension holistic rubric (one axis, e.g. an engagement tier) is one `judgment` row.
+
+**Then freeze:** run `grader_rubric.py --rubric RUBRIC.md` — it validates the tags and prints a `checkability fingerprint`. Record that fingerprint (the Stage-0 freeze marker); the extractors derive from the *frozen* rubric. A later fingerprint change means the rubric was edited and the checks need re-freezing (surface it; don't silently grade against a drifted rubric). **The rubric is the source of truth — a rubric edit updates the checks, so the tags live inline in `RUBRIC.md`, never in a companion file.**
+
 ### Step 3 — Critical thinking: scored or formative?
 
 **Ask:** "Is critical thinking (data interrogation, self-questioning, reasoning quality) part of the grade, or is it something you want surfaced as coaching but not scored?"

--- a/lib/tests/test_grader_rubric.py
+++ b/lib/tests/test_grader_rubric.py
@@ -1,0 +1,95 @@
+"""Unit tests — grader_rubric checkability parser + freeze fingerprint (Stage 0, #192).
+
+The whole hybrid pipeline routes on the per-criterion checkability tag, so parsing
+the RUBRIC.md table correctly (and detecting a bad/missing one) is load-bearing. The
+fingerprint is the "frozen rubric" marker — it must be stable under cosmetic edits
+but change the instant a criterion's routing changes.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_rubric import (  # noqa: E402
+    parse_checkability,
+    checkability_fingerprint,
+    CHECKABILITY,
+)
+
+RUBRIC = """# Some Assignment — Rubric
+
+## Criteria
+
+| # | Criterion | Checkability | What "Meets" looks like |
+|---|-----------|--------------|--------------------------|
+| 1 | **Includes a thesis** | mechanical | a claim is stated up front |
+| 2 | Addresses all 5 prompts | coverage | every prompt answered |
+| 3 | Demonstrates critical insight | judgment | goes beyond summary |
+
+## Holistic banding
+
+Score against the named band as a single judgment.
+"""
+
+
+def test_parses_criterion_and_tag_ignoring_extra_columns():
+    rows, issues = parse_checkability(RUBRIC)
+    assert issues == []
+    assert [r["criterion"] for r in rows] == [
+        "Includes a thesis", "Addresses all 5 prompts", "Demonstrates critical insight"]
+    assert [r["checkability"] for r in rows] == ["mechanical", "coverage", "judgment"]
+    # bold markup and the leading '#' / tier-descriptor columns are stripped/ignored
+    assert all(r["checkability"] in CHECKABILITY for r in rows)
+
+
+def test_stops_at_end_of_table():
+    """Prose after the table (holistic banding) must not be parsed as rows."""
+    rows, _ = parse_checkability(RUBRIC)
+    assert len(rows) == 3
+
+
+def test_missing_table_is_an_issue():
+    rows, issues = parse_checkability("# Rubric\n\nNo table here, just prose.\n")
+    assert rows == []
+    assert issues and "Checkability" in issues[0]
+
+
+def test_unknown_tag_is_flagged_not_silently_dropped():
+    bad = ("| Criterion | Checkability |\n|---|---|\n"
+           "| Good row | mechanical |\n| Bad row | vibes |\n")
+    rows, issues = parse_checkability(bad)
+    assert [r["criterion"] for r in rows] == ["Good row"]
+    assert any("vibes" in it for it in issues)
+
+
+def test_optional_evidence_hint_column():
+    txt = ("| Criterion | Checkability | Evidence hint |\n|---|---|---|\n"
+           "| ≥3 citations | mechanical | APA (Author, YEAR); target ≥3 |\n"
+           "| Critical insight | judgment | — |\n")
+    rows, issues = parse_checkability(txt)
+    assert issues == []
+    assert rows[0]["evidence_hint"] == "APA (Author, YEAR); target ≥3"
+    assert rows[1]["evidence_hint"] is None  # an em-dash means "no hint"
+
+
+# --- fingerprint (the freeze marker) ---------------------------------------
+
+def test_fingerprint_is_stable_under_reordering():
+    a = [{"criterion": "X", "checkability": "mechanical"},
+         {"criterion": "Y", "checkability": "judgment"}]
+    b = list(reversed(a))
+    assert checkability_fingerprint(a) == checkability_fingerprint(b)
+
+
+def test_fingerprint_changes_when_a_tag_changes():
+    base = [{"criterion": "X", "checkability": "mechanical"}]
+    moved = [{"criterion": "X", "checkability": "judgment"}]
+    assert checkability_fingerprint(base) != checkability_fingerprint(moved)
+
+
+def test_fingerprint_changes_when_a_criterion_is_added():
+    one = [{"criterion": "X", "checkability": "coverage"}]
+    two = one + [{"criterion": "Y", "checkability": "coverage"}]
+    assert checkability_fingerprint(one) != checkability_fingerprint(two)

--- a/lib/tools/grader_rubric.py
+++ b/lib/tools/grader_rubric.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Parse a RUBRIC.md's checkability-tagged criteria table (Stage 0 — issue #192).
+
+Every rubric criterion carries a CHECKABILITY tag so the hybrid grader can route it
+to the layer that's authoritative for it (HG-1, route by checkability):
+
+  - mechanical — binary / countable: "includes a thesis", "≥3 citations", "code runs".
+                 NLP is authoritative (the LLM confirms).
+  - coverage   — all-of-a-set present: "addresses all 5 prompts". NLP flags, LLM verifies.
+  - judgment   — quality / insight: "critical insight", "synthesis". LLM only; NLP gives
+                 at most weak hints — never force regex onto judgment.
+
+The tags live INLINE in RUBRIC.md — single source of truth, so a rubric edit updates
+the checks (no companion file to drift). This module reads the criteria-checkability
+table; the evidence extractor (grader_signals.py, Sprint 1) derives per-criterion
+term-banks / coverage from these rows.
+
+"Frozen" (Stage 0) = a committed RUBRIC.md whose checkability_fingerprint is recorded;
+if the fingerprint changes, the rubric was edited and downstream should re-freeze.
+
+Usage:
+    uv run python lib/tools/grader_rubric.py --rubric grading/<task>/RUBRIC.md
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import re
+import sys
+from pathlib import Path
+
+CHECKABILITY = ("mechanical", "coverage", "judgment")
+
+_CRITERION_COLS = ("criterion", "criteria")
+_CHECK_COLS = ("checkability", "check")
+_HINT_COLS = ("evidence hint", "evidence", "hint")
+
+
+def _cells(line: str) -> list:
+    """`| a | b | c |` -> ['a', 'b', 'c']."""
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def _is_separator(cells: list) -> bool:
+    non_empty = [c for c in cells if c]
+    return bool(non_empty) and all(re.fullmatch(r":?-{2,}:?", c) for c in non_empty)
+
+
+def _col_index(header: list, names: tuple) -> int | None:
+    for n in names:
+        if n in header:
+            return header.index(n)
+    return None
+
+
+def parse_checkability(rubric_text: str) -> tuple:
+    """Parse the criteria table that carries a `Checkability` column.
+
+    Returns (rows, issues). rows = [{criterion, checkability, evidence_hint}].
+    Extra columns (#, tier descriptors) are ignored; only Criterion + Checkability
+    are required, Evidence hint is optional. `issues` is a list of human-readable
+    problems (missing table, unknown tag) — a non-empty list means the freeze
+    isn't clean.
+    """
+    rows: list = []
+    issues: list = []
+    lines = rubric_text.splitlines()
+
+    header_idx = None
+    header = None
+    for i, ln in enumerate(lines):
+        if "|" not in ln:
+            continue
+        lowered = [c.lower() for c in _cells(ln)]
+        if any(c in _CHECK_COLS for c in lowered):
+            header_idx, header = i, lowered
+            break
+
+    if header is None:
+        issues.append("No criteria table with a 'Checkability' column found in RUBRIC.md. "
+                      "Add one so each criterion is routed by checkability (mechanical / "
+                      "coverage / judgment).")
+        return rows, issues
+
+    ci_crit = _col_index(header, _CRITERION_COLS)
+    ci_check = _col_index(header, _CHECK_COLS)
+    ci_hint = _col_index(header, _HINT_COLS)
+    if ci_crit is None:
+        issues.append("The checkability table has no 'Criterion' column.")
+        return rows, issues
+
+    for ln in lines[header_idx + 1:]:
+        if "|" not in ln:
+            break  # table ended
+        cells = _cells(ln)
+        if _is_separator(cells):
+            continue
+        if len(cells) <= max(ci_crit, ci_check):
+            continue
+        criterion = cells[ci_crit].strip().strip("*").strip()
+        check = cells[ci_check].strip().lower()
+        hint = cells[ci_hint].strip() if (ci_hint is not None and ci_hint < len(cells)) else ""
+        if not criterion:
+            continue
+        if check not in CHECKABILITY:
+            issues.append(f"{criterion!r}: unknown checkability {check!r} — "
+                          f"use one of {', '.join(CHECKABILITY)}.")
+            continue
+        rows.append({
+            "criterion": criterion,
+            "checkability": check,
+            "evidence_hint": hint if (hint and hint != "—") else None,
+        })
+
+    if not rows and not issues:
+        issues.append("Checkability table found but no valid criterion rows parsed.")
+    return rows, issues
+
+
+def checkability_fingerprint(rows: list) -> str:
+    """Stable 'frozen' marker: a hash of the (criterion, checkability) pairs.
+
+    Order-insensitive (reordering criteria is not a rubric change), but changes the
+    moment a criterion or its checkability tag changes — so drift from a frozen
+    rubric is detectable.
+    """
+    pairs = sorted(f"{r['criterion'].strip().lower()}::{r['checkability']}" for r in rows)
+    return hashlib.sha256("\n".join(pairs).encode("utf-8")).hexdigest()[:16]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Parse + validate a RUBRIC.md checkability table (Stage 0, #192).")
+    ap.add_argument("--rubric", required=True, help="Path to RUBRIC.md")
+    args = ap.parse_args()
+
+    path = Path(args.rubric)
+    if not path.is_file():
+        print(f"No rubric at {path}", file=sys.stderr)
+        return 1
+    rows, issues = parse_checkability(path.read_text(encoding="utf-8"))
+
+    for r in rows:
+        hint = f"  ({r['evidence_hint']})" if r["evidence_hint"] else ""
+        print(f"  [{r['checkability']:<10}] {r['criterion']}{hint}")
+    by_tag = {t: sum(1 for r in rows if r["checkability"] == t) for t in CHECKABILITY}
+    print(f"\n{len(rows)} criteria — " + ", ".join(f"{n} {t}" for t, n in by_tag.items()))
+    if rows:
+        print(f"checkability fingerprint (freeze marker): {checkability_fingerprint(rows)}")
+    if issues:
+        print("\nIssues:", file=sys.stderr)
+        for it in issues:
+            print(f"  ⛔ {it}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.17"
+version = "1.7.18"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/scaffold/grading/rubric_templates/ai_log.md
+++ b/scaffold/grading/rubric_templates/ai_log.md
@@ -24,6 +24,20 @@ becomes the headline; the full mixture is the formative signal.
 | 5 | Critical inquiry        | "Why is it that ___" Questions AI's responses; tests its confidence; cross-checks against own knowledge. |
 | N/A | No AI use stated        | Student submits "I did this myself." |
 
+## Criteria checkability (issue #192, HG-1)
+
+This is a **single-dimension** rubric — the whole submission is classified on one
+axis (the AI-engagement tier), which is a **judgment** call. NLP contributes only
+weak hints (e.g. detecting `"Why is it that"` / question-pattern turns as tier-5
+signals); the tier itself is the LLM's read. Multi-criterion rubrics tag one row
+per criterion; here there is one:
+
+| Criterion | Checkability | Evidence hint |
+|---|---|---|
+| AI-engagement tier | judgment | question-pattern turns, hypothesis language → weak tier-5 hints only |
+
+Validate + freeze: `uv run python canvas-toolbox/lib/tools/grader_rubric.py --rubric ./RUBRIC.md`.
+
 ## Pass criteria (instructor-edited)
 
 - **Pass** = any honest engagement. Every tier mixture passes, including

--- a/scaffold/grading/rubric_templates/cohesive_narrative.md
+++ b/scaffold/grading/rubric_templates/cohesive_narrative.md
@@ -11,13 +11,25 @@ This captures the criteria-set that surfaced from that real run.
 
 ## The five canonical criteria
 
-| # | Criterion | What "Meets" looks like |
-|---|-----------|--------------------------|
-| 1 | **Project task complete** | The narrative addresses every required deliverable of the assignment (no skipped sub-parts, no off-topic substitution). |
-| 2 | **Cohesive analysis** | The narrative reads as ONE story across all sub-tasks. Conclusions link back to the framing question; transitions between sections are explicit. Not a stitched-together set of independent answers. |
-| 3 | **Reproducible work** | The analysis is reproducible from the submission. Data sources, parameter choices, seed values, and any sampling decisions are stated explicitly. A reader could re-run the work from what's in the submission. |
-| 4 | **Correct calculations** | Numerical results are right. Where uncertainty exists (e.g. monte-carlo, fitting), the band of acceptable answers is stated and the result falls in it. Wrong answers don't pass on style alone. |
-| 5 | **Mathematical notation** | Notation is consistent with the course's conventions. Equations, units, and symbols match the assigned style guide. (Drop this row if your course doesn't grade notation.) |
+The **Checkability** column routes each criterion to the layer that's authoritative
+for it (issue #192, HG-1): `mechanical` = binary/countable → NLP authoritative; `coverage`
+= all-of-a-set present → NLP flags, LLM verifies; `judgment` = quality/insight → LLM only.
+Tag every row; the hybrid grader reads this column and derives its per-criterion evidence
+from these rows (never force regex onto a `judgment` row). Adjust the defaults below to
+your assignment.
+
+| # | Criterion | Checkability | What "Meets" looks like |
+|---|-----------|--------------|--------------------------|
+| 1 | **Project task complete** | coverage | The narrative addresses every required deliverable of the assignment (no skipped sub-parts, no off-topic substitution). |
+| 2 | **Cohesive analysis** | judgment | The narrative reads as ONE story across all sub-tasks. Conclusions link back to the framing question; transitions between sections are explicit. Not a stitched-together set of independent answers. |
+| 3 | **Reproducible work** | coverage | The analysis is reproducible from the submission. Data sources, parameter choices, seed values, and any sampling decisions are stated explicitly. A reader could re-run the work from what's in the submission. |
+| 4 | **Correct calculations** | judgment | Numerical results are right. Where uncertainty exists (e.g. monte-carlo, fitting), the band of acceptable answers is stated and the result falls in it. Wrong answers don't pass on style alone. |
+| 5 | **Mathematical notation** | mechanical | Notation is consistent with the course's conventions. Equations, units, and symbols match the assigned style guide. (Drop this row if your course doesn't grade notation.) |
+
+**Validate + freeze after editing:** `uv run python canvas-toolbox/lib/tools/grader_rubric.py
+--rubric ./RUBRIC.md` parses this table, reports any untagged/mis-tagged rows, and prints a
+`checkability fingerprint` — the Stage-0 freeze marker. Record it once the tags are settled;
+a changed fingerprint later means the rubric was edited and the checks need a re-freeze.
 
 ## Holistic banding (not additive)
 

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.17"
+version = "1.7.18"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**Sprint 0 of the #192 layer-routed hybrid grader** — the Stage-0 precondition. Everything downstream (evidence extraction, injection, conflict audit, the HG-6 low-band audit) routes on a per-criterion checkability tag; this establishes it.

## What & why
Every rubric criterion is tagged by **checkability** so the grader routes it to the authoritative layer (HG-1):

| Tag | Criterion is… | Authoritative |
|---|---|---|
| `mechanical` | binary / countable ("≥3 citations", "code runs") | NLP (LLM confirms) |
| `coverage` | all-of-a-set present ("addresses all 5 prompts") | NLP flags, LLM verifies |
| `judgment` | quality / insight ("critical insight", "synthesis") | LLM only; NLP → weak hints |

Tags live **inline in `RUBRIC.md`** — single source of truth, so a rubric edit updates the checks (the doc's explicit anti-drift stance; no companion file).

## Pieces
- **[`grader_rubric.py`](lib/tools/grader_rubric.py)** — parses the checkability table (tolerant of the `#` / tier-descriptor columns and an optional `Evidence hint` column), validates the tags, and prints a `checkability_fingerprint`: the **freeze marker**. Order-insensitive (reordering criteria isn't a change) but changes the instant a criterion or its tag changes, so drift from a frozen rubric is detectable. `parse_checkability()` / `checkability_fingerprint()` + CLI; 8 unit tests.
- **Scaffold templates** (`cohesive_narrative.md`, `ai_log.md`) — gain the `Checkability` column with sensible defaults + a validate-and-freeze note. `ai_log` demonstrates the single-dimension case (one `judgment` row). Both round-trip through the parser (verified).
- **`grader_setup_knowledge.md`** — Step 2.5: tag each criterion ("could a careful non-expert verify by looking/counting, or does it take judgment?"), then freeze — all three rubric paths.

## Verify
`grader_rubric.py --rubric <template>` parses both templates cleanly (5-criterion cohesive_narrative → 1 mechanical / 2 coverage / 2 judgment; ai_log → 1 judgment), emits a fingerprint, exit 0. Full suite green under `uv run pytest`.

Next: Sprint 1 — `grader_signals.py` derives per-criterion evidence (term-banks, coverage, citations) from these tagged rows.

Bumps `1.7.17` → `1.7.18` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
