### PR TITLE
feat(grader_push): --regrade resubmission-only + supersede-not-stack (PR 2/2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.28] — 2026-07-23
+
+**`--regrade` is now resubmission-only and supersede-not-stack — the poka-yoke completing the Andon.**
+
+PR 2 of 2 (PR 1, v1.7.27, added the default hard gate). `--regrade` no longer just relaxes the gate; it enforces "never re-grade unless a late resubmission" and replaces the prior comment instead of adding another.
+
+### Changed
+- **`grader_push.py`** — `--regrade` now admits **only resubmissions** (`submitted_at > graded_at`), via a `classify_submission_state()` step (`ungraded` / `graded_current` / `resubmitted`). Unchanged already-graded work is refused *even with* `--regrade` ("already graded, no new submission — nothing to re-grade"). And on the resubmissions it does push, it **supersedes**: deletes the prior grader comment(s) recorded in `.push_log.md` for those rows, then re-posts one — so a resubmission ends with a single fresh comment, not a stacked pile. Only our own logged comment_ids are touched (never student/TA comments); best-effort + logged, and a missing prior (fresh clone) is a no-op.
+
+### Added
+- Pure `classify_submission_state()` + `comments_to_supersede()` helpers; `regrade_gate()` now takes the classified state. Unit tests for the classifier, the resubmission-only gate, and the supersede selection.
+
+Together with the Andon (v1.7.27): default never re-comments; `--regrade` touches only genuine resubmissions and replaces rather than stacks. That's the full "never comment/re-grade unless a late resubmission" behavior.
+
+---
+
 ## [1.7.27] — 2026-07-23
 
 **Andon: `grader_push.py` now refuses to re-comment/re-grade an already-graded submission by default — stops the "4 comments per student" bug.**

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -33,7 +33,9 @@ from grader_push import (  # noqa: E402
     comment_for,
     resolve_feedback_file,
     is_already_graded,
+    classify_submission_state,
     regrade_gate,
+    comments_to_supersede,
     assignment_posts_manually,
     post_assignment_grades,
 )
@@ -553,22 +555,58 @@ def test_is_already_graded_by_graded_at():
     assert is_already_graded({"grade": "A"}) is False  # a display grade alone isn't the signal
 
 
+# --- classify_submission_state (resubmission classifier) -------------------
+
+def test_classify_ungraded():
+    assert classify_submission_state({"graded_at": None}) == "ungraded"
+    assert classify_submission_state({}) == "ungraded"
+
+
+def test_classify_graded_current_when_no_newer_submission():
+    assert classify_submission_state(
+        {"graded_at": "2026-07-22T12:00:00Z", "submitted_at": "2026-07-20T09:00:00Z"}
+    ) == "graded_current"
+
+
+def test_classify_resubmitted_when_submitted_after_graded():
+    assert classify_submission_state(
+        {"graded_at": "2026-07-20T09:00:00Z", "submitted_at": "2026-07-22T12:00:00Z"}
+    ) == "resubmitted"
+
+
+# --- regrade_gate: Andon + resubmission-only -------------------------------
+
 def test_regrade_gate_allows_first_time_grade():
-    allowed, reason = regrade_gate(already_graded=False, regrade=False)
-    assert allowed is True and reason == ""
+    assert regrade_gate("ungraded", regrade=False) == (True, "")
 
 
-def test_regrade_gate_refuses_already_graded_by_default():
-    """The Andon: an already-graded submission is refused unless --regrade — this
-    is what stops the 4-comments-per-student stacking."""
-    allowed, reason = regrade_gate(already_graded=True, regrade=False)
-    assert allowed is False
-    assert "--regrade" in reason
+def test_regrade_gate_refuses_graded_by_default():
+    """The Andon: any already-graded submission is refused unless --regrade —
+    what stops the 4-comments-per-student stacking."""
+    for state in ("graded_current", "resubmitted"):
+        allowed, reason = regrade_gate(state, regrade=False)
+        assert allowed is False and "--regrade" in reason
 
 
-def test_regrade_gate_allows_already_graded_with_flag():
-    allowed, reason = regrade_gate(already_graded=True, regrade=True)
-    assert allowed is True and reason == ""
+def test_regrade_only_admits_resubmissions():
+    """--regrade is resubmission-only: a resubmission passes, but unchanged
+    already-graded work is still refused ('never re-grade unless a resubmission')."""
+    assert regrade_gate("resubmitted", regrade=True) == (True, "")
+    allowed, reason = regrade_gate("graded_current", regrade=True)
+    assert allowed is False and "resubmission-only" in reason
+
+
+# --- comments_to_supersede (supersede-not-stack selection) ------------------
+
+def test_supersede_selects_only_pushable_prior_comments():
+    ledger = [("KC2-A", 111), ("KC2-B", 222), ("KC2-C", 333)]
+    # only A and C are being re-pushed now
+    out = comments_to_supersede(ledger, {"KC2-A", "KC2-C"})
+    assert out == [("KC2-A", 111), ("KC2-C", 333)]
+
+
+def test_supersede_empty_when_no_prior_comments():
+    assert comments_to_supersede([], {"KC2-A"}) == []
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -187,19 +187,48 @@ def is_already_graded(submission: dict) -> bool:
     return bool(submission) and submission.get("graded_at") is not None
 
 
