### PR TITLE
feat(grader): Sprint 1a — prose/text evidence signals, framed as evidence (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.19] — 2026-07-22
+
+**Hybrid grader Sprint 1a (#192): prose/text evidence signals, tagged and framed as evidence-to-verify.** (#192, Sprint 1a)
+
+`grader_signals.py` was notebook/code-oriented. This adds the prose signal set alongside it — the deterministic, criterion-independent evidence a methodology/essay grader needs.
+
+### Added
+- **`grader_signals.py`** — `prose_evidence(text)` emits, per submission: word / section / paragraph counts (structural), inline-APA `(Author, YEAR)` / DOI / URL / References-section detection (evaluative), and `?`-count / readability proxies (judgment-hint). Each item carries a taxonomy `tag` and a `framing` that presents it as **evidence to verify** — e.g. "0 literal (Author, YEAR) matches — check for DOI/URL/numbered or paraphrased attribution" — never a met/unmet verdict (HG-3). Flows into `feedback/_signals.json` via `analyze()`. 8 unit tests (counts correct, code excluded from word count, `et al.` citations, evidence framing).
+
+Sprint 1b maps these signals to the checkability-tagged rubric rows and adds rubric-derived term-banks + coverage.
+
+---
+
 ## [1.7.18] — 2026-07-22
 
 **Stage 0 of the hybrid grader (#192): rubrics now carry a per-criterion `Checkability` tag — the foundation the NLP+LLM routing derives from.** (#192, Sprint 0)

--- a/lib/tests/test_grader_signals_prose.py
+++ b/lib/tests/test_grader_signals_prose.py
@@ -1,0 +1,78 @@
+"""Unit tests — grader_signals prose evidence (issue #192, Sprint 1a).
+
+The prose signal pool is criterion-independent EVIDENCE (Sprint 1b maps it to the
+rubric). Two things must hold: the counts are right, and every item is framed as
+evidence-to-verify + carries a valid taxonomy tag (never a met/unmet verdict — HG-3).
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_signals import prose_evidence, analyze  # noqa: E402
+
+_VALID_TAGS = {"structural", "evaluative", "judgment-hint"}
+
+
+def _by_signal(text):
+    return {e["signal"]: e for e in prose_evidence(text)}
+
+
+def test_every_item_is_tagged_and_framed_as_evidence():
+    ev = prose_evidence("# Intro\n\nSome prose with a question? Yes.\n")
+    assert ev, "expected evidence items"
+    for e in ev:
+        assert e["tag"] in _VALID_TAGS, e
+        assert e["framing"] and isinstance(e["framing"], str)
+        # framing must not read as a verdict
+        assert "met" not in e["framing"].lower().split() and "unmet" not in e["framing"].lower()
+
+
+def test_word_count_excludes_code():
+    text = "# Title\n\nfour words in prose\n\n```python\nthis code should not count at all\n```\n"
+    wc = _by_signal(text)["word_count"]["value"]
+    # "Title four words in prose" = 5 words; code block excluded
+    assert wc == 5
+
+
+def test_apa_inline_citations_detected():
+    text = "As shown (Smith, 2020) and (Jones & Lee, 2021) and (Doe et al., 2019), the trend holds."
+    assert _by_signal(text)["apa_inline_citations"]["value"] == 3
+
+
+def test_zero_citations_framing_points_to_paraphrase_not_verdict():
+    e = _by_signal("No citations here at all.")["apa_inline_citations"]
+    assert e["value"] == 0
+    assert "paraphrase" in e["framing"].lower()  # evidence-to-verify, not "criterion unmet"
+
+
+def test_doi_url_and_references_section():
+    text = ("See https://example.com/x and doi 10.1000/abc123.\n\n"
+            "## References\n\n- Smith 2020\n")
+    by = _by_signal(text)
+    assert by["urls"]["value"] >= 1
+    assert by["doi_references"]["value"] == 1
+    assert by["has_references_section"]["value"] is True
+
+
+def test_no_references_heading_flags_for_verification():
+    e = _by_signal("Body with an inline (Smith, 2020) but no heading.")["has_references_section"]
+    assert e["value"] is False
+    assert "inline" in e["framing"].lower()
+
+
+def test_sections_and_paragraphs_counted():
+    text = "# A\n\npara one\n\n## B\n\npara two\n\npara three\n"
+    by = _by_signal(text)
+    assert by["section_count"]["value"] == 2
+    assert by["paragraph_count"]["value"] >= 3
+
+
+def test_analyze_includes_prose_evidence():
+    """Wiring guard: analyze() must carry prose_evidence into the signals dict
+    that gets written to _signals.json."""
+    result = analyze("# H\n\nsome prose (Smith, 2020).\n", ["pandas"])
+    assert "prose_evidence" in result
+    assert any(e["signal"] == "apa_inline_citations" for e in result["prose_evidence"])

--- a/lib/tools/grader_signals.py
+++ b/lib/tools/grader_signals.py
@@ -23,6 +23,10 @@ WHAT IT EMITS PER SUBMISSION
   - data_checks: count of data-interrogation idioms (count/isNull/describe/distinct/etc.)
   - prose_questions: count of `?` in prose/markdown (self-questioning proxy)
   - injection_flags: count of prompt-injection language hits (>0 → human review)
+  - prose_evidence: (#192) a list of prose signals — word/section/paragraph counts,
+    inline-APA / DOI / URL / References-section detection, readability — each tagged
+    structural / evaluative / judgment-hint and framed as EVIDENCE TO VERIFY, never
+    a met/unmet verdict. Sprint 1b maps these to the checkability-tagged rubric rows.
 
 CONFLICT → NEEDS-REVIEW
   When priors disagree with the LLM band, the agent emits a `conflict_needs_review`
@@ -112,6 +116,25 @@ INJECTION_RE = re.compile(
     re.I,
 )
 
+# --- Prose/text evidence patterns (issue #192 Sprint 1a) --------------------
+# Deterministic, criterion-INDEPENDENT signals for prose submissions (methodology,
+# essays). Each is EVIDENCE to verify against the text, never a met/unmet verdict.
+# Inline APA: (Author, 2020) / (Smith & Jones, 2021) / (Smith et al., 2019).
+APA_INLINE_RE = re.compile(
+    r"\([A-Z][A-Za-z'’.-]+"                        # first author surname
+    r"(?:\s+(?:and|&)\s+[A-Z][A-Za-z'’.-]+)?"      # optional "& Lee" / "and Lee"
+    r"(?:\s+et\s+al\.?)?"                          # optional "et al." (terminal, no name after)
+    r"(?:\s*,\s*[A-Z][A-Za-z'’.-]+)*"              # optional extra comma-separated authors
+    r",\s*(?:19|20)\d{2}[a-z]?\)"                  # , YEAR)
+)
+# A word-like token — excludes markdown markup (#, *, -) so a heading's `#` isn't a "word".
+_WORD_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9'’-]*")
+DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Za-z0-9]+")
+URL_RE = re.compile(r"https?://[^\s)>\]]+")
+REFERENCES_RE = re.compile(r"^#{1,6}\s*(references|bibliography|works\s+cited|sources)\b",
+                           re.I | re.M)
+_SENTENCE_END_RE = re.compile(r"[.!?]+")
+
 
 def code_blocks(text: str) -> list[str]:
     """Extract code from fenced blocks. The de-id adapters write cells as ```python blocks."""
@@ -142,7 +165,57 @@ def analyze(text: str, languages: list[str]) -> dict:
             # toPandas() alone isn't misuse — small aggregated results are often converted for plotting.
             # The agent judges whether the AGGREGATION was done in the parent or in pandas.
             result[f"uses_topandas"] = bool(topandas.search(code))
+    result["prose_evidence"] = prose_evidence(text)  # #192 Sprint 1a
     return result
+
+
+def _prose_only(text: str) -> str:
+    """Strip fenced code blocks — prose signals must not count code as words/sections."""
+    return re.sub(r"```.*?```", "", text, flags=re.DOTALL)
+
+
+def prose_evidence(text: str) -> list[dict]:
+    """Deterministic prose/text evidence for #192's hybrid grader (Sprint 1a).
+
+    Criterion-INDEPENDENT signals (Sprint 1b maps them to the checkability-tagged
+    rubric rows). Each item is `{signal, value, tag, framing}`:
+      - `tag` is the signal taxonomy — structural / evaluative / judgment-hint.
+      - `framing` presents it as EVIDENCE TO VERIFY against the text, never a
+        met/unmet verdict (HG-3) — e.g. "0 literal matches — check for paraphrase."
+    """
+    prose = _prose_only(text)
+    wc = len(_WORD_RE.findall(prose))
+    sections = len(re.findall(r"^#{1,6}\s", prose, re.M))
+    paragraphs = len([b for b in re.split(r"\n\s*\n", prose.strip()) if b.strip()])
+    apa = len(APA_INLINE_RE.findall(prose))
+    doi = len(DOI_RE.findall(prose))
+    urls = len(URL_RE.findall(prose))
+    has_refs = bool(REFERENCES_RE.search(prose))
+    questions = prose.count("?")
+    sentences = max(1, len(_SENTENCE_END_RE.findall(prose)))
+    avg_sentence_words = round(wc / sentences, 1)
+
+    return [
+        {"signal": "word_count", "value": wc, "tag": "structural",
+         "framing": "prose word count (code excluded) — verify against the rubric's target length, if it sets one"},
+        {"signal": "section_count", "value": sections, "tag": "structural",
+         "framing": "markdown headings — a proxy for whether required sections exist; verify each required section by name, not by count"},
+        {"signal": "paragraph_count", "value": paragraphs, "tag": "structural",
+         "framing": "prose paragraphs (structure only)"},
+        {"signal": "apa_inline_citations", "value": apa, "tag": "evaluative",
+         "framing": f"{apa} literal (Author, YEAR) match(es) — before concluding uncited, check for DOI/URL/numbered or paraphrased attribution"},
+        {"signal": "doi_references", "value": doi, "tag": "evaluative",
+         "framing": f"{doi} DOI(s) present"},
+        {"signal": "urls", "value": urls, "tag": "evaluative",
+         "framing": f"{urls} URL(s) present — may be sources or just links; verify in context"},
+        {"signal": "has_references_section", "value": has_refs, "tag": "evaluative",
+         "framing": ("a References/Bibliography heading is present" if has_refs
+                     else "no References/Bibliography heading — check for inline-only citations before concluding unsourced")},
+        {"signal": "prose_questions", "value": questions, "tag": "judgment-hint",
+         "framing": "count of '?' — a weak self-questioning proxy; NOT evidence of insight on its own"},
+        {"signal": "avg_sentence_words", "value": avg_sentence_words, "tag": "judgment-hint",
+         "framing": "average words per sentence — a readability proxy only, never a quality verdict"},
+    ]
 
 
 def print_table(signals: dict[str, dict], languages: list[str]) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.18"
+version = "1.7.19"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.18"
+version = "1.7.19"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**Sprint 1a of the #192 hybrid grader.** `grader_signals.py` was notebook/code-oriented; this adds the **prose/text signal set** a methodology/essay grader needs — the deterministic, *criterion-independent* evidence pool. (Sprint 1b maps it to the checkability-tagged rubric rows + adds term-banks/coverage.)

## `prose_evidence(text)`
Per submission, emits `{signal, value, tag, framing}` items:

| Tag | Signals |
|---|---|
| `structural` | word count (code excluded), section count, paragraph count |
| `evaluative` | inline-APA `(Author, YEAR)`, DOI, URL, References-section presence |
| `judgment-hint` | `?`-count (self-questioning proxy), avg words/sentence (readability) |

The **framing** is the point: every item reads as *evidence to verify against the text*, never a verdict (HG-3) — e.g. `apa_inline_citations: 0 → "before concluding uncited, check for DOI/URL/numbered or paraphrased attribution"`. That's what keeps the corpus in the loop and lets the HG-6 low-band audit catch a deterministic miss instead of it silently costing points.

Flows into `feedback/_signals.json` via `analyze()` (existing notebook signals untouched).

## Details that needed care
- **Word count excludes code** and markdown markup (word-token regex, so a heading's `#` isn't a "word").
- **APA regex** handles `(Smith et al., 2019)` (terminal "et al.," with no trailing name) and `(Jones & Lee, 2021)`.

## Verify
8 unit tests: counts correct, code excluded, `et al.` / `&` citations, DOI/URL/References detection, and every item tagged + framed as evidence (no "met"/"unmet"). Full suite green under `uv run pytest`.

Bumps `1.7.18` → `1.7.19` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
