### PR TITLE
fix(grader_push): consolidate + test the #228 empty-comment fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.26] — 2026-07-22
+
+**Harden + test the `grader_push.py` empty-comment fix.** (#228)
+
+The path-resolution fix landed inline in `9c0c906` (direct to main). This consolidates it and closes the two release-hygiene gaps that commit left: no test and no version signal.
+
+### Changed
+- **`grader_push.py`** — the three inline `str(challenge / feedback_file)` fixes (HOLD extraction, plan-building, lock/resubmit check) are consolidated into one `resolve_feedback_file(challenge, feedback_file)` helper, which also passes through absolute paths and paths that already exist as-is (run from inside the challenge dir), so it never double-prefixes. Behavior is unchanged from `9c0c906`.
+
+### Added
+- Regression test reproducing the original silent bug (`comment_for("feedback/KC2-*.md")` empty from a repo-root CWD) and confirming the resolved path loads the comment — the guard the original fix shipped without. Plus a version bump so vendored copies can detect via `--version` that they need to `git pull` to get the fix.
+
+---
+
 ## [1.7.25] — 2026-07-22
 
 **Post-push workflow-state audit + idempotent repair — grades no longer stick in "needs grading" after a resubmission.** (#226)

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -30,6 +30,8 @@ from grader_push import (  # noqa: E402
     find_deprecated_disclosure_tags,
     DEPRECATED_DISCLOSURE_TAGS,
     push_precheck,
+    comment_for,
+    resolve_feedback_file,
     assignment_posts_manually,
     post_assignment_grades,
 )
@@ -535,6 +537,44 @@ def test_every_deprecated_tag_constant_is_detected(tmp_path):
     for i, dep in enumerate(DEPRECATED_DISCLOSURE_TAGS):
         fb = _write_fb(tmp_path, f"KC1-{i}.md", f"body\n\n{dep}\n")
         assert find_deprecated_disclosure_tags([fb]), f"not detected: {dep!r}"
+
+
+# ---------------------------------------------------------------------------
+# resolve_feedback_file — issue #228 (challenge-relative path resolution)
+# The fix landed inline in 9c0c906; this consolidates + guards it against
+# regression (the original silent bug shipped with no test).
+# ---------------------------------------------------------------------------
+
+def test_bug228_challenge_relative_comment_was_empty_now_found(tmp_path):
+    """Run from repo root, `.review.csv` stores `feedback/KC2-*.md` (challenge-
+    relative). comment_for's bare Path() resolved it against CWD -> empty comment
+    -> grades pushed with NO feedback (silent)."""
+    challenge = tmp_path / "grading" / "kc2"
+    (challenge / "feedback").mkdir(parents=True)
+    fb = challenge / "feedback" / "KC2-TESTXYZ.md"
+    fb.write_text("## Comment to student\n\nGreat work on the joins.", encoding="utf-8")
+
+    # BUG: the raw challenge-relative path is empty from a repo-root CWD
+    assert comment_for("feedback/KC2-TESTXYZ.md") == ""
+    # FIX: resolved against the challenge dir, the comment loads
+    resolved = resolve_feedback_file(challenge, "feedback/KC2-TESTXYZ.md")
+    assert resolved == str(fb)
+    assert "Great work on the joins." in comment_for(resolved)
+
+
+def test_resolve_feedback_file_passthroughs(tmp_path):
+    absfile = tmp_path / "x.md"
+    assert resolve_feedback_file(tmp_path / "grading", str(absfile)) == str(absfile)  # absolute
+    assert resolve_feedback_file(tmp_path, "") == ""                                   # empty
+
+
+def test_resolve_feedback_file_keeps_a_path_that_already_exists(tmp_path, monkeypatch):
+    """Run from inside the challenge dir: `feedback/x.md` already resolves against
+    CWD, so it passes through — no double-prefixing."""
+    (tmp_path / "feedback").mkdir()
+    (tmp_path / "feedback" / "x.md").write_text("## Comment to student\n\nok", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+    assert resolve_feedback_file(tmp_path, "feedback/x.md") == "feedback/x.md"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -156,6 +156,26 @@ def comment_for(feedback_file: str) -> str:
     return t.split("## Comment to student", 1)[1].strip()
 
 
+def resolve_feedback_file(challenge: Path, feedback_file: str) -> str:
+    """Resolve a `.review.csv` feedback_file path against the challenge dir (#228).
+
+    Paths in `.review.csv` are challenge-relative (e.g. `feedback/KC2-ABC.md`), but
+    `comment_for` / `extract_hold_token` do a bare `Path()` that resolves against CWD.
+    Run from the repo root with `--challenge-dir grading/kc2`, that looked in
+    `<root>/feedback/...`, found nothing, and returned an empty comment — so EVERY
+    comment came back blank and only grades pushed (silent). The fix (9c0c906)
+    prefixes the challenge dir; this consolidates the three call sites into one
+    tested helper and adds passthrough for absolute paths and paths that already
+    exist as-is (run from inside the challenge dir), so it never double-prefixes.
+    """
+    if not feedback_file:
+        return feedback_file
+    p = Path(feedback_file)
+    if p.is_absolute() or p.exists():
+        return feedback_file
+    return str(challenge / feedback_file)
+
+
 # Transparency disclosure (default, no opt-out): every AI-drafted feedback
 # comment carries this tag so a student always knows the words were drafted by
 # AI and reviewed by their instructor — never passed off as solely the
@@ -1423,12 +1443,10 @@ def main() -> int:
     hold_by_key: dict[str, str] = {}
     if not args.no_hold_tokens and not args.grade_only:
         for r in rows:
-            ff = r.get("feedback_file", "") or ""
+            ff = resolve_feedback_file(challenge, r.get("feedback_file", "") or "")  # #228
             if not ff:
                 continue
-            # Resolve feedback_file relative to challenge dir
-            ff_resolved = str(challenge / ff)
-            tok = extract_hold_token(ff_resolved)
+            tok = extract_hold_token(ff)
             if tok:
                 hold_by_key[r.get("key", "")] = tok
 
@@ -1438,9 +1456,7 @@ def main() -> int:
         grade = (r.get("final_grade") or "").strip() or (r.get("recommended_score") or "").strip()
         # Issue: feedback_file paths in .review.csv are relative to challenge dir,
         # but comment_for() uses Path() relative to CWD. Resolve them here.
-        feedback_file = r.get("feedback_file", "")
-        if feedback_file:
-            feedback_file = str(challenge / feedback_file)
+        feedback_file = resolve_feedback_file(challenge, r.get("feedback_file", ""))  # #228
         comment = "" if args.grade_only else (
             append_disclosure_tag(comment_for(feedback_file)) or args.default_comment)
         uid = resolve_user_id(r.get("submission_file", ""), subs)
@@ -1482,10 +1498,7 @@ def main() -> int:
     if not args.no_lock_check and not args.grade_only and lock_state.get("locked_now"):
         for r in rows:
             key = r.get("key", "")
-            # Resolve feedback_file relative to challenge dir
-            feedback_file = r.get("feedback_file", "")
-            if feedback_file:
-                feedback_file = str(challenge / feedback_file)
+            feedback_file = resolve_feedback_file(challenge, r.get("feedback_file", ""))  # #228
             comment = comment_for(feedback_file) or args.default_comment
             if comment and comment_has_resubmit_language(comment):
                 locked_resubmit_keys.append((key, comment))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.25"
+version = "1.7.26"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.25"
+version = "1.7.26"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Builds on your inline fix `9c0c906` (already on `main`) — incorporating the salvageable parts of the now-closed duplicate #229 rather than re-doing the fix.

## What this adds on top of 9c0c906
- **DRY** — the three inline `str(challenge / feedback_file)` sites (HOLD extraction, plan-building, lock/resubmit check) collapse into one `resolve_feedback_file(challenge, feedback_file)` helper. Also passes through absolute paths and paths that already exist as-is (run from inside the challenge dir), so it never double-prefixes. **Behavior is unchanged from your fix.**
- **The regression test your commit shipped without** — a silent bug with no guard. It reproduces the failure (`comment_for("feedback/KC2-*.md") == ""` from a repo-root CWD) and confirms the resolved path loads the comment.
- **Version bump `1.7.25 → 1.7.26`** — so vendored course-repo copies can detect via `--version` that they need to `git pull` to get the fix (the real forward risk: DS 460 et al. still carry the bug until their vendored `canvas-toolbox` is pulled).

## Verify
96 grader_push helper tests pass (3 new); full suite green under `uv run pytest`; ruff clean.

Closes #228 (fixed by `9c0c906`, hardened + tested here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
