### PR TITLE
fix(grade_guardian): fail open on a missing script — never brick a session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.31] — 2026-07-27
+
+**The `grade_guardian` hook can no longer brick a session — it fails open if it can't find its own script.**
+
+A guardrail that hard-blocks when misconfigured is worse than no guardrail. If the hook's script path was ever wrong (a rename, a non-standard layout, or standalone canvas-toolbox where the `canvas-toolbox/` subdir prefix doubles), a bare `python3 <missing>` exited 2 — Python's can't-open-file code, which is *also* the hook "deny" code — so **every** `Bash`/`Read`/`Edit`/`Write` was blocked, including the tools needed to fix it. Found by hitting it in the toolkit repo itself.
+
+### Fixed
+- **`grade_guardian.py`** — `hook_command()` now wraps the invocation so a **missing script fails open** (`sh -c 'f=…; [ -f "$f" ] || exit 0; exec python3 "$f"'`): absent → allow (exit 0); present → `exec` hands off so the guardian's own exit code (2 = deny) still propagates. A wrong path can no longer lock anyone out.
+- **`cb-init`** — `_install_guardian_hook` now verifies the vendored `canvas-toolbox/lib/tools/grade_guardian.py` actually exists under the root **before** wiring the hook, so it's skipped in standalone / non-course layouts (where the path would be wrong) instead of installing a known-broken hook.
+
+Course repos on the standard `<root>/canvas-toolbox/` layout were never affected (their path resolves correctly); this removes the whole class of "bad path bricks the session" regardless.
+
+---
+
 ## [1.7.30] — 2026-07-27
 
 **New knowledge: "use the vendored tools, don't reimplement them" — the custom→vendored migration map, baked in so every course repo benefits.**

--- a/lib/tests/test_cb_init.py
+++ b/lib/tests/test_cb_init.py
@@ -28,7 +28,32 @@ from cb_init import (  # noqa: E402
     env_stub_content,
     parse_canvas_self_name,
     stub_is_filled,
+    _install_guardian_hook,
 )
+
+
+# ---------------------------------------------------------------------------
+# _install_guardian_hook — must NOT install a hook whose script isn't there
+# ---------------------------------------------------------------------------
+
+def test_guardian_hook_skipped_when_no_vendored_toolkit(tmp_path, capsys):
+    """Standalone / non-course layout: no `canvas-toolbox/lib/tools/grade_guardian.py`
+    under the root, so the hook must be SKIPPED — installing it there is what bricked
+    the session (path pointed at a missing script)."""
+    _install_guardian_hook(course_root=tmp_path, check_only=False)
+    assert not (tmp_path / ".claude" / "settings.json").exists()  # nothing written
+    assert "skipped" in capsys.readouterr().out.lower()
+
+
+def test_guardian_hook_installed_when_vendored_toolkit_present(tmp_path):
+    """Course layout: the vendored guardian exists → the hook IS wired in."""
+    g = tmp_path / "canvas-toolbox" / "lib" / "tools" / "grade_guardian.py"
+    g.parent.mkdir(parents=True)
+    g.write_text("# vendored guardian\n", encoding="utf-8")
+    _install_guardian_hook(course_root=tmp_path, check_only=False)
+    settings = tmp_path / ".claude" / "settings.json"
+    assert settings.exists()
+    assert "grade_guardian" in settings.read_text(encoding="utf-8")
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -14,7 +14,7 @@ _TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
 if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
-from grade_guardian import evaluate, ensure_hook  # noqa: E402
+from grade_guardian import evaluate, ensure_hook, hook_command  # noqa: E402
 
 HOOK = _TOOLS_DIR / "grade_guardian.py"
 
@@ -51,6 +51,31 @@ def test_ensure_hook_does_not_mutate_input():
     original = {}
     ensure_hook(original)
     assert original == {}  # deepcopy, not in-place
+
+
+# --- hook_command: FAIL OPEN on a missing script (never brick a session) ----
+
+def test_hook_command_fails_open_when_script_missing(tmp_path):
+    """A wrong path / uninstalled toolkit must ALLOW the tool (exit 0), not block
+    it. Regression for the standalone doubled-path brick: a bare `python3 <missing>`
+    exits 2 (= deny) and locks out every tool, including the Read/Edit to fix it."""
+    import os
+    cmd = hook_command()  # $CLAUDE_PROJECT_DIR/canvas-toolbox/lib/tools/grade_guardian.py
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": str(tmp_path)}  # no canvas-toolbox/ here
+    r = subprocess.run(cmd, shell=True, env=env, input="{}", capture_output=True, text=True)
+    assert r.returncode == 0  # missing script -> fail OPEN
+
+
+def test_hook_command_propagates_deny_when_script_present(tmp_path):
+    """When the guardian IS present, its exit code must propagate unchanged — a
+    deny (exit 2) must not be swallowed by the fail-open wrapper."""
+    import os
+    d = tmp_path / "canvas-toolbox" / "lib" / "tools"
+    d.mkdir(parents=True)
+    (d / "grade_guardian.py").write_text("import sys\nsys.exit(2)\n", encoding="utf-8")
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": str(tmp_path)}
+    r = subprocess.run(hook_command(), shell=True, env=env, input="{}", capture_output=True, text=True)
+    assert r.returncode == 2  # present + denies -> deny propagates
 
 
 # --- DENY: the paths the #213 incident used --------------------------------

