### PR TITLE
docs(knowledge): tool-reuse rule + custom→vendored migration map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.30] — 2026-07-27
+
+**New knowledge: "use the vendored tools, don't reimplement them" — the custom→vendored migration map, baked in so every course repo benefits.**
+
+A usage scan of the mature course repos (itm327, ds460) found the predictable drift trap: the toolkit was generalized *from* course scripts, so courses keep running old local copies that miss every safety fix (the duplicate-comment, empty-comment, and stuck-workflow-state bugs all came from custom scripts). This makes the guidance canonical instead of tribal.
+
+### Added
+- **`lib/agents/knowledge/toolkit_reuse_knowledge.md`** — the tool-discovery rule ("search `lib/tools/` first; never hand-write a Canvas script"), the known custom→vendored **migration map** (`push_grades.py→grader_push.py`, `checks.py→grader_signals.py`, `fix_canvas_grade_state.py→grader_audit_workflow.py`, the `tools/` course-build twins, …), the migration procedure, and how the `grade_guardian` hook makes it enforceable. Cataloged in `knowledge/README.md`.
+- **`cb-init`** — the generated course AGENTS.md stub now carries a pointer to it, so new course repos start with the reuse rule instead of growing a parallel toolchain.
+
+---
+
 ## [1.7.29] — 2026-07-27
 
 **Resubmission detection and re-grade now share one definition — the report flags exactly what `--regrade` acts on.**

--- a/lib/agents/knowledge/README.md
+++ b/lib/agents/knowledge/README.md
@@ -32,6 +32,7 @@ The twelve files cover overlapping but distinct ground. Quick routing:
 | Coaching a new faculty on feedback style — research-grounded WHAT/HOW split + first-time voice articulation | [`voice_coaching_knowledge.md`](voice_coaching_knowledge.md) |
 | Onboarding a new instructor / assignment to the grader (6-step interview) | [`grader_setup_knowledge.md`](grader_setup_knowledge.md) |
 | The layer-routed NLP + LLM hybrid grading architecture (which layer owns which rubric row; priors never score) | [`grader_hybrid_architecture.md`](grader_hybrid_architecture.md) |
+| Whether a course repo should reuse a vendored tool vs. hand-roll one — the custom→vendored migration map + tool-discovery rule | [`toolkit_reuse_knowledge.md`](toolkit_reuse_knowledge.md) |
 | Title IV course-engagement audit — classifying students into UW/UF/Never-Participated/Active by last engagement date for R2T4 reporting (NEW FERPA tier 3 — Downloads-folder named report) | [`course_engagement_audit_knowledge.md`](course_engagement_audit_knowledge.md) |
 
 ---

