### PR TITLE
feat(grader): Sprint 1c — LLM-sampled term-banks (build-time HG-6 complement) (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.22] — 2026-07-22
+
+**Hybrid grader Sprint 1c (#192): LLM-sampled term-banks — build-time scope alignment, the complement to HG-6.** (#192, Sprint 1c)
+
+The deterministic term-bank was one narrow LLM-authored guess; a synonym or paraphrase it didn't name is a false negative that undergrades work the student did. This offsets it at its source.
+
+### Added
+- **`grader_term_banks.py`** — at freeze time, samples the LLM N times (temperature-varied) for the vocabulary a student might actually use to satisfy each `mechanical`/`coverage` criterion, **unions** the samples (benefit of the doubt — a wider net catches paraphrase), and writes it into the RUBRIC.md `Evidence hint` column. `grader_signals.py` (Sprint 1b) then extracts **deterministically** against that richer, frozen bank. The LLM sampling is once, at build time, frozen + auditable — grading stays deterministic and priors still never score (HG-2). Only touches `mechanical`/`coverage` rows with an **empty** hint (never overwrites an instructor's hint; judgment rows skipped — HG-1). Dry-run by default; `--apply` writes (fills empty cells / adds the column). LLM injected as `sample_fn` for testing. 7 unit tests.
+- **`grader_hybrid_architecture.md`** (v1.2) — documents build-time alignment as the complement to HG-6's grade-time audit (widen the net + rescue what slips = belt and suspenders).
+
+---
+
 ## [1.7.21] — 2026-07-22
 
 **Hybrid grader Sprint 2 (#192): `grader_grade.py --with-signals` injects the framed evidence into every pass.** (#192, Sprint 2)

--- a/lib/agents/knowledge/grader_hybrid_architecture.md
+++ b/lib/agents/knowledge/grader_hybrid_architecture.md
@@ -1,6 +1,6 @@
 ---
 name: grader_hybrid_architecture
-version: "1.1"
+version: "1.2"
 last_updated: 2026-07-22
 description: How to think about AI-assisted grading as a layer-routed NLP + LLM hybrid.
 skill_type: knowledge
@@ -187,6 +187,14 @@ student points.
 - **`grader_signals.py`** — the NLP layer: `structural` + `evaluative` + `judgment-hint`
   signals, rubric-derived, each tagged. Prose set (length, citations, per-criterion term-banks,
   coverage) alongside the existing code/notebook set.
+- **`grader_term_banks.py`** — **build-time scope alignment (the complement to HG-6).** The
+  deterministic term-bank is one narrow LLM-authored guess; a synonym or paraphrase it didn't
+  name is a false negative that undergrades. So at *freeze time* sample the LLM N times for the
+  vocabulary a student might actually use, UNION the samples (benefit of the doubt — a wider net),
+  and write it into the `Evidence hint` column. Grading then extracts DETERMINISTICALLY against
+  that richer, frozen bank — the LLM sampling is once, at build time, frozen + auditable, so the
+  grade-time layer stays deterministic and priors still never score (HG-2). Build-time alignment
+  (widen the net) + HG-6's grade-time audit (rescue what still slips) = belt and suspenders.
 - **`grader_grade.py --with-signals`** — inject the evidence block into each pass prompt,
   labeled "priors, NOT the score."
 - **`grader_consensus.py`** — emit `conflict_needs_review` from the prior-vs-tier rule table;

--- a/lib/tests/test_grader_term_banks.py
+++ b/lib/tests/test_grader_term_banks.py
@@ -1,0 +1,104 @@
+"""Unit tests — grader_term_banks LLM-sampled term-bank builder (issue #192, Sprint 1c).
+
+The LLM is injected as a fake `sample_fn`, so these run with no network/provider.
+Two things must hold: sampling UNIONs across passes (wider net = benefit of the
+doubt), and the table editor only ever FILLS EMPTY cells (never clobbers an
+instructor's hint), round-tripping through the Sprint 0/1b parsers.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_term_banks import (  # noqa: E402
+    _parse_terms,
+    sample_term_bank,
+    suggest_hints,
+    apply_hints_to_rubric,
+)
+from grader_rubric import parse_checkability  # noqa: E402
+from grader_signals import parse_evidence_hint  # noqa: E402
+
+
+# --- parsing + sampling ----------------------------------------------------
+
+def test_parse_terms_json_array():
+    assert _parse_terms('Here: ["reproducible", "seed", "deterministic"]') == \
+        ["reproducible", "seed", "deterministic"]
+
+
+def test_parse_terms_fallback_list():
+    assert _parse_terms("- reproducible\n- random seed\n- deterministic") == \
+        ["reproducible", "random seed", "deterministic"]
+
+
+def test_sampling_unions_across_passes():
+    """Different samples contribute different terms; the union is wider than any one."""
+    responses = iter(['["reproducible", "seed"]',
+                      '["seed", "replicable"]',
+                      '["deterministic"]'])
+
+    def fake(criterion, temperature):
+        return next(responses)
+
+    tb = sample_term_bank("Reproducible work", fake, n=3)
+    assert set(tb) == {"reproducible", "seed", "replicable", "deterministic"}
+
+
+def test_suggest_hints_skips_judgment_and_already_hinted():
+    rows = [
+        {"criterion": "Reproducible work", "checkability": "mechanical", "evidence_hint": None},
+        {"criterion": "Critical insight", "checkability": "judgment", "evidence_hint": None},
+        {"criterion": "Cited", "checkability": "mechanical", "evidence_hint": "APA; ≥3"},
+    ]
+    hints = suggest_hints(rows, lambda c, t: '["term-a", "term-b"]', n=1)
+    assert set(hints) == {"Reproducible work"}  # judgment + hinted rows skipped
+
+
+# --- table editor: only fills empty cells ----------------------------------
+
+_RUBRIC_NO_HINT_COL = (
+    "## Criteria\n\n"
+    "| # | Criterion | Checkability |\n"
+    "|---|-----------|--------------|\n"
+    "| 1 | Reproducible work | mechanical |\n"
+    "| 2 | Critical insight | judgment |\n"
+)
+
+_RUBRIC_WITH_HINTS = (
+    "| Criterion | Checkability | Evidence hint |\n"
+    "|---|---|---|\n"
+    "| Reproducible work | mechanical |  |\n"
+    "| Cited | mechanical | APA; target ≥3 |\n"
+)
+
+
+def test_adds_evidence_hint_column_when_absent():
+    new, filled = apply_hints_to_rubric(_RUBRIC_NO_HINT_COL, {"Reproducible work": ["seed", "replicable"]})
+    assert filled == 1
+    assert "Evidence hint" in new
+    rows, issues = parse_checkability(new)
+    assert issues == []
+    repro = next(r for r in rows if r["criterion"] == "Reproducible work")
+    assert repro["evidence_hint"] == "seed, replicable"
+    # round-trip through S1b's hint parser
+    assert set(parse_evidence_hint(repro["evidence_hint"])["terms"]) == {"seed", "replicable"}
+
+
+def test_fills_empty_cell_but_never_overwrites_existing_hint():
+    new, filled = apply_hints_to_rubric(
+        _RUBRIC_WITH_HINTS,
+        {"Reproducible work": ["seed"], "Cited": ["should", "not", "appear"]})
+    assert filled == 1  # only the empty Reproducible-work cell
+    rows, _ = parse_checkability(new)
+    assert next(r for r in rows if r["criterion"] == "Reproducible work")["evidence_hint"] == "seed"
+    # the pre-existing APA hint is untouched
+    assert next(r for r in rows if r["criterion"] == "Cited")["evidence_hint"] == "APA; target ≥3"
+
+
+def test_no_checkability_table_is_a_noop():
+    text = "# Rubric\n\njust prose\n"
+    new, filled = apply_hints_to_rubric(text, {"X": ["y"]})
+    assert new == text and filled == 0

--- a/lib/tools/grader_term_banks.py
+++ b/lib/tools/grader_term_banks.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""LLM-sampled term-bank builder — freeze-time scope alignment (issue #192, Sprint 1c).
+
+WHY THIS EXISTS
+  The deterministic extractor (grader_signals.py) derives a criterion's term-bank
+  from the criterion's own words — a single, narrow guess. When that scope is off
+  (a synonym or paraphrase the criterion didn't literally name), the NLP layer
+  UNDER-detects, which drags the grade down on work the student actually did. That
+  is the HG-6 misalignment at its source.
+
+  This offsets it at BUILD time: sample the LLM N times (temperature-varied) for the
+  words/phrases a student might actually use to satisfy each criterion, UNION the
+  samples (benefit of the doubt — a wider net catches paraphrase), and write the
+  result into the RUBRIC.md `Evidence hint` column. grader_signals.py (Sprint 1b)
+  then extracts DETERMINISTICALLY against that richer, frozen term-bank.
+
+  So grading stays deterministic, reproducible, and cheap — the LLM sampling happens
+  ONCE, at freeze time, and the result is frozen + auditable in the rubric. It does
+  not reintroduce the LLM into the grade-time deterministic layer; it uses sampling
+  to ALIGN the deterministic scope. Priors still never score (HG-2). This is the
+  build-time complement to HG-6's grade-time low-band audit — belt and suspenders.
+
+WHAT IT DOES / DOESN'T TOUCH
+  - Only `mechanical` / `coverage` rows (judgment rows get no term-bank — HG-1).
+  - Only rows whose `Evidence hint` is EMPTY — never overwrites an instructor's hint.
+  - Dry-run by default; --apply writes (fills empty cells / adds the column).
+
+Usage:
+    uv run python lib/tools/grader_term_banks.py --rubric grading/<task>/RUBRIC.md
+    uv run python lib/tools/grader_term_banks.py --rubric ... --apply
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+
+try:
+    from grader_rubric import parse_checkability
+except ImportError:
+    parse_checkability = None
+
+_TEMPS = (0.3, 0.6, 0.9)
+_TERM_CAP = 20
+
+_SYSTEM = (
+    "You expand a grading-rubric criterion into a SEARCH TERM-BANK: the words and "
+    "short phrases a student's submission might actually use to satisfy it, including "
+    "synonyms and paraphrases. You never judge or score — you only widen the vocabulary "
+    "so a keyword search won't miss work that's phrased differently. Output ONLY a JSON "
+    "array of lowercase terms/phrases."
+)
+
+
+def _user_prompt(criterion: str) -> str:
+    return (f"Criterion: {criterion}\n\n"
+            "List 8–15 words or short phrases a student's submission might use to address "
+            "this criterion — synonyms, paraphrases, related terminology, common spellings. "
+            "Do not restate the criterion; give the vocabulary to search for. JSON array only.")
+
+
+def _parse_terms(response: str) -> list:
+    """Extract terms from an LLM response — a JSON array, or a comma/line-delimited list."""
+    if not response:
+        return []
+    m = re.search(r"\[.*?\]", response, re.DOTALL)
+    if m:
+        try:
+            arr = json.loads(m.group(0))
+            if isinstance(arr, list):
+                return [str(x).strip() for x in arr if str(x).strip()]
+        except (json.JSONDecodeError, ValueError):
+            pass
+    out = []
+    for part in re.split(r"[\n,]", response):
+        t = part.strip().strip("-*•\"'` ").strip()
+        if t and not t.endswith(":") and len(t) < 60:
+            out.append(t)
+    return out
+
+
+def _clean_terms(terms: list, cap: int = _TERM_CAP) -> list:
+    """Lowercase, collapse whitespace, dedupe (order-preserving), drop <3 chars, cap."""
+    seen: list = []
+    for t in terms:
+        t = re.sub(r"\s+", " ", str(t).strip().lower())
+        if len(t) >= 3 and t not in seen:
+            seen.append(t)
+    return seen[:cap]
+
+
+def sample_term_bank(criterion: str, sample_fn, n: int = 3) -> list:
+    """N temperature-varied LLM samples → UNION of parsed terms (benefit of the doubt).
+
+    `sample_fn(criterion: str, temperature: float) -> str` returns the raw LLM text.
+    Injecting it keeps this unit testable without a network/provider.
+    """
+    union: list = []
+    for i in range(max(1, n)):
+        union.extend(_parse_terms(sample_fn(criterion, _TEMPS[i % len(_TEMPS)])))
+    return _clean_terms(union)
+
+
+def suggest_hints(rows: list, sample_fn, n: int = 3) -> dict:
+    """Sample a term-bank for each mechanical/coverage row with an EMPTY hint.
+
+    Returns {criterion: [terms]}. Judgment rows and rows that already carry an
+    Evidence hint are skipped (HG-1; respect instructor authoring).
+    """
+    out: dict = {}
+    for r in rows:
+        if r["checkability"] == "judgment" or r.get("evidence_hint"):
+            continue
+        terms = sample_term_bank(r["criterion"], sample_fn, n)
+        if terms:
+            out[r["criterion"]] = terms
+    return out
+
+
+# --- RUBRIC.md table editing (pure; only fills EMPTY Evidence-hint cells) ----
+
+def _cells(line: str) -> list:
+    return [c.strip() for c in line.strip().strip("|").split("|")]
+
+
+def _append_cell(line: str, cell: str) -> str:
+    s = line.rstrip()
+    if s.endswith("|"):
+        s = s[:-1].rstrip()
+    return f"{s} | {cell} |"
+
+
+def apply_hints_to_rubric(rubric_text: str, hints: dict) -> tuple:
+    """Write term-banks into the criteria table's `Evidence hint` column.
+
+    Adds the column if absent; otherwise fills only EMPTY cells for the given
+    criteria (never overwrites an existing hint). Returns (new_text, n_filled).
+    """
+    lines = rubric_text.split("\n")
+    header_i = next((i for i, ln in enumerate(lines)
+                     if "|" in ln and any(c.lower() in ("checkability", "check")
+                                          for c in _cells(ln))), None)
+    if header_i is None:
+        return rubric_text, 0
+    header = [c.lower() for c in _cells(lines[header_i])]
+    ci_crit = next((i for i, c in enumerate(header) if c in ("criterion", "criteria")), None)
+    if ci_crit is None:
+        return rubric_text, 0
+    ci_hint = next((i for i, c in enumerate(header)
+                    if c in ("evidence hint", "evidence", "hint")), None)
+
+    sep_i = header_i + 1
+    body = []
+    j = sep_i + 1
+    while j < len(lines) and "|" in lines[j]:
+        body.append(j)
+        j += 1
+
+    def terms_for(cells: list) -> str:
+        crit = cells[ci_crit].strip().strip("*").strip() if ci_crit < len(cells) else ""
+        return ", ".join(hints.get(crit, []))
+
+    filled = 0
+    if ci_hint is None:  # add the column
+        lines[header_i] = _append_cell(lines[header_i], "Evidence hint")
+        lines[sep_i] = _append_cell(lines[sep_i], "---")
+        for bi in body:
+            val = terms_for(_cells(lines[bi]))
+            lines[bi] = _append_cell(lines[bi], val)
+            if val:
+                filled += 1
+    else:  # fill empty cells only
+        for bi in body:
+            cells = _cells(lines[bi])
+            if ci_crit >= len(cells):
+                continue
+            while len(cells) <= ci_hint:
+                cells.append("")
+            if cells[ci_hint].strip():
+                continue  # respect an existing hint
+            val = terms_for(cells)
+            if not val:
+                continue
+            cells[ci_hint] = val
+            lines[bi] = "| " + " | ".join(cells) + " |"
+            filled += 1
+
+    return "\n".join(lines), filled
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="LLM-sampled term-bank builder — fill a RUBRIC.md's Evidence hint "
+                    "column at freeze time (#192 Sprint 1c). Dry-run unless --apply.")
+    ap.add_argument("--rubric", required=True, help="Path to the checkability-tagged RUBRIC.md")
+    ap.add_argument("--apply", action="store_true", help="Write the hints into RUBRIC.md")
+    ap.add_argument("--samples", type=int, default=3, help="LLM samples per criterion (default 3)")
+    ap.add_argument("--provider", default="anthropic")
+    ap.add_argument("--model", default="claude-sonnet-4-6")
+    args = ap.parse_args()
+
+    if parse_checkability is None:
+        print("grader_rubric not importable.", file=sys.stderr)
+        return 1
+    path = Path(args.rubric)
+    if not path.is_file():
+        print(f"No rubric at {path}", file=sys.stderr)
+        return 1
+    rubric_text = path.read_text(encoding="utf-8")
+    rows, issues = parse_checkability(rubric_text)
+    for it in issues:
+        print(f"⚠️  {it}", file=sys.stderr)
+    if not rows:
+        return 1
+
+    from grader_grade import make_provider
+    llm = make_provider(args.provider, args.model)
+
+    def sample_fn(criterion: str, temperature: float) -> str:
+        return llm.grade(_SYSTEM, _user_prompt(criterion), temperature, max_tokens=512)
+
+    targets = [r for r in rows if r["checkability"] != "judgment" and not r.get("evidence_hint")]
+    print(f"Sampling term-banks for {len(targets)} criterion(a) "
+          f"({args.samples} samples each; judgment rows + already-hinted rows skipped):")
+    hints = suggest_hints(rows, sample_fn, args.samples)
+    for crit, terms in hints.items():
+        print(f"  • {crit}\n      → {', '.join(terms)}")
+
+    if not hints:
+        print("Nothing to fill.")
+        return 0
+    if not args.apply:
+        print("\nDry-run — re-run with --apply to write these into the Evidence hint column.")
+        return 0
+
+    new_text, filled = apply_hints_to_rubric(rubric_text, hints)
+    path.write_text(new_text, encoding="utf-8")
+    print(f"\n✓ Wrote {filled} Evidence hint(s) into {path}. Re-freeze: "
+          f"grader_rubric.py --rubric {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.21"
+version = "1.7.22"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.21"
+version = "1.7.22"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**Sprint 1c of the #192 hybrid grader — your idea: sample the LLM to build the term-bank so the deterministic layer's scope is aligned, offsetting the undergrade at its source.**

## The problem it fixes
S1b's `derive_term_bank` is one narrow literal guess — "Reproducible work" → `[reproducible, work]`, missing "reproduce / replicable / seed / deterministic". A student who used those words scores 0 literal hits → an **HG-6 false negative**. The deterministic `.py` was LLM-authored in one shot; if its scope is off, it under-detects silently.

## The fix — [`grader_term_banks.py`](lib/tools/grader_term_banks.py)
At **freeze time**, sample the LLM N times (temperature-varied) for the vocabulary a student might actually use per criterion, **union** the samples (benefit of the doubt — a wider net catches paraphrase), and write it into the `Evidence hint` column. `grader_signals.py` (S1b) then extracts **deterministically** against that richer, frozen bank.

The elegance: **the LLM sampling happens once, at build time, and is frozen + auditable in the rubric.** Grading stays deterministic, reproducible, and cheap; priors still never score (HG-2). It uses sampling to *align the deterministic scope*, not to grade. This is the **build-time complement to HG-6** — widen the net (1c) + rescue what still slips at grade time (S4's low-band audit) = belt and suspenders.

## Safety
- Only `mechanical`/`coverage` rows (judgment skipped — HG-1).
- Only rows with an **empty** hint — **never overwrites an instructor's hint**.
- Dry-run by default; `--apply` fills empty cells / adds the column.
- LLM injected as `sample_fn`, so the logic is fully unit-tested with no network.

## Verify
7 unit tests: JSON/list parsing, **union across samples** (wider than any one), skip judgment/already-hinted rows, and the table editor — adds the column when absent, **fills empty cells only**, never clobbers an existing hint, round-trips through the Sprint 0/1b parsers. Ran the editor against the real `cohesive_narrative` template (fills `Reproducible work → reproducible, seed, replicable, deterministic`, re-parses clean). Full suite green under `uv run pytest`.

Architecture doc → v1.2 documents build-time alignment as the HG-6 complement.

Bumps `1.7.21` → `1.7.22` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
