### PR TITLE
fix(grade_guardian): read Write body from `content` — the bypass-script catch was blind (#213)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.34] — 2026-07-27
+
+**Critical: the `grade_guardian` hook was blind to hand-written push scripts — it read the wrong field.**
+
+The guard's flagship catch (#213) is blocking the *creation* of a bypass script: a Bash hook can't see inside `python push.py`, but the Write hook sees the file body as it's written. Except it read the body from `tool_input["file_contents"]` — and Claude Code's Write tool sends it as **`content`**. So the body was always empty to the guard, the write-signature check never matched, and every hand-written Canvas push script sailed through. Found in the field: a grader that couldn't locate a push script simply wrote its own 186-line `requests.put` script, and the guard allowed it. The unit tests passed only because they used the same wrong key the code did.
+
+Fix: read the body from `content` (real Write param), `file_contents` (legacy/alt), and `new_string` (Edit) — whichever is present. Tests now use the real `content` key and pin all three, so a field-name drift can't silently disarm the catch again.
+
+If you vendor the hook, `cd canvas-toolbox && git pull` to 1.7.34 restores the protection — no re-init needed.
+
+---
+
 ## [1.7.33] — 2026-07-27
 
 **New `grader_standing.py` — push an instructor-computed "your grade" standing column, weekly and automatable.**

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -95,13 +95,24 @@ def test_denies_inline_python_requests_put():
 
 def test_denies_writing_the_bypass_script_at_creation():
     """The core catch: a Bash hook can't see inside `python /tmp/push.py`, but the
-    Write hook sees the file contents as the script is created."""
+    Write hook sees the file contents as the script is created. Claude Code's Write
+    tool sends the body as `content` — reading the wrong key silently blinded this
+    catch and let a hand-written push script through (the guardian field-name bug)."""
     body = ('import requests\n'
             'requests.put("https://x.instructure.com/api/v1/courses/1/assignments/2/'
             'submissions/3", data={"submission[posted_grade]": "90"})\n')
-    reason = evaluate("Write", {"file_path": "/tmp/push_kc_grades.py", "file_contents": body})
+    reason = evaluate("Write", {"file_path": "/tmp/push_kc_grades.py", "content": body})
     assert reason is not None
     assert "grader_push.py" in reason  # the denial redirects to the safe path
+
+
+def test_denies_bypass_script_regardless_of_body_key():
+    """Regression: the guard must read the body from whatever key the client uses —
+    `content` (Claude Code Write), `file_contents` (legacy/alt), `new_string` (Edit)."""
+    body = ('requests.put("https://x.instructure.com/api/v1/courses/1/assignments/2/'
+            'submissions/3", data={"submission[posted_grade]": "90"})')
+    for key in ("content", "file_contents", "new_string"):
+        assert evaluate("Write", {"file_path": "/tmp/p.py", key: body}) is not None, key
 
 
 def test_denies_edit_that_introduces_a_canvas_write():
@@ -136,14 +147,14 @@ def test_allows_editing_the_toolkit_source():
     reviewed path, not a bypass."""
     body = 'requests.put(f"{base}/api/v1/courses/{cid}/assignments/{aid}/submissions/{uid}")'
     assert evaluate("Write", {"file_path": "/repo/lib/tools/grader_push.py",
-                              "file_contents": body}) is None
+                              "content": body}) is None
 
 
 def test_allows_docs_with_example_code():
     """A design doc that shows the bad pattern as an EXAMPLE is prose, not a script."""
     body = "Bad: `requests.put('.../submissions/3', data={'submission[posted_grade]':'90'})`"
     assert evaluate("Write", {"file_path": "docs/grading_enforcement_A3.md",
-                              "file_contents": body}) is None
+                              "content": body}) is None
 
 
 def test_allows_feedback_and_non_ferpa_reads():
@@ -167,7 +178,7 @@ def _run_hook(payload: dict) -> subprocess.CompletedProcess:
 def test_hook_exits_2_and_redirects_on_a_bypass_write():
     r = _run_hook({"tool_name": "Write",
                    "tool_input": {"file_path": "/tmp/push.py",
-                                  "file_contents": 'requests.put("https://x.instructure.com/'
+                                  "content": 'requests.put("https://x.instructure.com/'
                                   'api/v1/courses/1/assignments/2/submissions/3")'}})
     assert r.returncode == 2
     assert "grader_push.py" in r.stderr

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -112,8 +112,13 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
             return None  # editing the reviewed tooling is allowed
         if _DOC_PATH.search(path):
             return None  # prose/docs — a code example is not an executable bypass
-        # Write carries file_contents; Edit carries new_string.
-        body = tool_input.get("file_contents") or tool_input.get("new_string") or ""
+        # Write sends the body as `content` (Claude Code's actual tool param); Edit
+        # sends `new_string`. `file_contents` is a legacy/alt key kept for safety.
+        # Reading the WRONG key silently blinds this catch — the bug that let a
+        # hand-written push script sail through (the guard read `file_contents`
+        # while the real payload used `content`). Check every plausible key.
+        body = (tool_input.get("content") or tool_input.get("file_contents")
+                or tool_input.get("new_string") or "")
         if _WRITE_VERB.search(body) and _CANVAS_CTX.search(body):
             target = path or "a new file"
             return _redirect(f"Canvas grade-write code being written into {target}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.33"
+version = "1.7.34"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.33"
+version = "1.7.34"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The bug (found in the field)

`grade_guardian`'s flagship protection (#213) is blocking the **creation** of a hand-written Canvas push script. A Bash hook can't see inside `python push.py`, but the Write hook sees the file body as it's written — so that's the reliable catch.

Except it read the body from `tool_input["file_contents"]`, and **Claude Code's Write tool sends it as `content`**. The body was always empty to the guard → the write-signature check never matched → **every hand-written push script sailed through.** The exact #213 scenario the hook exists to stop was never actually caught.

Observed in a grader session: an agent that couldn't find a push script simply wrote its own 186-line `requests.put` script, and the guard allowed it.

```
# real Claude Code Write payload (param = `content`)
{"tool_name":"Write","tool_input":{"file_path":".../push_final_grades.py","content":"...requests.put(.../submissions/...posted_grade...)"}}
  before: exit 0 (ALLOWED)   after: exit 2 (blocked)
```

The unit tests passed only because they used the **same wrong key** the code did (`file_contents`) — green tests over a dead integration.

## Fix

Read the body from whichever key is present: `content` (real Write param), `file_contents` (legacy/alt), `new_string` (Edit). Tests now use the real `content` key and pin all three, so a field-name drift can't silently disarm the catch again.

## Impact

Every vendored copy of the hook has been non-functional for Write-based bypass scripts. `cd canvas-toolbox && git pull` to 1.7.34 restores it — no re-init needed (the hook script is read live).

Guardian suite: 21 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
