### PR TITLE
feat(grader): Sprint 2 — --with-signals injects framed evidence into passes (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.21] — 2026-07-22
+
+**Hybrid grader Sprint 2 (#192): `grader_grade.py --with-signals` injects the framed evidence into every pass.** (#192, Sprint 2)
+
+The evidence layer (Sprints 1a/1b) now reaches the LLM. `grader_grade.py` already injected `_signals.json` as "CONTEXT only; never enter the score" — this renders the new prose + per-criterion evidence *with its framing* instead of dumping raw dicts.
+
+### Added
+- **`grader_grade.py`** — `--with-signals` injects the rich evidence block per submission: prose signals and per-criterion term-banks / coverage / citations, each as a framed bullet (`term_bank_hits=0 — check for paraphrase before concluding uncovered`) so the pass reads it as evidence, not a verdict (HG-3). This is the **enrichment** lever — it grounds the passes and reduces variance, and it spends tokens; run `grader_signals.py --rubric` first to populate the evidence.
+
+### Changed
+- **`grader_grade.py`** — `_format_priors()` renders compact scalar signals by default (unchanged, cheap) and excludes the nested `prose_evidence` / `criteria` structures from that line so they never dump as raw dicts; the rich rendering is gated behind `--with-signals`.
+
+With Sprint 2, the evidence *reaches* the passes. Sprint 3 audits the consensus against it (`conflict_needs_review`); Sprint 4 adds the HG-6 low-band audit.
+
+---
+
 ## [1.7.20] — 2026-07-22
 
 **Hybrid grader Sprint 1b (#192): per-criterion evidence — rubric-derived term-banks + coverage, routed by checkability.** (#192, Sprint 1b)

--- a/lib/tests/test_grader_grade_signals.py
+++ b/lib/tests/test_grader_grade_signals.py
@@ -1,0 +1,60 @@
+"""Unit tests — grader_grade signal injection (issue #192, Sprint 2).
+
+--with-signals (rich=True) must inject the S1a/S1b evidence with its framing so the
+passes read it as evidence, not verdicts. Default (rich=False) stays cheap: compact
+scalar signals only, and the nested structures must NOT dump as raw dicts.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_grade import _format_priors  # noqa: E402
+
+_PRIORS = {"KC3-A": {
+    "cells": 3, "outputs": 2, "injection_flags": 0,
+    "prose_evidence": [
+        {"signal": "apa_inline_citations", "value": 0, "tag": "evaluative",
+         "framing": "0 literal matches — check for paraphrase"},
+    ],
+    "criteria": [
+        {"criterion": "Includes a thesis", "checkability": "mechanical",
+         "evidence": [{"signal": "term_bank_hits", "value": 1, "tag": "evaluative",
+                       "framing": "term-bank (derived): 1 hit — check paraphrase if low"}]},
+    ],
+}}
+
+
+def _fmt(rich):
+    return _format_priors({"KC3-A": _PRIORS["KC3-A"]}, rich=rich)
+
+
+def test_empty_priors_render_to_empty_string():
+    assert _format_priors(None) == ""
+    assert _format_priors({}) == ""
+
+
+def test_default_is_scalar_only_no_raw_dicts():
+    out = _fmt(rich=False)
+    assert "cells=3" in out and "outputs=2" in out
+    # the nested evidence is NOT injected, and never dumps as a raw dict
+    assert "check for paraphrase" not in out
+    assert "criterion" not in out
+    assert "prose_evidence=" not in out and "criteria=" not in out
+
+
+def test_rich_injects_framed_prose_and_criterion_evidence():
+    out = _fmt(rich=True)
+    assert "cells=3" in out                                   # scalars still there
+    assert "check for paraphrase" in out                      # prose evidence framing
+    assert '"Includes a thesis"' in out and "mechanical" in out
+    assert "term-bank" in out                                 # per-criterion evidence framing
+
+
+def test_rich_evidence_is_framed_not_a_verdict():
+    out = _fmt(rich=True)
+    # framing language, not met/unmet verdicts
+    low = out.lower()
+    assert " unmet" not in low and "met criterion" not in low

--- a/lib/tools/grader_grade.py
+++ b/lib/tools/grader_grade.py
@@ -393,13 +393,31 @@ def _parse_response(text: str) -> dict | None:
 # Per-pass + cross-pass orchestration
 # ---------------------------------------------------------------------------
 
-def _format_priors(priors: dict | None) -> str:
+def _format_priors(priors: dict | None, rich: bool = False) -> str:
+    """Render one submission's signals as CONTEXT (evidence to verify, never a score).
+
+    Flat scalar signals always render compactly. With `rich=True` (--with-signals,
+    #192 enrichment), the prose evidence (#192 1a) and per-criterion evidence
+    (#192 1b) render as framed bullets so each pass reads them as evidence — not
+    verdicts (HG-3). The nested structures are excluded from the scalar line so they
+    never dump as raw dicts.
+    """
     if not priors:
         return ""
     lines = []
     for key in sorted(priors):
-        s = priors[key]
-        lines.append(f"- {key}: " + ", ".join(f"{k}={v}" for k, v in s.items()))
+        s = priors[key] or {}
+        scalars = {k: v for k, v in s.items() if k not in ("prose_evidence", "criteria")}
+        if scalars:
+            lines.append("- signals: " + ", ".join(f"{k}={v}" for k, v in scalars.items()))
+        if not rich:
+            continue
+        for e in s.get("prose_evidence", []):
+            lines.append(f"- [{e['tag']}] {e['signal']}={e['value']} — {e['framing']}")
+        for c in s.get("criteria", []):
+            lines.append(f'- criterion "{c["criterion"]}" ({c["checkability"]}):')
+            for e in c.get("evidence", []):
+                lines.append(f"    · {e['signal']}={e['value']} — {e['framing']}")
     return "\n".join(lines)
 
 
@@ -471,6 +489,12 @@ def main() -> int:
                     help="Optional scrubbed answer key (treated as reference, never as gate).")
     ap.add_argument("--signals", default=None,
                     help="Optional priors JSON (default: <challenge-dir>/feedback/_signals.json).")
+    ap.add_argument("--with-signals", action="store_true",
+                    help="#192 enrichment: inject the RICH evidence block (prose_evidence + "
+                         "per-criterion term-banks/coverage/citations, each framed as evidence "
+                         "to verify, NOT a score) into every pass. Grounds the passes + reduces "
+                         "variance; spends tokens. Without it, only the compact scalar signals "
+                         "are injected. Run grader_signals.py --rubric first to populate them.")
     # MODE flags (adjustment 3: calibration-gated)
     mode = ap.add_mutually_exclusive_group()
     mode.add_argument("--single", action="store_true",
@@ -642,7 +666,8 @@ def main() -> int:
                     continue
                 deid_text = sub.read_text(encoding="utf-8")
                 priors_block = _format_priors(
-                    {key: priors.get(key)} if priors.get(key) else None)
+                    {key: priors.get(key)} if priors.get(key) else None,
+                    rich=args.with_signals)
                 user_prompt = _build_user_prompt(
                     pass_number=n,
                     total_passes=n_passes,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.20"
+version = "1.7.21"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.20"
+version = "1.7.21"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**Sprint 2 of the #192 hybrid grader — the evidence layer now reaches the LLM.**

`grader_grade.py` already injected `_signals.json` into every pass as *"CONTEXT only; never enter the score."* But after Sprints 1a/1b enriched that JSON with `prose_evidence` + `criteria`, `_format_priors` would have dumped them as raw dicts. This renders them with their framing.

## `--with-signals`
The enrichment lever. Injects the rich evidence block per submission — prose signals + per-criterion term-banks / coverage / citations — each as a **framed** bullet:

```
- signals: cells=3
- [structural] word_count=812 — verify against target length
- criterion "Reproducible work" (coverage):
    · term_bank_hits=0 — 0 hits — check for paraphrase before concluding uncovered
```

So the pass reads **evidence to verify**, not a verdict (HG-3). It grounds the passes and reduces variance — and it spends tokens, hence an explicit opt-in ("enrichment... a quality lever that spends tokens"). Run `grader_signals.py --rubric` first to populate the evidence.

## Backward-compatible default
Without `--with-signals`, `_format_priors` renders only the compact scalar signals (unchanged, cheap) and **excludes** the nested `prose_evidence`/`criteria` from that line so they never dump as raw dicts. The rich rendering is gated behind the flag.

## Verify
4 unit tests: empty → empty; default is scalar-only with no raw-dict leakage; `--with-signals` injects framed prose + criterion evidence; framing carries no met/unmet verdict language. Full suite green under `uv run pytest`.

**Pipeline status:** evidence extracted (S1) → injected (S2). Next: Sprint 3 audits the consensus against the priors (`conflict_needs_review`), Sprint 4 the HG-6 low-band audit.

Bumps `1.7.20` → `1.7.21` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
