### PR TITLE
fix(grader_push): resolve feedback_file paths against the challenge dir (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.26] — 2026-07-22
+
+**Fix: `grader_push.py` pushed grades with EMPTY comments — challenge-relative feedback paths resolved against CWD.** (#228)
+
+Silent and high-impact: `.review.csv` stores `feedback_file` challenge-relative (e.g. `feedback/KC2-ABC.md`), but `comment_for` / `extract_hold_token` did a bare `Path()` that resolves against the current working directory. Run from the repo root with `--challenge-dir grading/kc2`, every feedback file was looked for at `<root>/feedback/...`, found nothing, and returned an empty comment — so grades pushed with no qualitative feedback, with no error. (DS 460 KC2, 2026-07-22.)
+
+### Fixed
+- **`grader_push.py`** — a new `resolve_feedback_file(challenge, feedback_file)` resolves the path against the challenge dir; applied at all three read sites (plan-building, HOLD-token extraction, lock/resubmit check). Absolute paths and paths that already exist as-is (run from inside the challenge dir) pass through unchanged. Regression test reproduces the empty-comment bug and confirms the fix.
+
+---
+
 ## [1.7.25] — 2026-07-22
 
 **Post-push workflow-state audit + idempotent repair — grades no longer stick in "needs grading" after a resubmission.** (#226)

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -30,6 +30,8 @@ from grader_push import (  # noqa: E402
     find_deprecated_disclosure_tags,
     DEPRECATED_DISCLOSURE_TAGS,
     push_precheck,
+    comment_for,
+    resolve_feedback_file,
     assignment_posts_manually,
     post_assignment_grades,
 )
@@ -535,6 +537,44 @@ def test_every_deprecated_tag_constant_is_detected(tmp_path):
     for i, dep in enumerate(DEPRECATED_DISCLOSURE_TAGS):
         fb = _write_fb(tmp_path, f"KC1-{i}.md", f"body\n\n{dep}\n")
         assert find_deprecated_disclosure_tags([fb]), f"not detected: {dep!r}"
+
+
+# ---------------------------------------------------------------------------
+# resolve_feedback_file — issue #228 (challenge-relative path resolution)
+# ---------------------------------------------------------------------------
+
+def test_bug228_challenge_relative_comment_was_empty_now_found(tmp_path):
+    """The #228 silent bug: run from repo root, `.review.csv` stores
+    `feedback/KC2-*.md` (challenge-relative), and comment_for's bare Path()
+    resolved it against CWD -> empty comment -> grades pushed with NO feedback."""
+    challenge = tmp_path / "grading" / "kc2"
+    (challenge / "feedback").mkdir(parents=True)
+    fb = challenge / "feedback" / "KC2-TESTXYZ.md"
+    fb.write_text("## Comment to student\n\nGreat work on the joins.", encoding="utf-8")
+
+    # BUG: the raw challenge-relative path is empty from a repo-root CWD
+    assert comment_for("feedback/KC2-TESTXYZ.md") == ""
+    # FIX: resolved against the challenge dir, the comment loads
+    resolved = resolve_feedback_file(challenge, "feedback/KC2-TESTXYZ.md")
+    assert resolved == str(fb)
+    assert "Great work on the joins." in comment_for(resolved)
+
+
+def test_resolve_feedback_file_passthroughs(tmp_path):
+    # absolute path — unchanged
+    absfile = tmp_path / "x.md"
+    assert resolve_feedback_file(tmp_path / "grading", str(absfile)) == str(absfile)
+    # empty — unchanged
+    assert resolve_feedback_file(tmp_path, "") == ""
+
+
+def test_resolve_feedback_file_keeps_a_path_that_already_exists(tmp_path, monkeypatch):
+    """Run from inside the challenge dir: `feedback/x.md` already resolves against
+    CWD, so it passes through (no double-prefixing)."""
+    (tmp_path / "feedback").mkdir()
+    (tmp_path / "feedback" / "x.md").write_text("## Comment to student\n\nok", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    assert resolve_feedback_file(tmp_path, "feedback/x.md") == "feedback/x.md"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -156,6 +156,24 @@ def comment_for(feedback_file: str) -> str:
     return t.split("## Comment to student", 1)[1].strip()
 
 
+def resolve_feedback_file(challenge: Path, feedback_file: str) -> str:
+    """Resolve a `.review.csv` feedback_file path against the challenge dir (#228).
+
+    Paths in `.review.csv` are challenge-relative (e.g. `feedback/KC2-ABC.md`), but
+    `comment_for` / `extract_hold_token` do a bare `Path()` that resolves against CWD.
+    Run from the repo root with `--challenge-dir grading/kc2`, that looked in
+    `<root>/feedback/...` and found nothing — so EVERY comment came back empty and
+    only grades pushed (silent). Resolve challenge-relative here. Absolute paths and
+    paths that already exist as-is (run from inside the challenge dir) pass through.
+    """
+    if not feedback_file:
+        return feedback_file
+    p = Path(feedback_file)
+    if p.is_absolute() or p.exists():
+        return feedback_file
+    return str(challenge / feedback_file)
+
+
 # Transparency disclosure (default, no opt-out): every AI-drafted feedback
 # comment carries this tag so a student always knows the words were drafted by
 # AI and reviewed by their instructor — never passed off as solely the
@@ -1423,7 +1441,7 @@ def main() -> int:
     hold_by_key: dict[str, str] = {}
     if not args.no_hold_tokens and not args.grade_only:
         for r in rows:
-            ff = r.get("feedback_file", "") or ""
+            ff = resolve_feedback_file(challenge, r.get("feedback_file", "") or "")  # #228
             if not ff:
                 continue
             tok = extract_hold_token(ff)
@@ -1435,7 +1453,8 @@ def main() -> int:
         key = r.get("key", "")
         grade = (r.get("final_grade") or "").strip() or (r.get("recommended_score") or "").strip()
         comment = "" if args.grade_only else (
-            append_disclosure_tag(comment_for(r.get("feedback_file", ""))) or args.default_comment)
+            append_disclosure_tag(comment_for(
+                resolve_feedback_file(challenge, r.get("feedback_file", "")))) or args.default_comment)  # #228
         uid = resolve_user_id(r.get("submission_file", ""), subs)
         done = key in pushed_keys and not args.force
         ok = bool(grade and uid and (comment or args.grade_only)) and not done
@@ -1475,7 +1494,8 @@ def main() -> int:
     if not args.no_lock_check and not args.grade_only and lock_state.get("locked_now"):
         for r in rows:
             key = r.get("key", "")
-            comment = comment_for(r.get("feedback_file", "")) or args.default_comment
+            comment = comment_for(
+                resolve_feedback_file(challenge, r.get("feedback_file", ""))) or args.default_comment  # #228
             if comment and comment_has_resubmit_language(comment):
                 locked_resubmit_keys.append((key, comment))
     # ---- end availability + grading-type metadata -----------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.25"
+version = "1.7.26"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.25"
+version = "1.7.26"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Fixes #228.

## The bug (silent, high-impact)
`.review.csv` stores `feedback_file` **challenge-relative** (e.g. `feedback/KC2-ABC.md`), but `comment_for` / `extract_hold_token` did a bare `Path(feedback_file)` that resolves against **CWD**. Run from the repo root with `--challenge-dir grading/kc2`, every feedback file was looked for at `<root>/feedback/...`, found nothing, and returned an **empty comment** — so grades pushed with no qualitative feedback, **no error**. (DS 460 KC2, 2026-07-22: student graded 3.0/4, pushed with an empty comment despite `grading/kc2/feedback/KC2-*.md` existing.)

## The fix
`resolve_feedback_file(challenge, feedback_file)` resolves the path against the challenge dir, applied at **all three** read sites:
- plan-building loop (the comment that goes to the student)
- HOLD-token extraction (#72)
- lock/resubmit-language check (#63)

Absolute paths and paths that already exist as-is (run from inside the challenge dir) pass through unchanged — no double-prefixing.

## Verify
Regression test reproduces the bug and confirms the fix:
```python
assert comment_for("feedback/KC2-TESTXYZ.md") == ""          # the bug, from repo-root CWD
resolved = resolve_feedback_file(challenge, "feedback/KC2-TESTXYZ.md")
assert "Great work on the joins." in comment_for(resolved)   # the fix
```
Plus passthrough cases (absolute, empty, already-existing). Full suite green under `uv run pytest`.

## Note
Pre-existing bug — **not** introduced by the recent `grader_push.py` changes (#207/#213/#226 never touched `comment_for` path resolution). The reporter had a verified local patch and filed it upstream per the vendored-dep rule.

Bumps `1.7.25` → `1.7.26` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
