### PR TITLE
feat(grader): Sprint 1b — rubric-derived per-criterion evidence (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.20] — 2026-07-22
+
+**Hybrid grader Sprint 1b (#192): per-criterion evidence — rubric-derived term-banks + coverage, routed by checkability.** (#192, Sprint 1b)
+
+Completes the evidence extractor. With a checkability-tagged `RUBRIC.md`, each submission gets per-criterion evidence routed by tag (HG-1).
+
+### Added
+- **`grader_signals.py`** — `--rubric RUBRIC.md` adds a `criteria` block per submission:
+  - `judgment` rows get **no** term matching (NLP contributes no evidence — score from the text).
+  - `mechanical` / `coverage` rows get a **term-bank** — derived from the criterion's own words by default (`derive_term_bank`), overridden by the `Evidence hint` column (`parse_evidence_hint`: numeric target, citation type, `prompts: a, b, c` coverage list, or plain override terms). Citation criteria route to the APA/DOI/URL counts; `coverage` rows report `k/N` items present + which are missing.
+  - Every item stays **evidence to verify** (HG-3): a 0-hit term-bank reads "check for paraphrase," never "criterion unmet" — the paraphrase false-negative the HG-6 low-band audit is designed to catch.
+- 12 unit tests (term-bank derivation, hint parsing, per-checkability routing, coverage-missing, end-to-end `rubric_evidence`).
+
+With Sprint 1 complete, the evidence layer is done; Sprint 2 injects it into the grading passes (`--with-signals`).
+
+---
+
 ## [1.7.19] — 2026-07-22
 
 **Hybrid grader Sprint 1a (#192): prose/text evidence signals, tagged and framed as evidence-to-verify.** (#192, Sprint 1a)

--- a/lib/tests/test_grader_signals_rubric.py
+++ b/lib/tests/test_grader_signals_rubric.py
@@ -1,0 +1,115 @@
+"""Unit tests — grader_signals rubric-derived evidence (issue #192, Sprint 1b).
+
+Option C: per-criterion evidence derives a term-bank from the criterion text by
+default and overrides with the Evidence hint. Routing is by checkability (HG-1):
+judgment rows get NO term matching; mechanical/coverage get term-banks / coverage /
+citations. Everything stays evidence-to-verify (HG-3).
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_signals import (  # noqa: E402
+    derive_term_bank,
+    parse_evidence_hint,
+    criterion_evidence,
+    rubric_evidence,
+)
+
+
+# --- derive_term_bank ------------------------------------------------------
+
+def test_term_bank_keeps_content_drops_boilerplate_and_numbers():
+    tb = derive_term_bank("≥3 scholarly citations (APA)")
+    assert "scholarly" in tb and "citations" in tb and "apa" in tb
+    assert "3" not in tb and "includes" not in tb
+
+
+def test_term_bank_drops_grading_verbs():
+    tb = derive_term_bank("Demonstrates a reproducible workflow")
+    assert "reproducible" in tb and "workflow" in tb
+    assert "demonstrates" not in tb and "a" not in tb
+
+
+# --- parse_evidence_hint ---------------------------------------------------
+
+def test_hint_target_and_citation_type():
+    h = parse_evidence_hint("APA (Author, YEAR); target ≥3")
+    assert h["target"] == 3
+    assert "APA" in h["citation_types"]
+
+
+def test_hint_coverage_item_list():
+    h = parse_evidence_hint("prompts: sampling, cleaning, visualization")
+    assert h["coverage_items"] == ["sampling", "cleaning", "visualization"]
+
+
+def test_hint_plain_terms():
+    h = parse_evidence_hint("monte carlo, random seed")
+    assert h["terms"] == ["monte carlo", "random seed"]
+    assert h["coverage_items"] == []
+
+
+# --- criterion_evidence: routing by checkability ---------------------------
+
+def test_judgment_row_gets_no_term_matching():
+    row = {"criterion": "Demonstrates critical insight", "checkability": "judgment"}
+    out = criterion_evidence(row, "Some deep text about insight and synthesis.")
+    sigs = [e["signal"] for e in out["evidence"]]
+    assert sigs == ["judgment_row"]
+    assert out["evidence"][0]["value"] is None  # never an NLP verdict on judgment
+
+
+def test_mechanical_row_derives_term_bank_and_counts_hits():
+    row = {"criterion": "Reproducible workflow stated", "checkability": "mechanical"}
+    text = "The workflow is reproducible: seeds and a reproducible pipeline are given."
+    out = criterion_evidence(row, text)
+    tb = next(e for e in out["evidence"] if e["signal"] == "term_bank_hits")
+    assert tb["value"] >= 2  # 'reproducible' x2 + 'workflow' x1
+    assert "paraphrase" in tb["framing"].lower()  # evidence-to-verify, not verdict
+
+
+def test_citation_criterion_routes_to_citation_counts():
+    row = {"criterion": "At least 3 citations", "checkability": "mechanical",
+           "evidence_hint": "APA; target ≥3"}
+    text = "See (Smith, 2020), (Jones, 2021), and (Lee et al., 2019)."
+    out = criterion_evidence(row, text)
+    cit = next(e for e in out["evidence"] if e["signal"] == "citations")
+    assert cit["value"] == 3 and "target ≥3" in cit["framing"]
+
+
+def test_coverage_reports_missing_items():
+    row = {"criterion": "Addresses all steps", "checkability": "coverage",
+           "evidence_hint": "items: sampling, cleaning, visualization"}
+    text = "We did sampling and cleaning carefully."   # visualization missing
+    out = criterion_evidence(row, text)
+    cov = next(e for e in out["evidence"] if e["signal"] == "coverage")
+    assert cov["value"] == "2/3"
+    assert "visualization" in cov["framing"]
+
+
+def test_coverage_without_item_list_notes_the_gap():
+    row = {"criterion": "Covers the required analysis", "checkability": "coverage"}
+    out = criterion_evidence(row, "some analysis text")
+    cov = next(e for e in out["evidence"] if e["signal"] == "coverage")
+    assert cov["value"] is None and "item list" in cov["framing"]
+
+
+# --- rubric_evidence end-to-end --------------------------------------------
+
+def test_rubric_evidence_maps_every_criterion():
+    rubric = ("| Criterion | Checkability |\n|---|---|\n"
+              "| Includes a thesis | mechanical |\n"
+              "| Critical insight | judgment |\n")
+    out, issues = rubric_evidence(rubric, "A clear thesis is stated. Insightful too.")
+    assert issues == []
+    assert [c["criterion"] for c in out] == ["Includes a thesis", "Critical insight"]
+    assert [c["checkability"] for c in out] == ["mechanical", "judgment"]
+
+
+def test_rubric_evidence_surfaces_a_missing_table():
+    out, issues = rubric_evidence("# Rubric\n\nno table\n", "text")
+    assert out == [] and issues

--- a/lib/tools/grader_signals.py
+++ b/lib/tools/grader_signals.py
@@ -63,6 +63,12 @@ try:
 except ImportError:
     __version__ = "0.0.0+unknown"
 
+try:
+    # #192 Sprint 1b — map evidence to the checkability-tagged rubric rows.
+    from grader_rubric import parse_checkability
+except ImportError:
+    parse_checkability = None
+
 # Language idiom catalogs — extend per course by passing --language or by adding entries here.
 # Each entry maps a language label to (primary_regex, optional_topandas_regex) where the primary
 # regex counts idioms broadly (covers both DataFrame-API and SQL forms where both exist).
@@ -218,6 +224,141 @@ def prose_evidence(text: str) -> list[dict]:
     ]
 
 
+# --- Rubric-derived evidence (issue #192 Sprint 1b) -------------------------
+# Option C: for each checkability-tagged criterion, DERIVE a term-bank from the
+# criterion text by default; OVERRIDE with the Evidence hint column when present.
+# Everything is EVIDENCE to verify (HG-3); a term-bank miss (paraphrase) is caught
+# downstream by the LLM reading the corpus and the HG-6 low-band audit — never a
+# score here.
+
+# Function words + grading boilerplate that make poor search terms.
+_STOP = {
+    "a", "an", "the", "and", "or", "of", "to", "in", "on", "for", "with", "at", "by",
+    "from", "as", "is", "are", "be", "that", "this", "these", "those", "it", "its",
+    "their", "them", "they", "which", "who", "whose", "what", "when", "where", "how",
+    "not", "no", "any", "all", "each", "every", "some", "one", "two", "three", "four",
+    "five", "least", "more", "than", "must", "should", "students", "student",
+    "submission", "assignment", "rubric", "criterion", "criteria", "points", "point",
+    "includes", "include", "including", "demonstrates", "demonstrate", "shows", "show",
+    "uses", "use", "using", "provides", "provide", "contains", "contain", "states",
+    "state", "addresses", "address", "present", "presents", "has", "have",
+}
+
+
+def derive_term_bank(criterion_text: str) -> list:
+    """Content words of a criterion, as a search term-bank (Option C default).
+
+    Lowercased, stopworded, deduped (order-preserving), length ≥3 — e.g.
+    '≥3 scholarly citations (APA)' -> ['scholarly', 'citations', 'apa'].
+    """
+    seen = []
+    for w in _WORD_RE.findall(criterion_text.lower()):
+        if len(w) >= 3 and w not in _STOP and not w.isdigit() and w not in seen:
+            seen.append(w)
+    return seen
+
+
+def parse_evidence_hint(hint: str | None) -> dict:
+    """Extract structure from the optional Evidence hint cell.
+
+    Returns {target, citation_types, coverage_items, terms}. Recognizes a numeric
+    target (`≥3` / `target 3` / `at least 3`), citation types (APA/MLA/DOI/URL), an
+    explicit coverage list (`prompts: a, b, c`), or otherwise comma/semicolon-
+    separated override terms. All fields are optional.
+    """
+    out: dict = {"target": None, "citation_types": [], "coverage_items": [], "terms": []}
+    if not hint:
+        return out
+    m = re.search(r"(?:≥|>=|target\s+|at\s+least\s+)\s*(\d+)", hint, re.I)
+    if m:
+        out["target"] = int(m.group(1))
+    for ct in ("APA", "MLA", "DOI", "URL"):
+        if re.search(rf"\b{ct}\b", hint, re.I):
+            out["citation_types"].append(ct)
+    m2 = re.search(r"(?:prompts?|items?|covers?|sections?|questions?|regulations?)\s*[:=]\s*(.+)",
+                   hint, re.I)
+    if m2:
+        out["coverage_items"] = [s.strip() for s in re.split(r"[;,]", m2.group(1)) if s.strip()]
+    else:
+        parts = [s.strip() for s in re.split(r"[;,]", hint) if s.strip()]
+        out["terms"] = [p for p in parts
+                        if not re.fullmatch(r"(?:≥|>=|target|at least)?\s*\d+|apa|mla|doi|url",
+                                            p, re.I)]
+    return out
+
+
+def _count_terms(prose: str, terms: list) -> int:
+    return sum(len(re.findall(rf"\b{re.escape(t)}\b", prose, re.I)) for t in terms)
+
+
+def criterion_evidence(row: dict, text: str) -> dict:
+    """Per-criterion evidence for one checkability-tagged rubric row (#192 1b).
+
+    Routes by checkability (HG-1): judgment → weak context only; mechanical/coverage
+    → citation routing + term-bank hits + (coverage) per-item presence. Every item
+    is framed as evidence to verify, never met/unmet.
+    """
+    crit, check = row["criterion"], row["checkability"]
+    parsed = parse_evidence_hint(row.get("evidence_hint"))
+    prose = _prose_only(text)
+    ev: list = []
+
+    if check == "judgment":
+        ev.append({"signal": "judgment_row", "value": None, "tag": "judgment-hint",
+                   "framing": f"'{crit}' is a judgment criterion — score it from the text itself. "
+                              "NLP contributes no evidence here; readability/structure are context only."})
+        return {"criterion": crit, "checkability": check, "evidence": ev}
+
+    if parsed["citation_types"]:
+        apa, doi, urls = (len(APA_INLINE_RE.findall(prose)),
+                          len(DOI_RE.findall(prose)), len(URL_RE.findall(prose)))
+        found = apa + doi + urls
+        frame = f"citations found: {apa} APA + {doi} DOI + {urls} URL = {found}"
+        if parsed["target"] is not None:
+            frame += f"; target ≥{parsed['target']}"
+        frame += " — verify format acceptability and paraphrased attribution before concluding uncited"
+        ev.append({"signal": "citations", "value": found, "tag": "evaluative", "framing": frame})
+
+    terms = parsed["terms"] or derive_term_bank(crit)
+    if terms:
+        hits = _count_terms(prose, terms)
+        src = "hint" if parsed["terms"] else "derived from criterion"
+        frame = (f"term-bank ({src}) {terms}: {hits} literal hit(s) — evidence the topic is "
+                 "addressed; if low, check for paraphrase/synonyms before concluding absent")
+        if parsed["target"] is not None and not parsed["citation_types"]:
+            frame += f" (rubric target ≥{parsed['target']})"
+        ev.append({"signal": "term_bank_hits", "value": hits, "tag": "evaluative", "framing": frame})
+
+    if check == "coverage":
+        items = parsed["coverage_items"]
+        if items:
+            missing = [it for it in items if _count_terms(prose, derive_term_bank(it) or [it]) == 0]
+            found_n = len(items) - len(missing)
+            frame = f"{found_n}/{len(items)} required items show literal evidence"
+            if missing:
+                frame += f"; NO literal hit for: {missing} — check for paraphrase before marking uncovered"
+            ev.append({"signal": "coverage", "value": f"{found_n}/{len(items)}", "tag": "evaluative",
+                       "framing": frame})
+        else:
+            ev.append({"signal": "coverage", "value": None, "tag": "evaluative",
+                       "framing": "coverage criterion with no item list in the Evidence hint — the "
+                                  "term-bank above is the only presence signal; list the required "
+                                  "items in the hint for per-item coverage"})
+    return {"criterion": crit, "checkability": check, "evidence": ev}
+
+
+def rubric_evidence(rubric_text: str, submission_text: str) -> tuple:
+    """Map every checkability-tagged criterion to its per-criterion evidence.
+
+    Returns (criteria_evidence, issues). issues surfaces a missing/invalid rubric
+    (the caller decides whether to proceed without per-criterion routing).
+    """
+    if parse_checkability is None:
+        return [], ["grader_rubric not importable — per-criterion evidence skipped."]
+    rows, issues = parse_checkability(rubric_text)
+    return [criterion_evidence(r, submission_text) for r in rows], issues
+
+
 def print_table(signals: dict[str, dict], languages: list[str]) -> None:
     # Header
     header = f"{'key':14} {'cells':>5} {'out':>4}"
@@ -252,6 +393,10 @@ def main() -> int:
     ap.add_argument("--language", action="append", default=None,
                     help=f"Language idiom catalog(s) to count. May repeat. "
                          f"Available: {list(LANGUAGES.keys())}. Default: {DEFAULT_LANGUAGES}")
+    ap.add_argument("--rubric", default=None,
+                    help="Path to a checkability-tagged RUBRIC.md (#192). When given, each "
+                         "submission also gets per-criterion evidence (term-banks / coverage / "
+                         "citations, routed by checkability) under a `criteria` key.")
     args = ap.parse_args()
 
     if args.challenge_dir:
@@ -277,10 +422,25 @@ def main() -> int:
         print(f"No de-id outputs in {deid} — run a grader_deidentify_* tool first.")
         return 1
 
+    rubric_text = None
+    if args.rubric:
+        rp = Path(args.rubric)
+        if not rp.is_file():
+            print(f"--rubric {rp} not found.", file=sys.stderr)
+            return 1
+        rubric_text = rp.read_text(encoding="utf-8")
+
     signals: dict[str, dict] = {}
     flagged: list[str] = []
     for f in files:
-        s = analyze(f.read_text(encoding="utf-8", errors="replace"), languages)
+        text = f.read_text(encoding="utf-8", errors="replace")
+        s = analyze(text, languages)
+        if rubric_text is not None:
+            criteria, r_issues = rubric_evidence(rubric_text, text)
+            s["criteria"] = criteria
+            if r_issues and f is files[0]:  # report rubric problems once
+                for it in r_issues:
+                    print(f"⚠️  rubric: {it}", file=sys.stderr)
         signals[f.stem] = s
         if s["injection_flags"]:
             flagged.append(f.stem)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.19"
+version = "1.7.20"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.19"
+version = "1.7.20"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**Sprint 1b of the #192 hybrid grader — completes the evidence extractor.** With a checkability-tagged `RUBRIC.md`, each submission now gets *per-criterion* evidence, routed by tag (Option C, which you approved).

## `grader_signals.py --rubric RUBRIC.md`
Adds a `criteria` block per submission. Routing by checkability (HG-1):

| Tag | What it produces |
|---|---|
| `judgment` | **nothing** — NLP contributes no evidence; score from the text |
| `mechanical` / `coverage` | a **term-bank** (derived from the criterion's own words, overridden by the `Evidence hint`), citation routing (APA/DOI/URL) when the hint names a citation type, and — for `coverage` — `k/N` items present + which are missing |

`parse_evidence_hint` reads the optional hint cell: a numeric target (`≥3`), citation type (`APA`), a coverage list (`prompts: sampling, cleaning, viz`), or plain override terms.

## The design payoff, verified end-to-end
Ran it against the real `cohesive_narrative` template + a sample submission that **paraphrased** "deliverable" instead of writing "project/task": the `Project task complete` term-bank scored **0 literal hits** and was framed *"check for paraphrase before concluding uncovered"* — **not** "criterion unmet." That's the whole architecture in one line: the deterministic layer under-detects, but it emits evidence, so the LLM reading the corpus (and the HG-6 low-band audit) catches the miss instead of it silently costing points.

## Verify
12 unit tests: term-bank derivation (drops boilerplate/numbers), hint parsing (target / citation / coverage-list / plain terms), per-checkability routing (judgment → no matching), coverage-missing, and end-to-end `rubric_evidence`. Full suite green under `uv run pytest`.

**Sprint 1 is complete** — the evidence layer is done. Sprint 2 injects it into the grading passes (`--with-signals`).

Bumps `1.7.19` → `1.7.20` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
