### PR TITLE
feat(grader): wire resubmission detector to the shared --regrade classifier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.29] — 2026-07-27
+
+**Resubmission detection and re-grade now share one definition — the report flags exactly what `--regrade` acts on.**
+
+Brings the `grader_fetch_resubmissions.py` detector onto `main` (from the `feature/grader-resubmissions` branch) and wires it to the same `classify_submission_state()` the `--regrade` gate uses, so the two can't drift.
+
+### Added
+- **`grader_fetch_resubmissions.py`** — detects submissions resubmitted after grading (`submitted_at > graded_at`) or never graded, and writes a FERPA-safe report (user_id + SpeedGrader links; `--all` scans a whole course). ITM 327 Spring 2026 had 21 resubmissions across 10 assignments go unnoticed for weeks — this surfaces them.
+
+### Changed
+- **`grader_push.py`** — `classify_submission_state()` now parses timestamps as datetimes instead of comparing ISO strings, so a resubmission with sub-second precision (`…:00.500Z` vs `…:00Z`, which string order mis-ranks) is classified correctly. It's the **single source of truth**: the detector imports it (not its own copy), and drops the old `workflow_state == "submitted"` pre-filter — so it also catches resubmissions whose workflow_state is stuck (issue #226), consistent with the re-grade gate.
+
+Net: detection and the `--regrade` action agree by construction — what the report shows is what gets re-graded.
+
+---
+
 ## [1.7.28] — 2026-07-23
 
 **`--regrade` is now resubmission-only and supersede-not-stack — the poka-yoke completing the Andon.**

--- a/docs/grading-readme.md
+++ b/docs/grading-readme.md
@@ -287,6 +287,13 @@ fresh `grader_fetch.py --challenge-dir grading/kc1 --assignment-id 12345`
 call lands at a fully-de-identified, leak-verified `submissions_deid/` ready
 for grading.
 
+**Finding resubmissions** — `grader_fetch_resubmissions.py` detects submissions a student
+resubmitted after being graded (`submitted_at > graded_at`). These are easy to overlook
+(they already have a grade), and Canvas's `needs_grading_count` doesn't explain why. It
+generates a FERPA-safe report (user_id only + SpeedGrader links); `--all` scans every
+assignment. It shares its "is this a resubmission" definition with `grader_push.py --regrade`
+(one `classify_submission_state`), so what the report flags is exactly what `--regrade` re-grades.
+
 ---
 
 ## The value-only / human-graded push path

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -574,6 +574,17 @@ def test_classify_resubmitted_when_submitted_after_graded():
     ) == "resubmitted"
 
 
+def test_classify_uses_datetime_not_string_comparison():
+    """A resubmission 500ms after grading: string comparison mis-orders it
+    ('.500Z' < 'Z' lexically) and would MISS the resubmission; datetime parsing
+    gets it right. Guards the shared classifier both the gate and the detector use."""
+    graded = "2026-07-22T12:00:00Z"
+    resubmit = "2026-07-22T12:00:00.500Z"   # 500ms later
+    assert resubmit < graded                 # string order is WRONG here...
+    assert classify_submission_state(
+        {"graded_at": graded, "submitted_at": resubmit}) == "resubmitted"  # ...datetime is right
+
+
 # --- regrade_gate: Andon + resubmission-only -------------------------------
 
 def test_regrade_gate_allows_first_time_grade():