--- a/lib/tools/cb_init.py
+++ b/lib/tools/cb_init.py
@@ -901,6 +901,19 @@ def _install_guardian_hook(*, course_root: Path, check_only: bool) -> None:
     if _ensure_guardian_hook is None:
         return  # pre-sync / partial vendored env — skip quietly
 
+    # Only wire the hook if the vendored guardian actually exists at the path the
+    # hook will use. In standalone canvas-toolbox (the toolkit IS the root, not a
+    # `<root>/canvas-toolbox/` subdir) that path doesn't exist — installing there
+    # gave a hook that pointed at `<root>/canvas-toolbox/canvas-toolbox/…` and
+    # bricked the session. The hook command also fails open now, but not installing
+    # a known-broken hook is the cleaner fix.
+    guardian = course_root / "canvas-toolbox" / "lib" / "tools" / "grade_guardian.py"
+    if not guardian.is_file():
+        print("  ⏭  grade-guardian hook skipped — no vendored "
+              "canvas-toolbox/lib/tools/grade_guardian.py under this root "
+              "(standalone or non-course layout).")
+        return
+
     settings_path = course_root / ".claude" / "settings.json"
     try:
         existing = json.loads(settings_path.read_text(encoding="utf-8")) if settings_path.exists() else {}

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -142,8 +142,18 @@ HOOK_MATCHER = "Bash|Write|Edit|Read"
 
 def hook_command(toolkit_subdir: str = "canvas-toolbox") -> str:
     """The PreToolUse `command` for a course repo. ${CLAUDE_PROJECT_DIR} is the
-    course root; the toolkit is vendored under it at <toolkit_subdir>/."""
-    return f'python3 "${{CLAUDE_PROJECT_DIR}}/{toolkit_subdir}/lib/tools/grade_guardian.py"'
+    course root; the toolkit is vendored under it at <toolkit_subdir>/.
+
+    FAILS OPEN if the guardian script is missing (a wrong path, a rename, an
+    uninstalled toolkit): a guardrail must NEVER brick a session because it can't
+    find itself. A bare `python3 <missing>` exits non-zero (Python's can't-open is
+    exit 2 = the "deny" code), which would block EVERY tool call — including the
+    Read/Edit you'd need to fix it. So: if the file is absent, `exit 0` (allow);
+    if present, `exec` hands off so the guardian's own exit code (2 = deny)
+    propagates unchanged.
+    """
+    path = f'$CLAUDE_PROJECT_DIR/{toolkit_subdir}/lib/tools/grade_guardian.py'
+    return f'sh -c \'f="{path}"; [ -f "$f" ] || exit 0; exec python3 "$f"\''
 
 
 def ensure_hook(settings: dict) -> tuple:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.30"
+version = "1.7.31"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.30"
+version = "1.7.31"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
**A guardrail that bricks a session when misconfigured is worse than no guardrail.** This removes that failure mode.

## What happened
Hit live in the toolkit repo: the `grade_guardian` hook's script path was wrong (standalone canvas-toolbox doubles the `canvas-toolbox/` subdir prefix → `…/canvas-toolbox/canvas-toolbox/lib/tools/grade_guardian.py`, missing). A bare `python3 <missing>` exits **2** — Python's can't-open-file code, which is *also* the hook **deny** code — so **every** `Bash`/`Read`/`Edit`/`Write` got blocked, **including the tools needed to diagnose or fix it.** Had to clear it from a terminal outside the session.

## The two fixes
1. **`hook_command()` fails open.** `sh -c 'f="…"; [ -f "$f" ] || exit 0; exec python3 "$f"'` — missing → `exit 0` (allow); present → `exec` hands off so the guardian's own exit code (2 = deny) **still propagates**. A wrong path can never lock anyone out again.
2. **`cb-init` won't install a known-broken hook** — `_install_guardian_hook` verifies `canvas-toolbox/lib/tools/grade_guardian.py` exists under the root before wiring it, so it's skipped in standalone / non-course layouts.

## Blast radius (important)
**Course repos on the standard `<root>/canvas-toolbox/` layout were never affected** — their path resolves correctly, and the scan confirmed itm327/m119/ds460 are working normally with the hook installed. This was specific to standalone canvas-toolbox. The fix removes the whole *class* of "bad path bricks the session" regardless of layout.

## Verify
4 tests: `hook_command` fails open on a missing script (exit 0) **and** propagates a deny (exit 2) when the script is present; `_install_guardian_hook` skips when there's no vendored guardian and installs when there is. Full suite green under `uv run pytest`.

Note: `ensure_hook` is idempotent, so this doesn't rewrite hooks already installed in course repos (they keep their correct command); it protects new installs and the standalone case.

Bumps `1.7.30` → `1.7.31` + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
