### PR TITLE
feat(grader_standing): push instructor-computed 'your grade' standing column (#242)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.33] — 2026-07-27
+
+**New `grader_standing.py` — push an instructor-computed "your grade" standing column, weekly and automatable.**
+
+Canvas's automatic-zero policy makes the running total misleading, and `grader_push`'s `regrade_gate` deliberately refuses to overwrite an already-graded submission with no resubmission (it guards against stacked comments). Both are correct, but together they block a real workflow instructors already run by hand: a single No-Submission "your grade" column, computed from a syllabus table, refreshed a couple times a semester. This tool automates that refresh.
+
+Standing is a different shape from feedback — roster-keyed (by Canvas `user_id`, resolved from SIS/login/email against the course roster), value-only (no comments, no de-identification; the instructor owns the number), and intentionally overwritten every run — so it's a **sanctioned sibling** of `grader_push` rather than a mode bolted onto it. It reuses grader_push's env/auth, `canvas_course_guard`, submission fetch, manual-post release, and the TTY-safe confirmation, so the two writers can't drift on what matters.
+
+The column is often weighted 100%, so the guards are strict: roster resolution **hard-fails** on any unmatched or ambiguous key (never grade the wrong student); dry-run by default with a FERPA-safe `user_id: old → new` diff; out-of-bounds grades abort; a score drop past `--swing-threshold` (the shifted-CSV symptom) aborts unless `--allow-swings`. `--yes` is allowed (deterministic, value-only) so weekly runs can be automated — the safe side of the HG-5 line.
+
+```
+grader_standing.py --csv standing.csv --assignment-id <id>            # dry-run diff
+grader_standing.py --csv standing.csv --assignment-id <id> --push     # write (confirm)
+grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-enrolled  # weekly/automated
+```
+
+---
+
 ## [1.7.32] — 2026-07-27
 
 **The HG-5 push confirmation now requires an interactive terminal — a piped `push` can no longer stand in for the instructor.**

--- a/lib/agents/knowledge/toolkit_reuse_knowledge.md
+++ b/lib/agents/knowledge/toolkit_reuse_knowledge.md
@@ -24,7 +24,11 @@ any script that talks to Canvas from a course repo.
 
 > **Before implementing ANY Canvas operation, search `canvas-toolbox/lib/tools/` first.
 > If a tool exists, use it. If one doesn't, propose it — never hand-write a Canvas API
-> script.** Grades and comments reach Canvas ONLY through `grader_push.py`.
+> script.** Grades reach Canvas ONLY through a sanctioned writer under `lib/tools/`:
+> `grader_push.py` for submission feedback (comments + grades), and
+> `grader_standing.py` for a roster-keyed **standing** column — an instructor-computed,
+> value-only "your grade" No-Submission assignment you refresh weekly (#242). Both share
+> one auth/course-guard/post-policy core, so they can't drift on what matters.
 
 ## Why this file exists (the drift trap)
 
@@ -54,6 +58,7 @@ then retire the local copy and repoint your AGENTS.md at the vendored path.
 | Custom script (in a course repo) | → vendored `canvas-toolbox/lib/tools/…` |
 |---|---|
 | `grading/push_grades.py` | `grader_push.py` |
+| `grading/push_your_grade.py`, `grading/update_standing.py` (writes a "your grade" column) | `grader_standing.py` — computes nothing; pushes your script's values, dry-run by default |
 | `grading/checks.py` | `grader_signals.py` |
 | `grading/consensus.py` | `grader_consensus.py` |
 | `grading/reidentify.py` | `grader_reidentify.py` |

--- a/lib/tests/test_grader_standing.py
+++ b/lib/tests/test_grader_standing.py
@@ -1,0 +1,173 @@
+"""Unit tests — grader_standing planning/resolution (issue #242).
+
+This tool writes to a column that is often weighted 100% of the grade, so the
+guards that must never silently fail are the ones under test: a CSV key that
+matches no student (or two), a grade out of bounds, and a big score drop (the
+symptom of a shifted CSV) must all be caught BEFORE any write.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_standing import (  # noqa: E402
+    _pick_column,
+    load_standing_rows,
+    plan_writes,
+)
+
+
+# --- _pick_column: auto-detect, override, case-insensitivity ---------------
+
+def test_pick_column_autodetects_first_candidate():
+    assert _pick_column(["name", "user_id", "grade"], ("user_id", "id"), None) == "user_id"
+
+
+def test_pick_column_is_case_insensitive():
+    assert _pick_column(["User_ID", "Grade"], ("user_id",), None) == "User_ID"
+
+
+def test_pick_column_honors_override():
+    assert _pick_column(["a", "b"], ("a",), "b") == "b"
+
+
+def test_pick_column_override_missing_is_fatal():
+    import pytest
+    with pytest.raises(SystemExit):
+        _pick_column(["a", "b"], ("a",), "zzz")
+
+
+def test_pick_column_returns_none_when_absent():
+    assert _pick_column(["foo", "bar"], ("user_id",), None) is None
+
+
+# --- load_standing_rows: reads the two columns, skips blank lines -----------
+
+def test_load_standing_rows_reads_key_and_grade(tmp_path):
+    p = tmp_path / "s.csv"
+    p.write_text("student_id,your_grade,note\n1001,A,ok\n1002,B,\n\n", encoding="utf-8")
+    rows, key_col, grade_col = load_standing_rows(str(p), None, None)
+    assert key_col == "student_id" and grade_col == "your_grade"
+    assert rows == [("1001", "A"), ("1002", "B")]
+
+
+# --- plan_writes: the safety gates -----------------------------------------
+
+INDEX = {"1001": 1001, "1002": 1002, "dup": None, "l99": 1003}
+ACTIVE = {1001, 1002, 1003}
+
+
+def test_plan_flags_unmatched_key_as_fatal():
+    plan, problems = plan_writes([("9999", "90")], INDEX, ACTIVE, {}, 100, 20)
+    assert plan == []
+    assert any(kind == "unmatched" for kind, _ in problems)
+
+
+def test_plan_flags_ambiguous_key_as_fatal():
+    plan, problems = plan_writes([("dup", "90")], INDEX, ACTIVE, {}, 100, 20)
+    assert plan == []
+    assert any(kind == "ambiguous" for kind, _ in problems)
+
+
+def test_plan_flags_out_of_bounds_as_fatal():
+    plan, problems = plan_writes([("1001", "150")], INDEX, ACTIVE, {}, 100, 20)
+    assert plan == []
+    assert any(kind == "out-of-bounds" for kind, _ in problems)
+
+
+def test_plan_flags_negative_grade_as_fatal():
+    _, problems = plan_writes([("1001", "-5")], INDEX, ACTIVE, {}, 100, 20)
+    assert any(kind == "out-of-bounds" for kind, _ in problems)
+
+
+def test_plan_flags_big_drop_as_warning_but_still_plans_write():
+    current = {1001: {"grade": "95", "score": 95.0}}
+    plan, problems = plan_writes([("1001", "40")], INDEX, ACTIVE, current, 100, 20)
+    assert any(kind == "big-drop" for kind, _ in problems)
+    assert plan and plan[0]["status"] == "write"  # planned, but caller must gate on the warning
+
+
+def test_plan_small_change_is_not_a_big_drop():
+    current = {1001: {"grade": "95", "score": 95.0}}
+    _, problems = plan_writes([("1001", "90")], INDEX, ACTIVE, current, 100, 20)
+    assert not any(kind == "big-drop" for kind, _ in problems)
+
+
+def test_plan_unchanged_value_is_a_noop():
+    current = {1001: {"grade": "A", "score": None}}
+    plan, problems = plan_writes([("1001", "A")], INDEX, ACTIVE, current, None, 20)
+    assert problems == []
+    assert plan[0]["status"] == "same"
+
+
+def test_plan_normal_write_resolves_and_marks_write():
+    plan, problems = plan_writes([("l99", "B")], INDEX, ACTIVE, {}, None, 20)
+    assert problems == []
+    assert plan[0]["uid"] == 1003 and plan[0]["status"] == "write"
+
+
+def test_plan_marks_inactive_students():
+    plan, _ = plan_writes([("1001", "A")], INDEX, {1002}, {}, None, 20)
+    assert plan[0]["inactive"] is True  # 1001 not in the active set
+
+
+# --- integration: main() dry-run, Canvas stubbed, writes NOTHING -----------
+
+import grader_standing as _GS  # noqa: E402
+
+
+class _Resp:
+    def __init__(self, payload, status=200, link=""):
+        self._payload = payload
+        self.status_code = status
+        self.headers = {"Link": link}
+        self.text = ""
+
+    def raise_for_status(self):
+        pass
+
+    def json(self):
+        return self._payload
+
+
+def test_main_dry_run_resolves_sis_keys_and_writes_nothing(tmp_path, monkeypatch, capsys):
+    """Drive the whole path: a CSV keyed by SIS/login resolves against the roster,
+    the diff renders FERPA-safe (user_id only), and dry-run writes NOTHING —
+    requests.put is monkeypatched to explode so any write would fail the test."""
+    csv_path = tmp_path / "standing.csv"
+    csv_path.write_text("login_id,your_grade\nalice@x.edu,88\nbob@x.edu,92\n", encoding="utf-8")
+
+    monkeypatch.setattr(_GS, "_env_canvas", lambda: ("tok", "407908", "https://x.instructure.com"))
+
+    def fake_get(url, **kw):
+        if "/users" in url:
+            return _Resp([
+                {"id": 501, "login_id": "alice@x.edu", "enrollments": [{"enrollment_state": "active"}]},
+                {"id": 502, "login_id": "bob@x.edu", "enrollments": [{"enrollment_state": "active"}]},
+            ])
+        if url.rstrip("/").endswith(f"/assignments/16958677"):
+            return _Resp({"name": "Your Grade", "points_possible": 100})
+        return _Resp({})
+    monkeypatch.setattr(_GS.requests, "get", fake_get)
+    monkeypatch.setattr(_GS, "fetch_submissions", lambda *a, **k: [
+        {"user_id": 501, "grade": "80", "score": 80.0},
+        {"user_id": 502, "grade": "92", "score": 92.0},
+    ])
+
+    def _no_write(*a, **k):
+        raise AssertionError("requests.put called during a DRY RUN")
+    monkeypatch.setattr(_GS.requests, "put", _no_write)
+
+    rc = _GS.main.__wrapped__ if hasattr(_GS.main, "__wrapped__") else _GS.main
+    monkeypatch.setattr(sys, "argv",
+                        ["grader_standing.py", "--csv", str(csv_path),
+                         "--assignment-id", "16958677", "--course-id", "407908"])
+    code = rc()
+    out = capsys.readouterr().out
+    assert code == 0
+    assert "Dry run — nothing written." in out
+    assert "user 501: 80 -> 88" in out          # alice: real change shown
+    assert "[same ] user 502" in out            # bob: 92 == 92, a no-op
+    assert "alice@x.edu" not in out             # FERPA: the login key is never echoed

--- a/lib/tools/grader_standing.py
+++ b/lib/tools/grader_standing.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""Push instructor-computed STANDING grades to a No-Submission column (#242).
+
+WHY THIS EXISTS
+  Canvas's automatic-zero / missing policy makes a course's running total
+  misleading (0s sit on not-yet-graded work), and grader_push's `regrade_gate`
+  deliberately REFUSES to overwrite an already-graded submission with no new
+  resubmission — it guards against stacked COMMENTS. Neither is wrong, but together
+  they block a legitimate instructor workflow: a single "your grade" No-Submission
+  column, computed from a syllabus table, that the instructor wants to refresh
+  weekly so students always see an accurate standing.
+
+  Standing is a different shape from feedback:
+    - roster-keyed (by Canvas user_id), not submission-file-keyed
+    - value-only: no comments, no disclosure tag, no de-identification — the
+      instructor OWNS the number; it is not AI-drafted feedback
+    - INTENTIONALLY overwritten every run
+  So it gets its own sanctioned writer rather than bending grader_push's
+  submission/feedback machinery (the M119 "split logic from transport" lesson).
+
+  It REUSES grader_push's env/auth, canvas_course_guard, submission fetch, and
+  manual-post release, plus the TTY-safe confirmation. The value-only write is the
+  only new code — so the two writers can't drift on the parts that matter (which
+  course is safe, how to authenticate, how to release manually-posted grades).
+
+SAFETY — this column is often weighted 100%, so a bad CSV row corrupts a whole
+grade. Guards, in order:
+  - Roster resolution HARD-FAILS on any unmatched or ambiguous key: for a
+    100%-weight write, never silently skip a student or grade the wrong one.
+  - Dry-run by DEFAULT: prints a FERPA-safe diff (user_id: current -> new, no
+    names) and writes NOTHING until you pass --push.
+  - Out-of-bounds is a HARD FAIL: a numeric grade < 0 or > points_possible is a
+    bug, always — it aborts --push.
+  - Big-drop guard: a fall larger than --swing-threshold (the classic symptom of
+    a shifted/misaligned CSV) is flagged; --push aborts unless --allow-swings.
+  - canvas_course_guard: refuses a live enrolled-course write unless --allow-enrolled.
+  - --yes is ALLOWED here (deterministic, instructor-computed, value-only) so the
+    weekly run can be automated — this is on the safe side of the HG-5 line, unlike
+    grader_push's commented pushes. Without --yes, confirmation demands a TTY
+    (shared with grader_push, #241), so a piped 'push' can't stand in for you.
+
+INPUT CONTRACT
+  A CSV your syllabus-table script emits. Two columns matter (auto-detected, or
+  name them with --key-column / --grade-column):
+    key   : one of user_id / canvas_user_id / id / sis_user_id / login_id /
+            student_id / email  (whatever your script has; it's resolved to a
+            Canvas user_id against the course roster)
+    grade : one of grade / final_grade / standing / points / score
+            (a number OR a letter — whatever the assignment's grading type takes)
+  Everything else in the CSV is ignored.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+
+try:
+    from _env_loader import force_utf8_console, load_env
+    load_env()
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+import requests
+
+try:
+    from __toolbox_version__ import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
+
+try:
+    from canvas_course_guard import enforce as guard_enforce
+except ImportError:
+    guard_enforce = None
+
+# Reuse grader_push's env, roster/submission fetch, post-policy release, and the
+# TTY-safe confirmation — one source of truth for the parts that must not drift.
+from grader_push import (
+    _env_canvas,
+    fetch_submissions,
+    assignment_posts_manually,
+    post_assignment_grades,
+    require_typed_confirmation,
+)
+
+_TIMEOUT = 30
+_KEY_COLS = ("user_id", "canvas_user_id", "id", "sis_user_id", "sis_id",
+             "login_id", "login", "student_id", "sis_login_id", "email")
+_GRADE_COLS = ("grade", "final_grade", "standing", "your_grade", "points", "score")
+
+
+def _pick_column(fieldnames, candidates, override):
+    """Return the CSV column to use, preferring an explicit --override, else the
+    first candidate present (case-insensitive)."""
+    lower = {f.lower(): f for f in (fieldnames or [])}
+    if override:
+        if override in (fieldnames or []):
+            return override
+        if override.lower() in lower:
+            return lower[override.lower()]
+        raise SystemExit(f"⛔ column {override!r} not in CSV header: {fieldnames}")
+    for c in candidates:
+        if c in lower:
+            return lower[c]
+    return None
+
+
+def fetch_roster_index(base, cid, headers):
+    """Map every student identifier -> Canvas user_id, and the set of active ids.
+
+    Returns (index, active_ids). `index` maps str(user_id), sis_user_id, login_id,
+    and email (all lowercased) to a numeric user_id. A string that maps to two
+    different users is recorded as ambiguous (value None) so resolution HARD-FAILS
+    on it rather than guessing.
+    """
+    index: dict[str, int | None] = {}
+    active: set[int] = set()
+
+    def _add(token, uid):
+        if token is None:
+            return
+        k = str(token).strip().lower()
+        if not k:
+            return
+        if k in index and index[k] != uid:
+            index[k] = None  # ambiguous — two users share this identifier
+        else:
+            index.setdefault(k, uid)
+
+    url = (f"{base}/api/v1/courses/{cid}/users?enrollment_type[]=student"
+           "&per_page=100&include[]=enrollments&include[]=email")
+    while url:
+        r = requests.get(url, headers=headers, timeout=_TIMEOUT)
+        r.raise_for_status()
+        for u in r.json() or []:
+            uid = u.get("id")
+            if uid is None:
+                continue
+            uid = int(uid)
+            _add(uid, uid)
+            _add(u.get("sis_user_id"), uid)
+            _add(u.get("login_id"), uid)
+            _add(u.get("email"), uid)
+            for e in u.get("enrollments") or []:
+                if (e.get("enrollment_state") or "").lower() in ("active", "invited"):
+                    active.add(uid)
+        import re
+        m = re.search(r'<([^>]+)>;\s*rel="next"', r.headers.get("Link", ""))
+        url = m.group(1) if m else None
+    return index, active
+
+
+def load_standing_rows(path, key_override, grade_override):
+    """Read (raw_key, grade_str) pairs from the CSV. Fails loudly if the key or
+    grade column can't be found — better than silently pushing nothing."""
+    with open(path, newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        key_col = _pick_column(reader.fieldnames, _KEY_COLS, key_override)
+        grade_col = _pick_column(reader.fieldnames, _GRADE_COLS, grade_override)
+        if not key_col:
+            raise SystemExit(f"⛔ no key column found. Have {reader.fieldnames}; "
+                             f"expected one of {_KEY_COLS} or pass --key-column.")
+        if not grade_col:
+            raise SystemExit(f"⛔ no grade column found. Have {reader.fieldnames}; "
+                             f"expected one of {_GRADE_COLS} or pass --grade-column.")
+        rows = []
+        for line in reader:
+            raw_key = (line.get(key_col) or "").strip()
+            grade = (line.get(grade_col) or "").strip()
+            if raw_key or grade:
+                rows.append((raw_key, grade))
+    return rows, key_col, grade_col
+
+
+def _as_float(s):
+    try:
+        return float(s)
+    except (TypeError, ValueError):
+        return None
+
+
+def plan_writes(rows, index, active, current_by_uid, points_possible, swing_threshold):
+    """Resolve every row to a user_id and classify it. Returns (plan, problems).
+
+    plan: list of dicts {uid, grade, current, new_score, status}. Statuses:
+      write / same (no-op) — safe to proceed.
+    problems: fatal issues (unmatched/ambiguous key, out-of-bounds) that must
+      abort --push; and 'big-drop' warnings that abort unless --allow-swings.
+    """
+    plan, problems = [], []
+    for raw_key, grade in rows:
+        uid = index.get(raw_key.lower())
+        if raw_key.lower() not in index:
+            problems.append(("unmatched", f"key {raw_key!r} matches no enrolled student"))
+            continue
+        if uid is None:
+            problems.append(("ambiguous", f"key {raw_key!r} matches more than one student"))
+            continue
+        new_score = _as_float(grade)
+        if new_score is not None and points_possible is not None and (
+                new_score < 0 or new_score > points_possible):
+            problems.append(("out-of-bounds",
+                             f"user {uid}: grade {grade} outside [0, {points_possible}]"))
+            continue
+        cur = current_by_uid.get(uid, {})
+        cur_grade, cur_score = cur.get("grade"), cur.get("score")
+        status = "same" if str(cur_grade or "").strip() == grade else "write"
+        if status == "write" and cur_score is not None and new_score is not None \
+                and (cur_score - new_score) > swing_threshold:
+            problems.append(("big-drop",
+                             f"user {uid}: {cur_score} -> {new_score} "
+                             f"(drop > {swing_threshold})"))
+        plan.append({"uid": uid, "grade": grade, "current": cur_grade,
+                     "new_score": new_score, "status": status,
+                     "inactive": uid not in active})
+    return plan, problems
+
+
+def main() -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(
+        description="Push instructor-computed standing grades to a No-Submission "
+                    "column (value-only, dry-run by default, gated).")
+    ap.add_argument("--csv", required=True, help="standing CSV your script emits")
+    ap.add_argument("--assignment-id", required=True, help="the 'your grade' assignment id")
+    ap.add_argument("--course-id", default=None, help="defaults to $CANVAS_COURSE_ID")
+    ap.add_argument("--key-column", default=None, help="override auto-detected key column")
+    ap.add_argument("--grade-column", default=None, help="override auto-detected grade column")
+    ap.add_argument("--swing-threshold", type=float, default=20.0,
+                    help="flag a score drop larger than this (default 20)")
+    ap.add_argument("--allow-swings", action="store_true",
+                    help="proceed despite big-drop warnings (out-of-bounds still aborts)")
+    ap.add_argument("--push", action="store_true", help="actually write (else dry-run)")
+    ap.add_argument("--yes", action="store_true",
+                    help="skip the typed confirmation — for automated weekly runs")
+    ap.add_argument("--allow-enrolled", action="store_true",
+                    help="bypass canvas_course_guard for your own enrolled course")
+    ap.add_argument("--post", action="store_true",
+                    help="release grades after push if the assignment posts manually")
+    ap.add_argument("--version", action="version", version=f"canvas-toolbox {__version__}")
+    args = ap.parse_args()
+
+    tok, env_cid, base = _env_canvas()
+    cid = args.course_id or env_cid
+    if not (tok and base and cid):
+        print("⛔ set CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID (or --course-id).",
+              file=sys.stderr)
+        return 1
+    headers = {"Authorization": f"Bearer {tok}"}
+    aid = args.assignment_id
+
+    # Assignment meta — name, points_possible (bounds), posting policy.
+    meta = {}
+    try:
+        rm = requests.get(f"{base}/api/v1/courses/{cid}/assignments/{aid}",
+                          headers=headers, timeout=_TIMEOUT)
+        if rm.status_code < 400:
+            meta = rm.json() or {}
+    except requests.RequestException:
+        pass
+    points_possible = meta.get("points_possible")
+    print(f"Standing push -> assignment {aid} "
+          f"({meta.get('name', '?')}; points_possible={points_possible}) on course {cid}")
+
+    rows, key_col, grade_col = load_standing_rows(args.csv, args.key_column, args.grade_column)
+    print(f"  read {len(rows)} row(s) from {args.csv} "
+          f"(key='{key_col}', grade='{grade_col}')")
+
+    index, active = fetch_roster_index(base, cid, headers)
+    current = {s["user_id"]: s for s in fetch_submissions(base, cid, headers, aid)}
+    plan, problems = plan_writes(rows, index, active, current,
+                                 points_possible, args.swing_threshold)
+
+    # FERPA-safe diff — user_id + old -> new only, never names.
+    writes = [p for p in plan if p["status"] == "write"]
+    for p in plan:
+        tag = "  [inactive]" if p["inactive"] else ""
+        mark = "WRITE" if p["status"] == "write" else "same "
+        print(f"  [{mark}] user {p['uid']}: {p['current'] or '—'} -> {p['grade']}{tag}")
+
+    fatal = [m for kind, m in problems if kind in ("unmatched", "ambiguous", "out-of-bounds")]
+    drops = [m for kind, m in problems if kind == "big-drop"]
+    for m in fatal:
+        print(f"  ⛔ {m}", file=sys.stderr)
+    for m in drops:
+        print(f"  ⚠️  big drop: {m}", file=sys.stderr)
+
+    print(f"\n{len(writes)} to write, {len(plan) - len(writes)} unchanged, "
+          f"{len(fatal)} fatal, {len(drops)} big-drop warning(s).")
+
+    if fatal:
+        print("⛔ Fatal problems above — nothing written. Fix the CSV/roster and re-run.",
+              file=sys.stderr)
+        return 1
+    if drops and not args.allow_swings:
+        print("⛔ Big-drop warning(s) — nothing written. Review, then re-run with "
+              "--allow-swings if intended.", file=sys.stderr)
+        return 1
+    if not args.push:
+        print("\nDry run — nothing written. Add --push to write.")
+        return 0
+    if not writes:
+        print("Nothing to write (all values already current).")
+        return 0
+
+    # canvas_course_guard: refuse a live enrolled-course write unless --allow-enrolled.
+    if guard_enforce:
+        guard_enforce(base, headers, cid, mode="write", allow_override=args.allow_enrolled)
+
+    if not args.yes:
+        print(f"\nThis writes {len(writes)} standing grade(s) to the LIVE course {cid}.")
+        if not require_typed_confirmation("Type 'push' to confirm: ", "push"):
+            print("Aborted.")
+            return 1
+
+    pushed, failed = 0, 0
+    for p in writes:
+        resp = requests.put(
+            f"{base}/api/v1/courses/{cid}/assignments/{aid}/submissions/{p['uid']}",
+            headers=headers, data={"submission[posted_grade]": p["grade"]}, timeout=_TIMEOUT)
+        if resp.status_code < 400:
+            print(f"  pushed user {p['uid']}: {p['current'] or '—'} -> {p['grade']}")
+            pushed += 1
+        else:
+            print(f"  ⛔ user {p['uid']}: HTTP {resp.status_code} {resp.text[:120]}",
+                  file=sys.stderr)
+            failed += 1
+    print(f"\nPushed {pushed}, failed {failed}.")
+
+    if args.post and pushed and assignment_posts_manually(base, cid, headers, aid):
+        ok, detail = post_assignment_grades(base, cid, headers, aid)
+        print(f"  {'released' if ok else '⛔ release failed'}: {detail}")
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.32"
+version = "1.7.33"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.32"
+version = "1.7.33"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What & why

Automates a workflow instructors in DS460/ITM327 already run by hand: a single **No-Submission "your grade" column**, computed from a syllabus table, refreshed a couple times a semester. Now it can run weekly.

**Why a new tool and not `grader_push`:** Canvas's auto-zero makes the running total misleading, and `grader_push`'s `regrade_gate` deliberately refuses to overwrite an already-graded submission with no resubmission (it guards against stacked *comments*). Both are correct — so instead of fighting them per-assignment, standing lives in its own column. That column is **roster-keyed, value-only, and intentionally overwritten each run** — a different shape from submission feedback, so it's a **sanctioned sibling** of `grader_push`, not a mode bolted into its 400-line `main()`.

It **reuses** grader_push's env/auth, `canvas_course_guard`, submission fetch, manual-post release (`--post`), and the TTY-safe confirmation (#241) — so the two writers can't drift on what actually matters (which course is safe, how to authenticate, how to release manually-posted grades). The value-only write is the only new code.

## Safety (this column is often weighted 100%)

A misaligned CSV row would corrupt a student's *entire* grade, so the guards are strict:

- **Roster resolution hard-fails** on any unmatched or ambiguous key — for a 100%-weight write, never silently skip a student or grade the wrong one. Keys resolve from `user_id` / `sis_user_id` / `login_id` / `email` against the course roster.
- **Dry-run by default** — a FERPA-safe `user_id: current → new` diff (no names), writes nothing until `--push`.
- **Out-of-bounds aborts** — a numeric grade `< 0` or `> points_possible` is always a bug.
- **Big-drop guard** — a fall past `--swing-threshold` (the classic shifted-CSV symptom) aborts unless `--allow-swings`.
- `--yes` is **allowed** (deterministic, value-only, instructor-computed) so weekly runs automate — the safe side of the HG-5 line, unlike commented pushes.

## Usage

```
grader_standing.py --csv standing.csv --assignment-id <id>                         # dry-run diff
grader_standing.py --csv standing.csv --assignment-id <id> --push                  # write (typed confirm)
grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-enrolled   # weekly/automated
```

Input contract: a CSV your script emits with a key column (`user_id`/`sis_user_id`/`login_id`/`student_id`/`email`, auto-detected or `--key-column`) and a grade column (`grade`/`final_grade`/`standing`/`your_grade`/…, or `--grade-column`). The tool **computes nothing** — it pushes your values.

## Tests

16 new: column autodetect + override, SIS/login/email resolution, the four hard-fail/warn gates, no-op detection, and an **end-to-end dry-run** that stubs Canvas and asserts `requests.put` is never called and no login key is echoed. Full suite **1014 passed**.

Reuse doctrine updated: two sanctioned writers under `lib/tools/` — `grader_push` (submission feedback) + `grader_standing` (roster standing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
