### PR TITLE
feat(grader): post-push workflow-state audit + idempotent repair (#226)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.25] — 2026-07-22
+
+**Post-push workflow-state audit + idempotent repair — grades no longer stick in "needs grading" after a resubmission.** (#226)
+
+A student resubmitting after being graded resets `workflow_state` to `"submitted"`; re-applying the grade doesn't always transition it back, so the grade posts but Canvas still shows "needs grading" (2026-07-22: 31 submissions stuck). Fixes it on two surfaces, both idempotent state-repairs that never change a grade.
+
+### Added
+- **`grader_audit_workflow.py`** — `--check` scans an assignment (or `--all-assignments`) for submissions that have a grade but are still `workflow_state "submitted"` (FERPA-safe: user_id + assignment); `--fix` idempotently re-posts the grade Canvas already carries to force `submitted → graded`. Leaves `pending_review` (moderated) and ungraded submissions untouched. Live-course writes pass `canvas_course_guard` (`--allow-enrolled`).
+- **`grader_push.py`** — `--auto-fix-workflow`: after a push, verifies the just-pushed rows and, if any are still `"submitted"`, re-posts the same grade to force the transition (without it, warns and points at `grader_audit_workflow.py`). Verification never fails the push itself.
+- **`grader_knowledge.md`** — documents the stuck-state issue + the repair path.
+
+**HG-5 alignment (#213):** the repair only ever re-posts the grade Canvas already has — a state fix, never a new/AI-drafted grade — so it stays outside the `--mark-reviewed` review gate without being a backdoor around it, and as a sanctioned `lib/tools/` tool it's the path the `grade_guardian` hook expects instead of a manual API re-post.
+
+---
+
 ## [1.7.24] — 2026-07-22
 
 **Hybrid grader Sprint 4 (#192): the HG-6 low-band benefit-of-the-doubt audit — the last piece.** (#192, Sprint 4)

--- a/lib/agents/knowledge/grader_knowledge.md
+++ b/lib/agents/knowledge/grader_knowledge.md
@@ -524,6 +524,15 @@ Before assigning a score to a key:
 
 **What this is NOT.** This is NOT a "trust the existing grade unconditionally" rule. The instructor's manual regrade or a genuine error correction is a legitimate downward move — the bypass at push is `--allow-lower`. But the DEFAULT is anchor-to-existing; deviation requires explicit reason; lowering is the highest-stakes deviation and gets the loudest surface.
 
+### Post-push workflow-state repair (issue #226, v1.7.25+)
+
+A student who **resubmits after being graded** resets `workflow_state` to `"submitted"`. Re-applying the grade doesn't always transition it back to `"graded"`, so the grade IS posted but the instructor's To-Do still reads "needs grading" (2026-07-22: 31 submissions stuck across 6 assignments). Two surfaces:
+
+- **`grader_push.py`** verifies the just-pushed rows after the push and warns; `--auto-fix-workflow` idempotently re-posts the SAME grade to force the transition.
+- **`grader_audit_workflow.py --check / --fix`** scans an assignment (or `--all-assignments`) for the same stuck state across existing grades and repairs it.
+
+**The guardrail:** the re-post ONLY re-sends the grade Canvas already carries — a state repair, never a new or changed grade. So it stays *outside* the HG-5 review gate (there is nothing new or AI-drafted to review) without being a backdoor around it, and — as a sanctioned `lib/tools/` tool — it is the path the `grade_guardian` hook (#213) expects, instead of the manual API re-post that the incident used. Live-course writes still pass `canvas_course_guard` (`--allow-enrolled`); `pending_review` (moderated) and ungraded submissions are left untouched.
+
 ### Standard Work — the task page is the source of truth, NOT the answer key (issue #102, v0.63.0+)
 
 The DS 250 U4T3 incident (2026-06-25) surfaced a high-stakes failure mode that's distinct from the regression / consensus / review-gate threads. The rubric was built from the **solution code** (which plotted feature importances) and required a chart. The student-facing task page said *"it doesn't say you have to graph the permutation importances, but I would like to"* — the chart was OPTIONAL. The rubric inherited a REQUIREMENT from the answer key that the task page explicitly called OPTIONAL. Result: confident, unanimous (3/3) consensus on the wrong rubric → 4 students wrongly marked incomplete.

--- a/lib/tests/test_grader_audit_workflow.py
+++ b/lib/tests/test_grader_audit_workflow.py
@@ -1,0 +1,51 @@
+"""Unit tests — grader_audit_workflow stuck-state detection (issue #226).
+
+The audit's whole correctness rests on which submissions count as "stuck": a grade
+posted but workflow_state still 'submitted'. It must NOT sweep in ungraded,
+moderated (pending_review), or already-graded submissions — re-posting those would
+be wrong.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_audit_workflow import find_stuck_submissions  # noqa: E402
+
+
+def _s(uid, grade, state):
+    return {"user_id": uid, "grade": grade, "workflow_state": state}
+
+
+def test_graded_but_still_submitted_is_stuck():
+    subs = [_s(1, "A", "submitted")]
+    assert [s["user_id"] for s in find_stuck_submissions(subs)] == [1]
+
+
+def test_properly_graded_is_not_stuck():
+    assert find_stuck_submissions([_s(1, "A", "graded")]) == []
+
+
+def test_ungraded_submitted_is_not_stuck():
+    assert find_stuck_submissions([_s(1, None, "submitted")]) == []
+    assert find_stuck_submissions([_s(2, "", "submitted")]) == []
+
+
+def test_pending_review_is_left_alone():
+    """Moderated grading queue — a re-post must not disturb it."""
+    assert find_stuck_submissions([_s(1, "A", "pending_review")]) == []
+
+
+def test_unsubmitted_is_not_stuck():
+    assert find_stuck_submissions([_s(1, None, "unsubmitted")]) == []
+
+
+def test_mixed_batch_returns_only_stuck():
+    subs = [_s(1, "A", "submitted"),     # stuck
+            _s(2, "B", "graded"),        # fine
+            _s(3, None, "submitted"),    # ungraded
+            _s(4, "C", "submitted"),     # stuck
+            _s(5, "D", "pending_review")]  # moderated
+    assert sorted(s["user_id"] for s in find_stuck_submissions(subs)) == [1, 4]

--- a/lib/tools/grader_audit_workflow.py
+++ b/lib/tools/grader_audit_workflow.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Post-push workflow-state audit + idempotent repair (issue #226).
+
+THE GAP
+  After a grade is posted, Canvas usually flips a submission from
+  workflow_state "submitted" to "graded". But when a student RESUBMITS after being
+  graded, the state resets to "submitted", and re-applying the grade doesn't always
+  transition it back — so the grade is posted but the instructor's To-Do still shows
+  "needs grading". (2026-07-22: 31 submissions stuck across 6 assignments.)
+
+WHAT THIS DOES
+  --check  scan assignment(s) and report submissions that have a grade but are still
+           workflow_state "submitted" (FERPA-safe: user_id + assignment, no names).
+  --fix    idempotently RE-POST the grade Canvas already has, which forces the
+           "submitted" → "graded" transition.
+
+THE HG-5 GUARDRAIL (issue #213)
+  --fix ONLY re-posts the grade a submission ALREADY carries — it never sets a new
+  or changed grade. So it is a workflow-STATE repair, not a grading path: it stays
+  outside the --mark-reviewed review gate (there is no new/AI-drafted grade to
+  review) without becoming a backdoor around it. Being a sanctioned lib/tools/ tool,
+  its re-post is the path the grade_guardian hook expects — never a custom script.
+  Live-course writes still pass canvas_course_guard (--allow-enrolled).
+
+Usage:
+    uv run python lib/tools/grader_audit_workflow.py --assignment-id 123 --check
+    uv run python lib/tools/grader_audit_workflow.py --all-assignments --fix --allow-enrolled
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+import requests
+
+try:
+    from _env_loader import force_utf8_console, load_env
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+    def load_env() -> None:
+        pass
+
+try:
+    from canvas_course_guard import enforce as guard_enforce
+except ImportError:
+    guard_enforce = None
+
+_TIMEOUT = 20
+
+
+def find_stuck_submissions(submissions: list) -> list:
+    """Submissions that carry a grade but are still workflow_state 'submitted' (#226).
+
+    Pure. `pending_review` (moderated) and `unsubmitted` are intentionally NOT stuck —
+    a re-post must not disturb a moderation queue or an ungraded submission.
+    """
+    return [s for s in submissions
+            if s.get("grade") not in (None, "")
+            and s.get("workflow_state") == "submitted"]
+
+
+def _canvas_env(course_override: str | None) -> tuple:
+    load_env()
+    tok = os.environ.get("CANVAS_API_TOKEN", "")
+    cid = course_override or os.environ.get("CANVAS_COURSE_ID", "")
+    base = os.environ.get("CANVAS_BASE_URL", "").rstrip("/")
+    if base and not base.startswith("http"):
+        base = "https://" + base
+    return tok, cid, base
+
+
+def _get_paginated(url: str, headers: dict, params: dict | None = None) -> list:
+    out: list = []
+    while url:
+        resp = requests.get(url, headers=headers, params=params, timeout=_TIMEOUT)
+        resp.raise_for_status()
+        body = resp.json()
+        out.extend(body if isinstance(body, list) else [body])
+        url = resp.links.get("next", {}).get("url")
+        params = None  # the next link carries its own query
+    return out
+
+
+def fetch_assignment_ids(base: str, cid: str, headers: dict) -> list:
+    items = _get_paginated(f"{base}/api/v1/courses/{cid}/assignments",
+                           headers, {"per_page": 100})
+    return [a["id"] for a in items if "id" in a]
+
+
+def fetch_submissions(base: str, cid: str, headers: dict, aid) -> list:
+    return _get_paginated(f"{base}/api/v1/courses/{cid}/assignments/{aid}/submissions",
+                          headers, {"per_page": 100})
+
+
+def repost_grade(base: str, cid: str, headers: dict, aid, uid, grade: str) -> bool:
+    """Idempotently re-post the EXISTING grade to force the state transition."""
+    resp = requests.put(
+        f"{base}/api/v1/courses/{cid}/assignments/{aid}/submissions/{uid}",
+        headers=headers, data={"submission[posted_grade]": grade}, timeout=_TIMEOUT)
+    return resp.status_code < 400
+
+
+def main() -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(
+        description="Audit + idempotently repair stuck submission workflow_state (#226).")
+    ap.add_argument("--course-id", default=None, help="Override CANVAS_COURSE_ID.")
+    ap.add_argument("--assignment-id", action="append", type=int, default=None,
+                    help="Assignment id to scan (repeatable).")
+    ap.add_argument("--all-assignments", action="store_true",
+                    help="Scan every assignment in the course.")
+    ap.add_argument("--fix", action="store_true",
+                    help="Re-post the EXISTING grade to force 'submitted' -> 'graded'. "
+                         "Default is --check (report only).")
+    ap.add_argument("--yes", "-y", action="store_true", help="Skip the fix confirmation.")
+    ap.add_argument("--allow-enrolled", action="store_true",
+                    help="canvas_course_guard override for the live-course re-post.")
+    args = ap.parse_args()
+
+    tok, cid, base = _canvas_env(args.course_id)
+    for var, val in (("CANVAS_API_TOKEN", tok), ("CANVAS_BASE_URL", base), ("course id", cid)):
+        if not val:
+            print(f"Missing {var}.", file=sys.stderr)
+            return 1
+    headers = {"Authorization": f"Bearer {tok}"}
+
+    if not args.assignment_id and not args.all_assignments:
+        print("Pass --assignment-id <id> (repeatable) or --all-assignments.", file=sys.stderr)
+        return 1
+
+    if args.fix and guard_enforce:
+        guard_enforce(base, headers, cid, mode="write", allow_override=args.allow_enrolled)
+
+    aids = args.assignment_id or fetch_assignment_ids(base, cid, headers)
+    stuck: list = []  # (aid, uid, grade)
+    for aid in aids:
+        for s in find_stuck_submissions(fetch_submissions(base, cid, headers, aid)):
+            stuck.append((aid, s["user_id"], s.get("grade")))
+
+    if not stuck:
+        print(f"No stuck submissions across {len(aids)} assignment(s) — every graded "
+              "submission is workflow_state 'graded'.")
+        return 0
+
+    print(f"⚠️  {len(stuck)} stuck submission(s) (grade posted but workflow_state "
+          f"'submitted') across {len({a for a, _, _ in stuck})} assignment(s):")
+    for aid, uid, grade in stuck:
+        print(f"    assignment {aid}  user_id {uid}  grade={grade}")
+
+    if not args.fix:
+        print("\n--check only. Re-run with --fix (--allow-enrolled) to idempotently re-post "
+              "the existing grades and force the transition.")
+        return 0
+
+    if not args.yes:
+        print(f"\nThis re-posts {len(stuck)} EXISTING grade(s) to the LIVE course {cid} "
+              "(no grade values change).")
+        if input("Type 'fix' to proceed: ").strip().lower() != "fix":
+            print("Aborted.")
+            return 1
+
+    fixed = failed = 0
+    for aid, uid, grade in stuck:
+        if repost_grade(base, cid, headers, aid, uid, grade):
+            fixed += 1
+        else:
+            failed += 1
+            print(f"    FAILED to re-post assignment {aid} user_id {uid}", file=sys.stderr)
+    print(f"\n✓ Re-posted {fixed} grade(s) to force the transition"
+          + (f"; {failed} failed." if failed else "."))
+    return 0 if not failed else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -110,6 +110,7 @@ import json
 import os
 import re
 import sys
+import time
 from pathlib import Path
 from _challenge_dir_guard import resolve_challenge_dir  # issue #44 FERPA guard
 
@@ -1134,6 +1135,11 @@ def main() -> int:
                          "because the canonical tag would get stacked on top of it at send-time. "
                          "Pass this flag to push anyway (rare; the stale tag stays in the "
                          "student-visible comment).")
+    ap.add_argument("--auto-fix-workflow", action="store_true",
+                    help="Issue #226: after pushing, if a just-pushed grade is still "
+                         "workflow_state 'submitted' (Canvas didn't transition — common after a "
+                         "resubmission), idempotently re-post the SAME grade to force "
+                         "'submitted' -> 'graded'. Never changes a grade value.")
     ap.add_argument("--allow-lower", action="store_true",
                     help="Issue #96: explicit opt-out from the regression-direction gate. By "
                          "default, grader_push refuses to LOWER an existing non-empty Canvas grade "
@@ -1660,6 +1666,7 @@ def main() -> int:
             return 1
 
     pushed = 0
+    pushed_uids: set = set()  # #226: verify workflow_state transition after push
     held = 0
     regressions_skipped = 0
     grade_type_skipped = 0
@@ -1779,6 +1786,8 @@ def main() -> int:
                     lg.write(f"- {key}: grade {before_repr} → {grade} pushed to assignment "
                              f"{args.assignment_id}\n")
                     pushed += 1
+                    if uid is not None:
+                        pushed_uids.add(int(uid))
                 # Issue #63: capture the new comment_id (if any) so --retract
                 # can DELETE it later. Canvas's PUT response includes
                 # submission_comments[] — pick the LAST entry as the one we
@@ -1826,6 +1835,34 @@ def main() -> int:
             print(f"\n⚠️  MANUAL posting policy: the {pushed} grade(s) are ENTERED but NOT "
                   "posted — students can't see them and the gradebook shows 'needs grading'. "
                   "Release them via the Gradebook 'Post grades' action, or re-run with --post.")
+
+    # Issue #226: a resubmission-after-grading can leave workflow_state stuck at
+    # "submitted" even though the grade posted (Canvas doesn't always transition on
+    # re-apply). Verify the pushed rows and, with --auto-fix-workflow, idempotently
+    # re-post the SAME grade to force "submitted" -> "graded" (never a new grade).
+    if pushed and args.push and pushed_uids:
+        try:
+            from grader_audit_workflow import find_stuck_submissions, repost_grade
+            time.sleep(2)  # let Canvas process the writes
+            fresh = fetch_submissions(base, cid, headers, args.assignment_id)
+            stuck = [s for s in find_stuck_submissions(fresh)
+                     if s.get("user_id") is not None and int(s["user_id"]) in pushed_uids]
+            if stuck:
+                print(f"\n⚠️  #226: {len(stuck)} just-pushed grade(s) are still "
+                      "workflow_state 'submitted' (Canvas didn't transition — common after a "
+                      "resubmission).")
+                if args.auto_fix_workflow:
+                    fixed = sum(1 for s in stuck
+                                if repost_grade(base, cid, headers, args.assignment_id,
+                                                s["user_id"], s.get("grade")))
+                    print(f"   ✓ re-posted the existing grade for {fixed}/{len(stuck)} to force "
+                          "the transition.")
+                else:
+                    print("   Fix: uv run python lib/tools/grader_audit_workflow.py "
+                          f"--assignment-id {args.assignment_id} --fix --allow-enrolled "
+                          "(or re-run this push with --auto-fix-workflow).")
+        except Exception as e:  # verification must never fail the push itself
+            print(f"\n(note: #226 workflow-state verify skipped — {e})")
 
     if failed:
         print(f"Failed: {failed}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.24"
+version = "1.7.25"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.24"
+version = "1.7.25"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Fixes #226.

## The gap
A student who **resubmits after being graded** resets `workflow_state` to `"submitted"`. Re-applying the grade doesn't always transition it back, so the grade IS posted but the instructor's To-Do still reads "needs grading" (real impact 2026-07-22: 31 submissions stuck across 6 assignments). Built both surfaces the issue recommended.

## `grader_audit_workflow.py` (Option 2)
- `--check` — scans an assignment (or `--all-assignments`) for submissions that have a grade but are still `workflow_state "submitted"`; reports FERPA-safe (user_id + assignment, no names).
- `--fix` — idempotently re-posts the grade **Canvas already carries** to force `submitted → graded`.
- Leaves `pending_review` (moderated) and ungraded submissions untouched.

## `grader_push.py --auto-fix-workflow` (Option 1)
After a push, verifies the just-pushed rows; if any are still `"submitted"`, re-posts the same grade to force the transition. Without the flag it warns and points at the audit tool. The verify is wrapped so it can **never fail the push itself**.

## HG-5 alignment — the guardrail from #213
This is the design point I flagged in the issue triage: the repair **only ever re-posts the grade Canvas already has** — a state fix, never a new or changed grade. So it stays *outside* the `--mark-reviewed` review gate (nothing new/AI-drafted to review) without being a backdoor around it. And as a sanctioned `lib/tools/` tool, it's exactly the path the `grade_guardian` hook expects — instead of the manual `/tmp` API re-post the incident used, which the hook would now block. Live writes still pass `canvas_course_guard` (`--allow-enrolled`).

## Verify
6 unit tests on `find_stuck_submissions` (the correctness pivot): graded-but-submitted → stuck; properly-graded / ungraded / `pending_review` / `unsubmitted` → left alone; mixed batch returns only the stuck. Full suite green under `uv run pytest`.

## Acceptance criteria
1. ✅ post-push verify in `grader_push.py`
2. ✅ warns with count + assignment
3. ✅ `--auto-fix-workflow`
4. ✅ standalone `grader_audit_workflow.py --check/--fix`
5. ✅ documented in `grader_knowledge.md`
6. ✅ workflow check available to the grader tooling

Bumps `1.7.24` → `1.7.25` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
