### PR TITLE
feat(grader): Sprint 4 — HG-6 low-band benefit-of-the-doubt audit (#192)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.24] — 2026-07-22
+
+**Hybrid grader Sprint 4 (#192): the HG-6 low-band benefit-of-the-doubt audit — the last piece.** (#192, Sprint 4)
+
+Deterministic layers under-detect, so a low consensus may be an artifact of a wrong/narrow NLP scope. Every low-band tier now gets one more look, priors removed.
+
+### Added
+- **`grader_lowband_audit.py`** — for each consensus in the bottom `--frac` (default 0.25) of the cohort's range, re-reads the raw submission with **priors excluded** ("does the required thing actually exist here, however worded?"). If that read grades **higher** than the low consensus, flags `undergrade_suspected` and routes to the instructor (writes `feedback/_lowband_audit.csv`, prints the queue). It **never lowers a grade and never auto-raises one** — disagreements resolve toward the student, by a human (HG-5/HG-6). Reuses `grader_grade`'s prompt/parse/provider; LLM injected as `grade_fn` for testing. 8 unit tests.
+
+**#192 is complete.** The layer-routed hybrid grader now runs end to end: checkability-tagged rubric (Stage 0) → NLP evidence, term-banks & coverage (1a/1b) with LLM-sampled scope alignment (1c) → injected into N consensus passes (2) → deterministic tier-vs-evidence audit (3) → HG-6 low-band rescue (4). Deterministic where it can, probabilistic where it must, human on top — benefit of the doubt throughout.
+
+---
+
 ## [1.7.23] — 2026-07-22
 
 **Hybrid grader Sprint 3 (#192): the consensus tier is now audited against the NLP evidence — conflicts route to a human, both directions.** (#192, Sprint 3)

--- a/lib/tests/test_grader_lowband_audit.py
+++ b/lib/tests/test_grader_lowband_audit.py
@@ -1,0 +1,73 @@
+"""Unit tests — grader_lowband_audit (issue #192, Sprint 4, HG-6).
+
+The audit re-reads low-band submissions with priors excluded and flags only UPWARD
+disagreements (resolve toward the student). It must never lower a grade, never
+auto-raise one, and only ever fire on the low band. The LLM is injected as
+`grade_fn`, so these run with no provider.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_lowband_audit import low_band_keys, audit_verdict, run_lowband_audit  # noqa: E402
+
+
+def _rows(*pairs):
+    return [{"key": k, "consensus": c} for k, c in pairs]
+
+
+# --- low_band_keys ---------------------------------------------------------
+
+def test_selects_bottom_fraction():
+    rows = _rows(("a", 1.0), ("b", 2.0), ("c", 3.0), ("d", 4.0))
+    # range 1..4, thresh = 1 + 0.25*3 = 1.75 → only 'a'
+    assert low_band_keys(rows, frac=0.25) == ["a"]
+
+
+def test_no_spread_no_low_band():
+    assert low_band_keys(_rows(("a", 3.0), ("b", 3.0))) == []
+
+
+def test_empty_rows():
+    assert low_band_keys([]) == []
+
+
+# --- audit_verdict: never lowers, fires only upward -------------------------
+
+def test_upward_disagreement_flags_undergrade():
+    flag, reason = audit_verdict(consensus=2.0, audit_score=3.0)
+    assert flag is True and "toward the student" in reason
+
+
+def test_equal_or_lower_audit_corroborates_not_flags():
+    assert audit_verdict(2.0, 2.0)[0] is False       # equal → corroborated
+    assert audit_verdict(2.0, 1.0)[0] is False       # lower → never lowers, no flag
+
+
+def test_missing_audit_score_does_not_flag():
+    flag, reason = audit_verdict(2.0, None)
+    assert flag is False and "manually" in reason
+
+
+# --- run_lowband_audit with an injected grader -----------------------------
+
+def test_run_audit_flags_only_the_undergraded():
+    low = _rows(("a", 1.0), ("b", 1.0))
+    # 'a' re-reads higher (undergrade), 'b' re-reads the same (corroborated)
+    grades = {"a": ("Meets", 3.0), "b": ("Developing", 1.0)}
+    records = run_lowband_audit(low, lambda k: grades[k])
+    by = {r["key"]: r for r in records}
+    assert by["a"]["undergrade_suspected"] is True
+    assert by["b"]["undergrade_suspected"] is False
+    # never mutates the consensus
+    assert by["a"]["consensus"] == 1.0 and by["a"]["audit_score"] == 3.0
+
+
+def test_run_audit_records_shape():
+    records = run_lowband_audit(_rows(("a", 1.0)), lambda k: ("Meets", 4.0))
+    r = records[0]
+    assert set(r) == {"key", "consensus", "audit_band", "audit_score",
+                      "undergrade_suspected", "audit_reason"}

--- a/lib/tools/grader_lowband_audit.py
+++ b/lib/tools/grader_lowband_audit.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""HG-6 low-band benefit-of-the-doubt audit (issue #192, Sprint 4).
+
+WHY THIS EXISTS
+  Deterministic layers UNDER-detect: a narrow term-bank or a regex that misses a
+  paraphrase is a false negative that drags the grade DOWN on work the student did.
+  The consensus may have been nudged low by those thin priors. So every consensus
+  that lands in the LOW band gets one more look — but a look with the priors
+  REMOVED, reading the raw submission, asking only "does the required thing actually
+  exist here, however it's worded?"
+
+  If that priors-excluded re-read grades HIGHER than the low consensus, the low band
+  may be an artifact of a wrong/narrow NLP scope — flag `undergrade_suspected` and
+  route it to the instructor. It NEVER lowers a grade and NEVER auto-raises one:
+  disagreements resolve TOWARD the student, by a human (HG-5/HG-6). Benefit of the
+  doubt is the default.
+
+  This is the grade-time complement to grader_term_banks.py's build-time alignment:
+  widen the net up front, rescue what still slips here.
+
+Usage:
+    uv run python lib/tools/grader_lowband_audit.py --challenge-dir grading/<task> \\
+        --rubric grading/<task>/RUBRIC.md
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+try:
+    from _env_loader import force_utf8_console
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+try:
+    from _challenge_dir_guard import resolve_challenge_dir
+except ImportError:
+    resolve_challenge_dir = None
+
+
+def low_band_keys(rows: list, frac: float = 0.25) -> list:
+    """Keys whose consensus is in the bottom `frac` of the cohort's score range.
+
+    Pure. Returns [] when the cohort has no spread (hi == lo) — no "low band" to audit.
+    """
+    scores = [r["consensus"] for r in rows if r.get("consensus") is not None]
+    if not scores:
+        return []
+    lo, hi = min(scores), max(scores)
+    if hi <= lo:
+        return []
+    thresh = lo + frac * (hi - lo)
+    return [r["key"] for r in rows
+            if r.get("consensus") is not None and r["consensus"] <= thresh]
+
+
+def audit_verdict(consensus: float, audit_score) -> tuple:
+    """Compare the priors-excluded audit score to the low consensus. Never lowers.
+
+    Returns (undergrade_suspected, reason). Fires only on an UPWARD disagreement —
+    resolve toward the student.
+    """
+    if audit_score is None:
+        return False, "audit produced no comparable score — review manually"
+    if audit_score > consensus:
+        return True, (f"priors-excluded re-read graded {audit_score} vs consensus "
+                      f"{consensus} — the text supports a higher band; verify toward the "
+                      "student (HG-6)")
+    return False, (f"priors-excluded re-read graded {audit_score} (≤ consensus "
+                   f"{consensus}) — low band corroborated")
+
+
+def run_lowband_audit(low_rows: list, grade_fn) -> list:
+    """Audit each low-band row. `grade_fn(key) -> (audit_band, audit_score)` is the
+    priors-excluded re-read (injected, so this is testable without a provider)."""
+    out = []
+    for r in low_rows:
+        band, score = grade_fn(r["key"])
+        flag, reason = audit_verdict(r["consensus"], score)
+        out.append({
+            "key": r["key"], "consensus": r["consensus"],
+            "audit_band": band, "audit_score": score,
+            "undergrade_suspected": flag, "audit_reason": reason,
+        })
+    return out
+
+
+def _read_consensus(path: Path) -> list:
+    rows = []
+    for row in csv.DictReader(path.open(encoding="utf-8")):
+        try:
+            rows.append({"key": row["key"], "consensus": float(row["consensus"])})
+        except (KeyError, ValueError):
+            continue
+    return rows
+
+
+def main() -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(
+        description="HG-6 low-band benefit-of-the-doubt audit (#192 Sprint 4). Re-reads "
+                    "low-band submissions with priors EXCLUDED; flags undergrade_suspected "
+                    "on an upward disagreement. Never moves a score.")
+    ap.add_argument("--challenge-dir", required=True, help="e.g. grading/kc3")
+    ap.add_argument("--rubric", required=True, help="Checkability-tagged RUBRIC.md")
+    ap.add_argument("--config", default=None, help="config.yml (for band_to_score).")
+    ap.add_argument("--frac", type=float, default=0.25, help="Bottom fraction = low band (0.25).")
+    ap.add_argument("--provider", default="anthropic")
+    ap.add_argument("--model", default="claude-sonnet-4-6")
+    args = ap.parse_args()
+
+    challenge = (resolve_challenge_dir(args.challenge_dir, verb="auditing")
+                 if resolve_challenge_dir else Path(args.challenge_dir))
+    fb = Path(challenge) / "feedback"
+    consensus_path = fb / "_consensus.csv"
+    if not consensus_path.exists():
+        print(f"No {consensus_path} — run grader_consensus.py first.", file=sys.stderr)
+        return 1
+    rows = _read_consensus(consensus_path)
+    low = [r for r in rows if r["key"] in set(low_band_keys(rows, args.frac))]
+    if not low:
+        print("No low-band submissions to audit (no cohort spread, or none in the bottom "
+              f"{int(args.frac * 100)}%).")
+        return 0
+
+    rubric_text = Path(args.rubric).read_text(encoding="utf-8")
+    deid_dir = Path(challenge) / "submissions_deid"
+
+    from grader_grade import (_build_user_prompt, _parse_response, SYSTEM_PROMPT,
+                              make_provider, _load_config)
+    band_to_score = None
+    if args.config:
+        band_to_score = (_load_config(Path(args.config)) or {}).get("band_to_score")
+    llm = make_provider(args.provider, args.model)
+
+    def grade_fn(key: str):
+        sub = deid_dir / f"{key}.md"
+        if not sub.exists():
+            return None, None
+        # priors_block="" — the whole point: re-read WITHOUT the NLP priors.
+        prompt = _build_user_prompt(
+            pass_number=1, total_passes=1, rubric_text=rubric_text, voice_text="",
+            course_context="", answer_key_text="", priors_block="",
+            deid_submission=sub.read_text(encoding="utf-8"), band_to_score=band_to_score)
+        parsed = _parse_response(llm.grade(SYSTEM_PROMPT, prompt, 0.2)) or {}
+        band = parsed.get("band")
+        score = parsed.get("score")
+        try:
+            score = float(score)
+        except (TypeError, ValueError):
+            score = (band_to_score or {}).get(band)
+        return band, score
+
+    print(f"HG-6 low-band audit: re-reading {len(low)} low-band submission(s) with priors "
+          "excluded (never moves a score)...")
+    records = run_lowband_audit(low, grade_fn)
+
+    out = fb / "_lowband_audit.csv"
+    with out.open("w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["key", "consensus", "audit_band", "audit_score",
+                                          "undergrade_suspected", "audit_reason"])
+        w.writeheader()
+        w.writerows(records)
+
+    flagged = [r for r in records if r["undergrade_suspected"]]
+    if flagged:
+        print(f"\n⚠️  {len(flagged)} UNDERGRADE-SUSPECTED (resolve toward the student):")
+        for r in flagged:
+            print(f"  {r['key']}: consensus {r['consensus']} → audit {r['audit_score']} — {r['audit_reason']}")
+    else:
+        print("\nNo undergrade suspected — every low-band tier was corroborated by the "
+              "priors-excluded re-read.")
+    print(f"\n-> {out}  ({len(records)} audited; never auto-moved a score)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.23"
+version = "1.7.24"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.23"
+version = "1.7.24"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**Sprint 4 — the last piece of #192, and the keystone of your benefit-of-the-doubt philosophy.**

## HG-6 low-band audit — [`grader_lowband_audit.py`](lib/tools/grader_lowband_audit.py)
Deterministic layers under-detect, so a low consensus may be an artifact of a wrong/narrow NLP scope (a paraphrase the term-bank missed). For each consensus in the bottom `--frac` (default 0.25) of the cohort's range, this **re-reads the raw submission with priors excluded** — "does the required thing actually exist here, however it's worded?" If that read grades **higher** than the low consensus, it flags `undergrade_suspected` and routes to the instructor.

**Never lowers a grade. Never auto-raises one.** Disagreements resolve toward the student, by a human (HG-5/HG-6). Writes `feedback/_lowband_audit.csv` + prints the queue.

Reuses `grader_grade`'s prompt/parse/provider; the LLM is injected as `grade_fn` so the logic is fully unit-tested with no provider.

## Verify
8 unit tests: bottom-fraction selection (+ no-spread → no low band), `audit_verdict` fires **only upward** (equal/lower → corroborated, never flagged; missing score → manual), and `run_lowband_audit` flags only the undergraded while never mutating the consensus. Full suite green under `uv run pytest`.

## #192 is complete
The layer-routed hybrid grader runs end to end:

```
Stage 0  checkability-tagged RUBRIC.md
  1a/1b  NLP evidence · term-banks · coverage   (framed as evidence, never verdicts)
  1c     LLM-sampled term-banks                  (build-time scope alignment)
  2      --with-signals                          (evidence injected into N consensus passes)
  3      tier-vs-evidence conflict audit         (both directions; never moves a score)
  4      HG-6 low-band re-read                    (priors excluded; toward the student)
```

Deterministic where it can, probabilistic where it must, human on top — benefit of the doubt throughout.

Bumps `1.7.23` → `1.7.24` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