--- a/lib/tools/grader_fetch_resubmissions.py
+++ b/lib/tools/grader_fetch_resubmissions.py
@@ -1,0 +1,396 @@
+#!/usr/bin/env python3
+"""
+grader_fetch_resubmissions.py — Detect and report Canvas resubmissions needing grading.
+
+Part of the canvas-toolbox generic grader skill (v1.7.12+). See:
+  - grading_readme.md (faculty-facing pipeline)
+  - lib/agents/canvas_grader.md (agent-facing pipeline)
+  - lib/agents/knowledge/grader_knowledge.md (FERPA two-zone architecture)
+
+WHY THIS EXISTS
+  Canvas marks submissions as "needs grading" when a student resubmits AFTER
+  receiving a grade. This happens when:
+    - Student receives "incomplete" or low grade
+    - Student fixes issues and resubmits
+    - Canvas detects submitted_at > graded_at → "needs grading" flag
+
+  Problem: These resubmissions are easy to overlook because:
+    1. They already have a grade (so don't show as "ungraded")
+    2. Canvas's needs_grading_count includes them but doesn't explain WHY
+    3. No built-in "show me resubmissions" filter in Canvas UI
+
+  Real-world impact: In ITM327 Spring 2026, 21 resubmissions across 10
+  assignments went unnoticed for weeks because only new/ungraded submissions
+  were being checked. This tool prevents that.
+
+WHAT IT DOES
+  1. Queries Canvas Submissions API for a course or specific assignment
+  2. Identifies submissions where:
+     - submitted_at > graded_at (resubmitted after grading), OR
+     - submitted but never graded (graded_at is null)
+  3. Generates a review report with:
+     - User IDs (no names — FERPA Zone 2)
+     - Submission timestamps
+     - Current grade status
+     - SpeedGrader links for review
+  4. Optionally scans ALL assignments with needs_grading_count > 0
+
+OUTPUT
+  Markdown file: `resubmissions_report_<assignment_id>.md` or
+                 `resubmissions_report_all.md`
+
+  Contains:
+    - Summary table of resubmissions by assignment
+    - Per-student breakdown
+    - SpeedGrader URLs for instructor review
+    - Grade decision template (JSON format for grader_push.py)
+
+FERPA / SECURITY BOUNDARY
+  * Output files use user_id only (Canvas internal DB ID, not directory info)
+  * No student names in filenames, console output, or reports
+  * SpeedGrader links are safe (require Canvas login + instructor role)
+  * Review reports are FERPA Zone 2 compliant
+
+WORKFLOW (with grader_push.py)
+  1. Fetch resubmissions:
+       python grader_fetch_resubmissions.py --course-id 415322 --all
+
+  2. Review submissions in Canvas SpeedGrader (links in report)
+
+  3. Create grades JSON:
+       {
+         "assignment_id": 16858475,
+         "grades": [
+           {"user_id": 12345, "grade": "complete", "comment": "Good work."}
+         ]
+       }
+
+  4. Push grades with AI disclosure (v1.7.12+):
+       python grader_push.py --grades-file grades.json
+
+USAGE
+  # Check specific assignment
+  python grader_fetch_resubmissions.py \\
+    --course-id 415322 \\
+    --assignment-id 16858475
+
+  # Check all assignments with needs_grading_count > 0
+  python grader_fetch_resubmissions.py \\
+    --course-id 415322 \\
+    --all
+
+  # Output to specific directory
+  python grader_fetch_resubmissions.py \\
+    --course-id 415322 \\
+    --all \\
+    --output-dir grading/resubmissions
+
+DESIGN NOTES
+  * Queries submissions API (not gradebook) for real-time status
+  * Handles Canvas's inconsistent needs_grading_count (reports actual state)
+  * No auto-grading (manual review required for resubmissions)
+  * Compatible with grader_push.py for grade submission
+"""
+
+import os
+import sys
+import argparse
+import requests
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Dict
+
+# Single source of truth for "is this a resubmission" — shared with the
+# grader_push.py --regrade gate so detection and the re-grade action agree.
+from grader_push import classify_submission_state
+
+# Canvas API setup
+BASE_URL_DEFAULT = 'https://byui.instructure.com'
+
+
+def get_canvas_config():
+    """Get Canvas API token and base URL from environment."""
+    token = os.getenv('CANVAS_API_TOKEN')
+    if not token:
+        print("Error: CANVAS_API_TOKEN environment variable not set", file=sys.stderr)
+        print("Set it with: export CANVAS_API_TOKEN='your-token-here'", file=sys.stderr)
+        sys.exit(1)
+
+    base_url = os.getenv('CANVAS_BASE_URL', BASE_URL_DEFAULT)
+    return token, base_url
+
+
+def fetch_assignment_info(course_id: int, assignment_id: int, headers: dict, base_url: str) -> Dict:
+    """Fetch assignment name and metadata."""
+    url = f'{base_url}/api/v1/courses/{course_id}/assignments/{assignment_id}'
+    try:
+        response = requests.get(url, headers=headers, timeout=30)
+        response.raise_for_status()
+        return response.json()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching assignment {assignment_id}: {e}", file=sys.stderr)
+        return {'name': f'Unknown Assignment {assignment_id}', 'id': assignment_id}
+
+
+def fetch_resubmissions(course_id: int, assignment_id: int, headers: dict, base_url: str) -> List[Dict]:
+    """
+    Fetch all resubmissions for an assignment.
+
+    Returns submissions where:
+    - submitted_at > graded_at (resubmitted after grading), OR
+    - submitted but never graded (graded_at is null)
+    """
+    url = f'{base_url}/api/v1/courses/{course_id}/assignments/{assignment_id}/submissions'
+    params = {'per_page': 100}
+
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=30)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching submissions: {e}", file=sys.stderr)
+        return []
+
+    submissions = response.json()
+    resubmissions = []
+
+    for s in submissions:
+        submitted_at = s.get('submitted_at')
+        if not submitted_at:
+            continue  # no real attempt to review
+
+        # SINGLE definition of "resubmission" — shared with grader_push.py's
+        # --regrade gate (classify_submission_state), so what this report flags is
+        # exactly what --regrade will act on. Timestamp-based, so it also catches
+        # resubmissions whose workflow_state is stuck at "graded" (issue #226).
+        state = classify_submission_state(s)
+        if state == 'resubmitted':
+            reason = 'Resubmitted after grading'
+        elif state == 'ungraded':
+            reason = 'Never graded'
+        else:  # graded_current — already graded, no newer submission
+            continue
+
+        resubmissions.append({
+            'user_id': s['user_id'],
+            'submitted_at': submitted_at,
+            'graded_at': s.get('graded_at'),
+            'current_grade': s.get('grade'),
+            'workflow_state': s.get('workflow_state'),
+            'attempt': s.get('attempt'),
+            'reason': reason,
+        })
+
+    return resubmissions
+
+
+def get_assignments_needing_grading(course_id: int, headers: dict, base_url: str) -> List[Dict]:
+    """Fetch all assignments with needs_grading_count > 0."""
+    url = f'{base_url}/api/v1/courses/{course_id}/assignments'
+    params = {'per_page': 100}
+
+    try:
+        response = requests.get(url, headers=headers, params=params, timeout=30)
+        response.raise_for_status()
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching assignments: {e}", file=sys.stderr)
+        return []
+
+    assignments = response.json()
+
+    needs_grading = []
+    for a in assignments:
+        count = a.get('needs_grading_count', 0)
+        if count > 0:
+            needs_grading.append({
+                'id': a['id'],
+                'name': a['name'],
+                'needs_grading_count': count,
+                'due_at': a.get('due_at'),
+                'points_possible': a.get('points_possible')
+            })
+
+    return needs_grading
+
+
+def generate_report(course_id: int, assignment_id: int, assignment_name: str,
+                   resubmissions: List[Dict], base_url: str) -> str:
+    """Generate Markdown report for instructor review."""
+
+    timestamp = datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M UTC')
+
+    report = f"""# Resubmissions Needing Grading
+
+**Assignment**: {assignment_name} ({assignment_id})
+**Course ID**: {course_id}
+**Generated**: {timestamp}
+**Resubmissions Found**: {len(resubmissions)}
+
+---
+
+## Summary
+
+This assignment has {len(resubmissions)} resubmission(s) where students submitted AFTER receiving a grade.
+Canvas marks these as "needs grading" but they require manual review.
+
+"""
+
+    if not resubmissions:
+        report += "✅ No resubmissions found. All submissions are up to date.\n"
+        return report
+
+    report += "## Resubmissions\n\n"
+
+    for r in resubmissions:
+        report += f"""### user_id {r['user_id']}
+
+- **Reason**: {r['reason']}
+- **Submitted**: {r['submitted_at']}
+- **Last graded**: {r['graded_at'] or 'NEVER'}
+- **Current grade**: {r['current_grade'] or 'None'}
+- **Attempt**: {r['attempt']}
+- **SpeedGrader**: {base_url}/courses/{course_id}/gradebook/speed_grader?assignment_id={assignment_id}&student_id={r['user_id']}
+
+"""
+
+    report += """---
+
+## Next Steps
+
+1. **Review each submission** using the SpeedGrader links above
+2. **Determine new grades** based on the resubmission
+3. **Create grades JSON** for grader_push.py:
+
+```json
+{
+  "assignment_id": """ + str(assignment_id) + """,
+  "assignment_name": \"""" + assignment_name + """\",
+  "grades": [
+"""
+
+    for i, r in enumerate(resubmissions):
+        comma = "," if i < len(resubmissions) - 1 else ""
+        report += f"""    {{"user_id": {r['user_id']}, "grade": "complete", "comment": ""}}{comma}
+"""
+
+    report += """  ]
+}
+```
+
+4. **Push grades** with AI disclosure (v1.7.12+):
+   ```bash
+   python grader_push.py --grades-file grades.json
+   ```
+
+---
+
+**FERPA Zone 2**: This report uses user_id only (no names).
+**Canvas-Toolbox**: v1.7.12+ compatible
+"""
+
+    return report
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Detect Canvas resubmissions needing grading',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Check specific assignment
+  python grader_fetch_resubmissions.py --course-id 415322 --assignment-id 16858475
+
+  # Check all assignments with needs_grading_count > 0
+  python grader_fetch_resubmissions.py --course-id 415322 --all
+
+  # Custom output directory
+  python grader_fetch_resubmissions.py --course-id 415322 --all --output-dir grading/resubmissions
+        """
+    )
+
+    parser.add_argument('--course-id', type=int, required=True,
+                       help='Canvas course ID')
+    parser.add_argument('--assignment-id', type=int,
+                       help='Specific assignment ID to check')
+    parser.add_argument('--all', action='store_true',
+                       help='Check all assignments with needs_grading_count > 0')
+    parser.add_argument('--output-dir', type=str, default='.',
+                       help='Output directory for reports (default: current directory)')
+    parser.add_argument('--base-url', type=str,
+                       help=f'Canvas base URL (default: {BASE_URL_DEFAULT} or CANVAS_BASE_URL env var)')
+
+    args = parser.parse_args()
+
+    if not args.assignment_id and not args.all:
+        parser.error('Must specify either --assignment-id or --all')
+
+    # Get Canvas API config
+    token, base_url = get_canvas_config()
+    if args.base_url:
+        base_url = args.base_url
+
+    headers = {
+        'Authorization': f'Bearer {token}',
+        'Content-Type': 'application/json'
+    }
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    total_resubmissions = 0
+
+    if args.all:
+        print(f"Fetching all assignments with ungraded submissions (course {args.course_id})...")
+        assignments = get_assignments_needing_grading(args.course_id, headers, base_url)
+
+        if not assignments:
+            print("No assignments found with needs_grading_count > 0")
+            return
+
+        print(f"\nFound {len(assignments)} assignments to check:\n")
+
+        for a in assignments:
+            print(f"Checking: {a['name']} ({a['id']})...")
+            resubmissions = fetch_resubmissions(args.course_id, a['id'], headers, base_url)
+
+            if resubmissions:
+                total_resubmissions += len(resubmissions)
+                print(f"  ✓ {len(resubmissions)} resubmission(s) found")
+
+                report = generate_report(args.course_id, a['id'], a['name'], resubmissions, base_url)
+                report_file = output_dir / f"resubmissions_{a['id']}_{a['name'].replace(' ', '_').replace(':', '')[:50]}.md"
+                report_file.write_text(report)
+                print(f"  → Report: {report_file}")
+            else:
+                print(f"  • No resubmissions")
+
+            print()
+
+        print(f"Total resubmissions across all assignments: {total_resubmissions}")
+        print(f"Reports saved to: {output_dir}/")
+
+    else:
+        # Single assignment
+        assignment_info = fetch_assignment_info(args.course_id, args.assignment_id, headers, base_url)
+        assignment_name = assignment_info['name']
+
+        print(f"Checking: {assignment_name} ({args.assignment_id})...")
+        resubmissions = fetch_resubmissions(args.course_id, args.assignment_id, headers, base_url)
+
+        if resubmissions:
+            print(f"\n✓ Found {len(resubmissions)} resubmission(s):")
+            for r in resubmissions:
+                print(f"  - user_id {r['user_id']}: {r['reason']}")
+
+            report = generate_report(args.course_id, args.assignment_id, assignment_name,
+                                   resubmissions, base_url)
+            report_file = output_dir / f"resubmissions_{args.assignment_id}_{assignment_name.replace(' ', '_').replace(':', '')[:50]}.md"
+            report_file.write_text(report)
+            print(f"\nReport: {report_file}")
+        else:
+            print("\n• No resubmissions found")
+
+    print("\nDone.")
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -187,17 +187,31 @@ def is_already_graded(submission: dict) -> bool:
     return bool(submission) and submission.get("graded_at") is not None
 
 
+def _parse_canvas_ts(ts):
+    """Parse a Canvas ISO-8601 timestamp to a datetime, or None. Handles the `Z`
+    suffix and mixed precision (fractional seconds), so comparisons are robust
+    rather than relying on lexicographic string order."""
+    if not ts:
+        return None
+    from datetime import datetime
+    try:
+        return datetime.fromisoformat(str(ts).replace("Z", "+00:00"))
+    except (ValueError, TypeError):
+        return None
+
+
 def classify_submission_state(submission: dict) -> str:
     """`ungraded` | `graded_current` | `resubmitted` — from Canvas's own timestamps.
 
     `resubmitted` = graded, then a NEWER submission (`submitted_at > graded_at`):
     the ONLY state `--regrade` acts on ("never re-grade unless a late resubmission").