--- a/lib/agents/knowledge/toolkit_reuse_knowledge.md
+++ b/lib/agents/knowledge/toolkit_reuse_knowledge.md
@@ -1,0 +1,104 @@
+---
+name: toolkit_reuse_knowledge
+version: '1.0'
+last_updated: '2026-07-27'
+description: Consume the vendored canvas-toolbox tools; do not reimplement them. The canonical custom-script → vendored-tool migration map, the tool-discovery rule that stops parallel toolchains forming, and how the grade_guardian hook makes it enforceable.
+skill_type: knowledge
+shape: reference
+scope: 'Why course repos accumulate parallel custom scripts (the toolkit was generalized FROM them), why that drift is dangerous (it bypasses the safety hardening), the tool-discovery rule, the known custom→vendored migration map, and the migration procedure. Out of scope: the internals of any specific tool (see that tool''s --help/docstring) and the grading protocol itself (grader_knowledge / the HG-5 pointer).'
+consumed_by:
+- cb_init.py (course AGENTS.md stub points here)
+provenance:
+  sources:
+    - '2026-07-27 usage scan of itm327-master + ds460-master (mature consumer repos)'
+    - 'issue #213 (tool-bypass RCA) + the grade_guardian hook (v1.7.15)'
+metadata: { knowledge_id: toolkit_reuse }
+---
+
+# Use the vendored tools — don't reimplement them
+
+**Consumed by:** the course-repo AGENTS.md stub (via `cb-init`). Read this before writing
+any script that talks to Canvas from a course repo.
+
+## The core rule
+
+> **Before implementing ANY Canvas operation, search `canvas-toolbox/lib/tools/` first.
+> If a tool exists, use it. If one doesn't, propose it — never hand-write a Canvas API
+> script.** Grades and comments reach Canvas ONLY through `grader_push.py`.
+
+## Why this file exists (the drift trap)
+
+Many of the toolkit's tools were **generalized *from* course-repo scripts** — e.g.
+`grader_signals.py` says *"GENERALIZED FROM ds460-master/grading/checks.py"*, and
+`grader_push.py`'s HOLD-token pattern (#72) was *"lifted from itm327's
+build_mid_letter_comments + push_mid_letter."* So the pattern is predictable: a course
+builds a script → the toolkit absorbs and hardens it → the course keeps running its
+**old local copy**. Now there are two implementations, and the local one:
+
+- **misses every safety fix** the vendored tool has gained. The field bugs that bit real
+  courses — 4 comments stacked on one student, empty comments pushed silently
+  (#228), grades stuck at `workflow_state: submitted` (#226), autonomous un-reviewed
+  pushes (HG-5) — **all came from custom push scripts**, and are all fixed in the
+  vendored `grader_push.py`.
+- **drifts** from the maintained version and has to be re-fixed by hand each time.
+- **bypasses the `grade_guardian` hook** — the harness-level guard (#213, v1.7.15) that
+  blocks direct Canvas writes and the *creation* of a bypass script. A custom script
+  only escapes it because the hook isn't installed; see "Make it enforceable" below.
+
+## The migration map (custom → vendored)
+
+Known duplications observed in the mature repos. **Verify each against the vendored
+tool's `--help` / docstring before switching** (names match; confirm the behavior fits),
+then retire the local copy and repoint your AGENTS.md at the vendored path.
+
+| Custom script (in a course repo) | → vendored `canvas-toolbox/lib/tools/…` |
+|---|---|
+| `grading/push_grades.py` | `grader_push.py` |
+| `grading/checks.py` | `grader_signals.py` |
+| `grading/consensus.py` | `grader_consensus.py` |
+| `grading/reidentify.py` | `grader_reidentify.py` |
+| `grading/deidentify_*.py` | `grader_deidentify_*.py` |
+| `grading/check_name_leak.py` | `grader_name_leak_check.py` |
+| `grading/reconcile_gradebook.py` | `grader_reconcile.py` |
+| `…/fix_canvas_grade_state.py` | `grader_audit_workflow.py` (#226: stuck-`workflow_state` `--check`/`--fix`) |
+| `…/add_ai_tag.py` | *(delete)* — `grader_push.py` appends `— AI drafted, instructor reviewed` automatically |
+| `tools/canvas_sync.py` | `canvas_sync.py` |
+| `tools/blueprint_sync.py` | `blueprint_sync.py` |
+| `tools/course_mirror.py` | `course_mirror.py` |
+| `tools/module_settings_sync.py` | `module_settings_sync.py` |
+| `tools/module_structure_diff.py` | `module_structure_diff.py` |
+| `tools/course_quality_check.py` | `course_quality_check.py` |
+| `tools/canvas_pages.py` · `tools/canvas_quiz_questions.py` | same-named vendored tools |
+
+**When a custom script is legitimate:** it does something the toolkit doesn't (and
+shouldn't) cover — course-specific content (lab/video injectors, PDF splitters), bespoke
+final-grade math, one-off DAG scaffolding. Keep those local; and if a local tool is
+*reusable* across courses, upstream it (`cb_report_bug.py --title "enhancement: …"`)
+rather than letting every course carry its own copy.
+
+## The migration procedure
+
+1. `cd <course>/canvas-toolbox && git pull` — get the current tool.
+2. `uv run python canvas-toolbox/lib/tools/<vendored>.py --help` — confirm it covers your use.
+3. Retire the local copy (deprecate with a pointer comment, then archive/delete).
+4. Repoint every AGENTS.md / docs invocation from `tools/<x>.py` → `canvas-toolbox/lib/tools/<x>.py`.
+5. Make it enforceable (below).
+
+## Make it enforceable — the `grade_guardian` hook
+
+A deprecation *comment* doesn't stop an agent from running the old script. The hook does.
+Install it once per course repo:
+
+```bash
+uv run python canvas-toolbox/lib/tools/cb_init.py --yes   # step 14 wires the hook
+```
+
+After that, a direct Canvas grade write — or the creation of a script that would do one —
+is **blocked at the harness and redirected to `grader_push.py`.** Structural, not advisory.
+Verify: `grep grade_guardian .claude/settings.json`.
+
+## The one-line summary
+
+The toolkit was built by absorbing course scripts and hardening them. Consuming the
+vendored tool is how you get that hardening for free; keeping the local copy is how you
+keep re-living the bugs it already fixed.

--- a/lib/tools/cb_init.py
+++ b/lib/tools/cb_init.py
@@ -793,6 +793,18 @@ When you find a defect:
 
 ---
 
+## ⚠️ Use the vendored tools — don't reimplement them
+
+Before implementing **any** Canvas operation, search `canvas-toolbox/lib/tools/` first —
+use the tool if it exists, propose one if it doesn't, and **never hand-write a Canvas API
+script**. The toolkit was generalized *from* course scripts, so a local copy silently
+misses every safety fix the vendored tool has gained (the duplicate-comment, empty-comment,
+and stuck-workflow-state bugs all came from custom scripts). Full rationale + the
+custom→vendored **migration map**: `canvas-toolbox/lib/agents/knowledge/toolkit_reuse_knowledge.md`.
+The `grade_guardian` hook (installed by `cb-init`) enforces this at the harness.
+
+---
+
 ## Course Context
 
 [Add course-specific context here as you work]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.29"
+version = "1.7.30"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.29"
+version = "1.7.30"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Bakes the "use the vendored tools, don't reimplement them" guidance into the toolkit as canonical knowledge — the reusable version of the two course-repo letters, so **every** course benefits, not just itm327/ds460.

## Why
A usage scan of the mature repos found the predictable drift trap: the toolkit was generalized **from** course scripts (`grader_signals` ← `ds460/checks.py`; the HOLD pattern ← `itm327`), so courses keep running their **old local copies** — which miss every safety fix. The duplicate-comment stacking, the empty-comment bug (#228), the stuck-`workflow_state` (#226), autonomous un-reviewed pushes (HG-5) **all came from custom push scripts.**

## What
- **`lib/agents/knowledge/toolkit_reuse_knowledge.md`** (new) — the tool-discovery rule (*"search `lib/tools/` first; never hand-write a Canvas script"*), the known **custom→vendored migration map** (`push_grades.py→grader_push.py`, `checks.py→grader_signals.py`, `consensus.py→grader_consensus.py`, `fix_canvas_grade_state.py→grader_audit_workflow.py` (#226), `add_ai_tag.py→delete`, the `tools/` course-build twins…), the migration procedure, and how the `grade_guardian` hook makes it **enforceable** rather than advisory. When custom is *legitimate* (course-specific content tools) is called out too. Cataloged in `knowledge/README.md`.
- **`cb-init`** — the generated course AGENTS.md stub now carries a pointer to it, so a **new** course repo starts with the reuse rule instead of growing a parallel toolchain in the first place. Single-sourced (pointer, not a copy), same pattern as the HG-5 grading pointer.

## Verify
`cb_init` compiles, 20 cb_init tests pass, the knowledge doc's YAML frontmatter parses, full suite green under `uv run pytest`, ruff clean.

Bumps `1.7.29` → `1.7.30` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