-def regrade_gate(already_graded: bool, regrade: bool) -> tuple:
-    """The duplicate-comment Andon: default REFUSES to touch an already-graded
-    submission. Returns (allowed, reason).
+def classify_submission_state(submission: dict) -> str:
+    """`ungraded` | `graded_current` | `resubmitted` — from Canvas's own timestamps.
 
-    - not graded -> allowed (first-time grade, the normal path).
-    - graded + --regrade -> allowed (explicit, deliberate re-grade of a
-      resubmission/correction; the resubmission-aware light-comment + supersede
-      behavior is the follow-up PR).
-    - graded, no flag -> REFUSED, so a re-run can never stack another comment.
+    `resubmitted` = graded, then a NEWER submission (`submitted_at > graded_at`):
+    the ONLY state `--regrade` acts on ("never re-grade unless a late resubmission").
+    ISO-8601 UTC strings compare lexicographically == chronologically.
     """
-    if not already_graded or regrade:
+    if not is_already_graded(submission):
+        return "ungraded"
+    ga = submission.get("graded_at")
+    sa = submission.get("submitted_at")
+    if sa and ga and sa > ga:
+        return "resubmitted"
+    return "graded_current"
+
+
+def regrade_gate(state: str, regrade: bool) -> tuple:
+    """Duplicate-comment Andon + resubmission-only re-grade. Returns (allowed, reason).
+
+    - `ungraded` -> allowed (first-time grade, the normal path).
+    - graded, no `--regrade` -> REFUSED, so a re-run can never stack a 2nd comment.
+    - `--regrade` + `resubmitted` -> allowed (the only re-grade path).
+    - `--regrade` + `graded_current` -> REFUSED: already graded, no new submission —
+      nothing to re-grade. Keeps re-grading tied to an actual resubmission.
+    """
+    if state == "ungraded":
         return True, ""
-    return False, "already graded — pass --regrade for resubmissions (default won't re-comment)"
+    if not regrade:
+        return False, "already graded — pass --regrade for resubmissions (default won't re-comment)"
+    if state == "resubmitted":
+        return True, ""
+    return False, "already graded, no new submission — nothing to re-grade (--regrade is resubmission-only)"
+
+
+def comments_to_supersede(ledger: list, pushable_keys) -> list:
+    """Prior grader comments to delete before re-posting (--regrade supersede-not-
+    stack). `ledger` = [(key, comment_id)] from `_read_comment_ledger`; return only
+    entries whose key is being re-pushed now, so each resubmission ends with ONE
+    fresh comment instead of a stacked pile.
+    """
+    keys = set(pushable_keys)
+    return [(k, c) for (k, c) in ledger if k in keys]
 
 
 # Transparency disclosure (default, no opt-out): every AI-drafted feedback
@@ -1188,12 +1217,13 @@ def main() -> int:
                          "Pass this flag to push anyway (rare; the stale tag stays in the "
                          "student-visible comment).")
     ap.add_argument("--regrade", action="store_true",
-                    help="Allow pushing to submissions Canvas has ALREADY graded "
-                         "(resubmissions / corrections). DEFAULT REFUSES them so a re-run "
-                         "never stacks a second grader comment — Canvas appends comments and "
-                         "never replaces them (the 4-comments-per-student bug). The "
-                         "resubmission-aware behavior (one light comment, supersede-not-stack) "
-                         "lands in the follow-up; this flag is the explicit opt-in gate.")
+                    help="Re-grade RESUBMISSIONS only (submitted_at > graded_at). Default "
+                         "REFUSES any already-graded submission so a re-run never stacks a "
+                         "second grader comment (Canvas appends, never replaces — the "
+                         "4-comments-per-student bug). --regrade admits ONLY genuine "
+                         "resubmissions (not unchanged already-graded work), and supersedes "
+                         "the prior grader comment (deletes it, then re-posts ONE) instead of "
+                         "stacking. Grade value updates as normal.")
     ap.add_argument("--auto-fix-workflow", action="store_true",
                     help="Issue #226: after pushing, if a just-pushed grade is still "
                          "workflow_state 'submitted' (Canvas didn't transition — common after a "
@@ -1504,11 +1534,12 @@ def main() -> int:
             append_disclosure_tag(comment_for(feedback_file)) or args.default_comment)
         uid = resolve_user_id(r.get("submission_file", ""), subs)
         done = key in pushed_keys and not args.force
-        # Duplicate-comment Andon: never re-comment/re-grade an already-graded
-        # submission unless --regrade (Canvas appends comments; re-runs stack them).
-        gate_ok, gate_reason = regrade_gate(
-            is_already_graded(existing_by_uid.get(uid, {}) if uid is not None else {}),
-            args.regrade)
+        # Duplicate-comment Andon + resubmission-only re-grade: default refuses any
+        # already-graded submission; --regrade admits ONLY resubmissions (not
+        # unchanged already-graded work). Canvas appends comments; re-runs stack them.
+        _sub_state = classify_submission_state(
+            existing_by_uid.get(uid, {}) if uid is not None else {})
+        gate_ok, gate_reason = regrade_gate(_sub_state, args.regrade)
         ok = bool(grade and uid and (comment or args.grade_only)) and not done and gate_ok
         plan.append((key, uid, grade, comment, ok))
         hold = hold_by_key.get(key)
@@ -1744,6 +1775,34 @@ def main() -> int:
         if input("Type 'push' to confirm: ").strip().lower() != "push":
             print("Aborted.")
             return 1
+
+    # --regrade supersede-not-stack: delete our prior grader comment(s) for the rows
+    # we're about to re-push, so each resubmission ends with ONE fresh comment, not a
+    # stacked pile. Best-effort + logged; a missing prior (fresh clone / no ledger) is
+    # a no-op. Only our own logged comment_ids are touched — never student/TA comments.
+    if args.regrade and not args.grade_only:
+        supersede = comments_to_supersede(
+            _read_comment_ledger(log, str(args.assignment_id)), {p[0] for p in pushable})
+        if supersede:
+            uid_by_key = {p[0]: p[1] for p in pushable}
+            print(f"\n♻️  --regrade: superseding {len(supersede)} prior grader comment(s) "
+                  "so each resubmission gets ONE fresh comment (not stacked):")
+            with log.open("a", encoding="utf-8") as lg:
+                for s_key, s_comment_id in supersede:
+                    s_uid = uid_by_key.get(s_key)
+                    if s_uid is None:
+                        continue
+                    resp = requests.delete(
+                        f"{base}/api/v1/courses/{cid}/assignments/{args.assignment_id}"
+                        f"/submissions/{s_uid}/comments/{s_comment_id}",
+                        headers=headers, timeout=_TIMEOUT)
+                    if resp.status_code < 400 or resp.status_code == 404:
+                        print(f"  superseded {s_key}: deleted prior comment {s_comment_id}")
+                        lg.write(f"- {s_key}: comment {s_comment_id} superseded (regrade) on "
+                                 f"assignment {args.assignment_id}\n")
+                    else:
+                        print(f"  (supersede note: {s_key} comment {s_comment_id} not deleted "
+                              f"— {resp.status_code}; the re-post will still land)")
 
     pushed = 0
     pushed_uids: set = set()  # #226: verify workflow_state transition after push

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.27"
+version = "1.7.28"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.27"
+version = "1.7.28"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**PR 2 of 2 — the poka-yoke completing the Andon** (PR 1 = the default hard gate, v1.7.27). This makes `--regrade` match your rule exactly: *never comment or re-grade unless it's a late resubmission, and then fewer comments + an updated score.*

## 1. Resubmission-only
`classify_submission_state()` splits already-graded work using Canvas's own timestamps:

| State | Meaning | `--regrade` |
|---|---|---|
| `ungraded` | `graded_at` null | (default path — full grade) |
| `graded_current` | graded, no newer submission | ⛔ refused **even with `--regrade`** — "nothing to re-grade" |
| `resubmitted` | `submitted_at > graded_at` | ✅ the only re-grade path |

So re-grading is structurally tied to an actual resubmission — you can't accidentally re-grade unchanged work.

## 2. Supersede-not-stack (the "fewer comments")
Before re-posting a resubmission's comment, it **deletes our prior grader comment(s)** for those rows (from the `.push_log.md` comment-id ledger), then posts **one** fresh comment. A resubmission ends with a single comment, not a stacked pile.
- Only **our own logged comment_ids** are touched — never student/TA comments.
- Best-effort + logged; a missing prior (fresh clone / no ledger) is a no-op, and skipped on `--grade-only`.

## Net behavior (with the Andon)
- **Default:** never re-comments/re-grades an already-graded submission. (PR 1)
- **`--regrade`:** touches only genuine resubmissions, and **replaces** rather than stacks. (PR 2)

That's the full "never comment/re-grade unless a late resubmission" you asked for — as a structural boundary, not an advisory warning.

## Verify
`classify_submission_state` (ungraded / graded_current / resubmitted), the resubmission-only gate (default refuses graded; `--regrade` admits only resubmissions), and `comments_to_supersede` (only the rows being re-pushed). Full suite green under `uv run pytest`; ruff clean.

Bumps `1.7.27` → `1.7.28` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
