### PR TITLE
feat(grader_push): Andon — refuse re-comment/re-grade of already-graded work (PR 1/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.27] — 2026-07-23
+
+**Andon: `grader_push.py` now refuses to re-comment/re-grade an already-graded submission by default — stops the "4 comments per student" bug.**
+
+Canvas **appends** comments (never replaces), and the collision guard only *warned* (bypassable), while `.push_log` idempotency is per-repo and `--force`-defeatable. So re-runs stacked grader comments — some students got 4 — and stale mirrors graded old attempts. This is the stop-the-bleeding half; the resubmission-aware `--regrade` behavior (light comment, supersede-not-stack) is the follow-up.
+
+### Changed
+- **`grader_push.py`** — the push plan now **hard-skips any submission Canvas has already graded** (`graded_at` set) unless `--regrade` is passed. Default mode therefore cannot stack a second comment. `fetch_submissions` now also returns `graded_at` / `submitted_at` / `workflow_state` (needed for the gate and the coming resubmission classifier). Independent of `--force` (which only overrides the local `.push_log`), so it also closes the `--force`-stacks-comments hole.
+
+### Added
+- **`grader_push.py`** — `--regrade` flag: explicit opt-in to touch already-graded submissions (resubmissions/corrections). Pure `is_already_graded()` + `regrade_gate()` helpers with unit tests.
+
+---
+
 ## [1.7.26] — 2026-07-22
 
 **Harden + test the `grader_push.py` empty-comment fix.** (#228)

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -32,6 +32,8 @@ from grader_push import (  # noqa: E402
     push_precheck,
     comment_for,
     resolve_feedback_file,
+    is_already_graded,
+    regrade_gate,
     assignment_posts_manually,
     post_assignment_grades,
 )
@@ -537,6 +539,36 @@ def test_every_deprecated_tag_constant_is_detected(tmp_path):
     for i, dep in enumerate(DEPRECATED_DISCLOSURE_TAGS):
         fb = _write_fb(tmp_path, f"KC1-{i}.md", f"body\n\n{dep}\n")
         assert find_deprecated_disclosure_tags([fb]), f"not detected: {dep!r}"
+
+
+# ---------------------------------------------------------------------------
+# is_already_graded + regrade_gate — the duplicate-comment Andon
+# Default REFUSES already-graded submissions so re-runs never stack a 2nd comment.
+# ---------------------------------------------------------------------------
+
+def test_is_already_graded_by_graded_at():
+    assert is_already_graded({"graded_at": "2026-07-22T10:00:00Z"}) is True
+    assert is_already_graded({"graded_at": None}) is False
+    assert is_already_graded({}) is False           # unknown -> not graded (don't over-gate)
+    assert is_already_graded({"grade": "A"}) is False  # a display grade alone isn't the signal
+
+
+def test_regrade_gate_allows_first_time_grade():
+    allowed, reason = regrade_gate(already_graded=False, regrade=False)
+    assert allowed is True and reason == ""
+
+
+def test_regrade_gate_refuses_already_graded_by_default():
+    """The Andon: an already-graded submission is refused unless --regrade — this
+    is what stops the 4-comments-per-student stacking."""
+    allowed, reason = regrade_gate(already_graded=True, regrade=False)
+    assert allowed is False
+    assert "--regrade" in reason
+
+
+def test_regrade_gate_allows_already_graded_with_flag():
+    allowed, reason = regrade_gate(already_graded=True, regrade=True)
+    assert allowed is True and reason == ""
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -176,6 +176,32 @@ def resolve_feedback_file(challenge: Path, feedback_file: str) -> str:
     return str(challenge / feedback_file)
 
 
+def is_already_graded(submission: dict) -> bool:
+    """True if Canvas has ALREADY graded this submission (`graded_at` is set).
+
+    The Andon trigger: Canvas APPENDS comments (never replaces), so pushing to an
+    already-graded submission on a re-run stacks a second grader comment — 4
+    comments/student were observed in the field. `graded_at` is the honest signal
+    that this is not a first-time grade.
+    """
+    return bool(submission) and submission.get("graded_at") is not None
+
+
+def regrade_gate(already_graded: bool, regrade: bool) -> tuple:
+    """The duplicate-comment Andon: default REFUSES to touch an already-graded
+    submission. Returns (allowed, reason).
+
+    - not graded -> allowed (first-time grade, the normal path).
+    - graded + --regrade -> allowed (explicit, deliberate re-grade of a
+      resubmission/correction; the resubmission-aware light-comment + supersede
+      behavior is the follow-up PR).
+    - graded, no flag -> REFUSED, so a re-run can never stack another comment.
+    """
+    if not already_graded or regrade:
+        return True, ""
+    return False, "already graded — pass --regrade for resubmissions (default won't re-comment)"
+
+
 # Transparency disclosure (default, no opt-out): every AI-drafted feedback
 # comment carries this tag so a student always knows the words were drafted by
 # AI and reviewed by their instructor — never passed off as solely the
@@ -621,11 +647,12 @@ def fetch_submissions(base: str, cid: str, headers: dict, aid: str,
                       include_comments: bool = False) -> list[dict]:
     """All submissions for the assignment.
 
-    Default: returns lean {user_id, id, grade, score} per submission.
-    `grade` is the displayed string ("3.5" / "B+" / "complete" / None);
-    `score` is the numeric value (float or None). Both are needed for
-    the issue #96 regression check (numeric vs letter vs pass/fail
-    direction comparison).
+    Default: returns lean {user_id, id, grade, score, graded_at, submitted_at,
+    workflow_state} per submission. `grade` is the displayed string ("3.5" /
+    "B+" / "complete" / None); `score` is the numeric value (float or None) —
+    both needed for the issue #96 regression check. `graded_at` / `submitted_at`
+    / `workflow_state` drive the duplicate-comment Andon (already-graded gate)
+    and the resubmission classifier.
 
     If `include_comments`, paginates with include[]=submission_comments
     and returns the full Canvas submission payloads (each dict has a
@@ -655,6 +682,11 @@ def fetch_submissions(base: str, cid: str, headers: dict, aid: str,
                     "id": s["id"],
                     "grade": s.get("grade"),
                     "score": s.get("score"),
+                    # Duplicate-comment Andon + resubmission classifier: graded_at set
+                    # = Canvas already graded this; submitted_at > graded_at = resubmission.
+                    "graded_at": s.get("graded_at"),
+                    "submitted_at": s.get("submitted_at"),
+                    "workflow_state": s.get("workflow_state"),
                 }
                 for s in batch
             ]
@@ -1155,6 +1187,13 @@ def main() -> int:
                          "because the canonical tag would get stacked on top of it at send-time. "
                          "Pass this flag to push anyway (rare; the stale tag stays in the "
                          "student-visible comment).")
+    ap.add_argument("--regrade", action="store_true",
+                    help="Allow pushing to submissions Canvas has ALREADY graded "
+                         "(resubmissions / corrections). DEFAULT REFUSES them so a re-run "
+                         "never stacks a second grader comment — Canvas appends comments and "
+                         "never replaces them (the 4-comments-per-student bug). The "
+                         "resubmission-aware behavior (one light comment, supersede-not-stack) "
+                         "lands in the follow-up; this flag is the explicit opt-in gate.")
     ap.add_argument("--auto-fix-workflow", action="store_true",
                     help="Issue #226: after pushing, if a just-pushed grade is still "
                          "workflow_state 'submitted' (Canvas didn't transition — common after a "
@@ -1417,7 +1456,10 @@ def main() -> int:
     # per row. The push loop looks up by uid to print before → after and refuse
     # silent regressions (lower-direction grade writes).
     existing_by_uid: dict[int, dict] = {
-        int(s["user_id"]): {"grade": s.get("grade"), "score": s.get("score")}
+        int(s["user_id"]): {"grade": s.get("grade"), "score": s.get("score"),
+                            "graded_at": s.get("graded_at"),
+                            "submitted_at": s.get("submitted_at"),
+                            "workflow_state": s.get("workflow_state")}
         for s in subs if s.get("user_id") is not None
     }
 
@@ -1451,6 +1493,7 @@ def main() -> int:
                 hold_by_key[r.get("key", "")] = tok
 
     plan = []
+    regrade_skipped = 0
     for r in rows:
         key = r.get("key", "")
         grade = (r.get("final_grade") or "").strip() or (r.get("recommended_score") or "").strip()
@@ -1461,11 +1504,19 @@ def main() -> int:
             append_disclosure_tag(comment_for(feedback_file)) or args.default_comment)
         uid = resolve_user_id(r.get("submission_file", ""), subs)
         done = key in pushed_keys and not args.force
-        ok = bool(grade and uid and (comment or args.grade_only)) and not done
+        # Duplicate-comment Andon: never re-comment/re-grade an already-graded
+        # submission unless --regrade (Canvas appends comments; re-runs stack them).
+        gate_ok, gate_reason = regrade_gate(
+            is_already_graded(existing_by_uid.get(uid, {}) if uid is not None else {}),
+            args.regrade)
+        ok = bool(grade and uid and (comment or args.grade_only)) and not done and gate_ok
         plan.append((key, uid, grade, comment, ok))
         hold = hold_by_key.get(key)
         if done:
             mark, why = "done", "  (already pushed)"
+        elif not gate_ok:
+            regrade_skipped += 1
+            mark, why = "SKIP", f"  ({gate_reason})"
         elif hold:
             mark, why = "HOLD", f"  ({hold} — comment will post; grade withheld)"
         elif ok:
@@ -1475,6 +1526,11 @@ def main() -> int:
         # FERPA-safe console: key, grade, matched?, comment preview — NO names
         print(f"  [{mark}] {key}: grade={grade or '—'}  matched={'yes' if uid else 'NO'}  "
               f"comment=\"{comment[:50].replace(chr(10), ' ')}…\"{why}")
+
+    if regrade_skipped:
+        print(f"\n⛔ {regrade_skipped} row(s) SKIPPED — already graded in Canvas. Default mode "
+              "never re-comments/re-grades (Canvas APPENDS comments; re-runs stack them — the "
+              "4-comments-per-student bug). Pass --regrade to push to resubmissions/corrections.")
 
     # ---- Issue #63 part 1: availability awareness ------------------------
     # ---- Issue #99: grading_type capture for posted_grade validation -----

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.26"
+version = "1.7.27"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.26"
+version = "1.7.27"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**PR 1 of 2 — the Andon.** Stops the "4 comments per student" bug now; PR 2 adds the resubmission-aware `--regrade` behavior (light comment, supersede-not-stack).

## The bug
Canvas **appends** comments (never replaces). The safeguards were all soft: the collision guard (#62) only *warned*, `.push_log` idempotency is per-repo and **`--force`-defeatable**, and grading the same student across runs sidesteps it. So re-runs stacked grader comments — some students got 4 — and stale mirrors graded old attempts.

## The gate (structural, not advisory)
The push plan now **hard-skips any submission Canvas has already graded** (`graded_at` set) unless `--regrade`:

| State | Default | `--regrade` |
|---|---|---|
| ungraded (`graded_at` null) | ✅ grade + comment | ✅ |
| already graded | ⛔ **SKIP** — "already graded — pass --regrade for resubmissions" | ✅ push |

So default mode **structurally cannot stack a second comment.** It's independent of `--force` (which only overrides the local `.push_log`), so it also closes the `--force`-stacks-comments hole. A re-run of a completed batch now skips everything with a clear count + hint instead of re-commenting.

`fetch_submissions` now also returns `graded_at` / `submitted_at` / `workflow_state` (the gate needs `graded_at`; PR 2's resubmission classifier needs `submitted_at > graded_at`).

## Scope boundary
This PR's `--regrade` just *relaxes* the gate (the explicit opt-in). It does **not** yet enforce resubmission-only or do supersede-not-stack — that's PR 2. So `--regrade` here still appends; the point of PR 1 is that **default no longer does.**

## Verify
4 unit tests: `is_already_graded` (graded_at is the signal, not a display grade), and `regrade_gate` (first-time allowed, already-graded refused by default, allowed with the flag). Full suite green under `uv run pytest`; ruff clean.

Bumps `1.7.26` → `1.7.27` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