-    ISO-8601 UTC strings compare lexicographically == chronologically.
+    This is the SINGLE definition of "resubmission" — grader_fetch_resubmissions.py's
+    detector imports it too, so what the report flags is exactly what --regrade acts on.
     """
     if not is_already_graded(submission):
         return "ungraded"
-    ga = submission.get("graded_at")
-    sa = submission.get("submitted_at")
+    ga = _parse_canvas_ts(submission.get("graded_at"))
+    sa = _parse_canvas_ts(submission.get("submitted_at"))
     if sa and ga and sa > ga:
         return "resubmitted"
     return "graded_current"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.28"
+version = "1.7.29"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.28"
+version = "1.7.29"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Wires the resubmission **detector** and the `--regrade` **gate** to one definition of "is this a resubmission," so they can't drift. Brings `grader_fetch_resubmissions.py` onto `main` from the `feature/grader-resubmissions` branch (which this supersedes).

## The single source of truth
- **Before:** the detector had its own inline `submitted_at > graded_at`; `grader_push.py`'s `--regrade` had `classify_submission_state()`. Two copies → they'd drift the moment "resubmission" grew a nuance (a due-date/grace-window rule).
- **After:** the detector `import`s `classify_submission_state` from `grader_push` — literally the same function object (`d.classify is grader_push.classify` → True). **What the report flags is exactly what `--regrade` re-grades.**

## Two improvements that fell out of unifying
- **Datetime, not string comparison.** The classifier now parses timestamps (`Z → +00:00`) instead of comparing ISO strings. A sub-second resubmission (`…:00.500Z` vs `…:00Z`) is mis-ranked by string order (`.500Z` sorts *before* `Z`) and would be **missed**; datetime gets it right. Regression test added that fails under the old string compare.
- **Catches `#226`-stuck resubmissions.** The detector dropped its old `workflow_state == "submitted"` pre-filter (unreliable — the #226 bug leaves resubmissions stuck at `graded`). It now classifies by timestamp/graded_at, same as the gate — so a stuck resubmission still shows up.

## The detector
`grader_fetch_resubmissions.py --course-id … [--assignment-id … | --all]` → FERPA-safe report (user_id + SpeedGrader links) of submissions resubmitted after grading or never graded. (ITM 327 Spring 2026: 21 resubmissions across 10 assignments went unnoticed for weeks.)

## Verify
Classifier robustness test (sub-second resubmission), existing state tests, detector `--help` CI-safe, `d.classify is grader_push.classify` confirmed. Full suite green under `uv run pytest`; ruff clean.

Bumps `1.7.28` → `1.7.29` + CHANGELOG. The `feature/grader-resubmissions` branch can be deleted once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
