### PR TITLE
feat(course_engagement_audit): derive UF cutoff from Canvas course end date

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.35] — 2026-07-27
+
+**`course_engagement_audit` derives the UF cutoff from the Canvas course end date — no more hand-supplied date.**
+
+The Title IV audit required `--uf-date YYYY-MM-DD`, so a grader either interrupted to ask the instructor for a date or guessed one. But the tool already fetches the course object — the end date was sitting right there, thrown away. Now `--uf-date` is optional: with no value (or `end`), it uses the course's Canvas `end_at`, falling back to the term end date; `term-end` forces the term date; an explicit `YYYY-MM-DD` still wins. The resolved cutoff and its source print in the header (`UF cutoff: 2026-07-25 (source: Canvas course end date)`) so the classification date stays auditable. If Canvas has no course or term end set, it asks for an explicit date rather than guessing.
+
+---
+
 ## [1.7.34] — 2026-07-27
 
 **Critical: the `grade_guardian` hook was blind to hand-written push scripts — it read the wrong field.**

--- a/lib/tests/test_course_engagement_audit_helpers.py
+++ b/lib/tests/test_course_engagement_audit_helpers.py
@@ -21,6 +21,7 @@ if str(_TOOLS_DIR) not in sys.path:
 
 from course_engagement_audit import (  # noqa: E402
     parse_uf_date,
+    resolve_uf_cutoff,
     parse_iso_utc,
     compute_last_engagement,
     classify_student,
@@ -52,6 +53,57 @@ def test_parse_uf_date_invalid_returns_none():
     """Garbage → None (caller refuses)."""
     for bad in ("", None, "garbage", "2026", "2026/04/15", "04-15-2026"):
         assert parse_uf_date(bad) is None
+
+
+# ---------------------------------------------------------------------------
+# resolve_uf_cutoff — derive the cutoff from Canvas course/term settings so the
+# operator doesn't hand-look-up a date ("check the end date in Canvas settings")
+# ---------------------------------------------------------------------------
+
+def test_resolve_uf_cutoff_defaults_to_course_end_date():
+    """No arg -> the course's Canvas end_at (date part), labeled as such."""
+    course = {"end_at": "2026-07-25T05:59:59Z", "term": {"end_at": "2026-08-01T00:00:00Z"}}
+    d, src = resolve_uf_cutoff(None, course)
+    assert d is not None and d.strftime("%Y-%m-%d") == "2026-07-25"
+    assert src == "Canvas course end date"
+
+
+def test_resolve_uf_cutoff_end_keyword_matches_default():
+    course = {"end_at": "2026-07-25T05:59:59Z"}
+    assert resolve_uf_cutoff("end", course)[0].day == 25
+
+
+def test_resolve_uf_cutoff_falls_back_to_term_end_when_no_course_end():
+    """A course with no end_at (the common case — dates come from the term)."""
+    course = {"end_at": None, "term": {"end_at": "2026-08-01T12:00:00Z"}}
+    d, src = resolve_uf_cutoff(None, course)
+    assert d is not None and d.strftime("%Y-%m-%d") == "2026-08-01"
+    assert src == "Canvas term end date"
+
+
+def test_resolve_uf_cutoff_term_end_keyword_forces_term():
+    course = {"end_at": "2026-07-25T00:00:00Z", "term": {"end_at": "2026-08-01T00:00:00Z"}}
+    d, src = resolve_uf_cutoff("term-end", course)
+    assert d.strftime("%Y-%m-%d") == "2026-08-01" and src == "Canvas term end date"
+
+
+def test_resolve_uf_cutoff_explicit_date_wins():
+    course = {"end_at": "2026-07-25T00:00:00Z"}
+    d, src = resolve_uf_cutoff("2026-06-01", course)
+    assert d.strftime("%Y-%m-%d") == "2026-06-01" and src == "explicit --uf-date"
+
+
+def test_resolve_uf_cutoff_none_when_no_dates_available():
+    """No arg + Canvas has neither course nor term end -> caller must ask for one."""
+    d, src = resolve_uf_cutoff(None, {"end_at": None, "term": {}})
+    assert d is None and src == "Canvas term end date"
+
+
+def test_resolve_uf_cutoff_invalid_explicit_reports_explicit_source():
+    """A bad explicit date returns None but labels the source so the caller can
+    print the right 'invalid --uf-date' message rather than 'no end date'."""
+    d, src = resolve_uf_cutoff("not-a-date", {"end_at": "2026-07-25T00:00:00Z"})
+    assert d is None and src == "explicit --uf-date"
 
 
 def test_parse_uf_date_invalid_day_returns_none():

--- a/lib/tools/course_engagement_audit.py
+++ b/lib/tools/course_engagement_audit.py
@@ -134,6 +134,31 @@ def parse_uf_date(s: str | None) -> datetime | None:
         return None
 
 
+def resolve_uf_cutoff(arg: str | None, course: dict) -> tuple:
+    """Resolve the UF cutoff from an operator arg OR the Canvas course settings.
+
+    So the operator doesn't have to hand-look-up a date: with no --uf-date (or
+    'end'/'auto'), use the course's Canvas end date (`end_at`), falling back to the
+    enclosing term's end date. 'term-end' forces the term end date. An explicit
+    YYYY-MM-DD is used as-is. Canvas end dates are full ISO timestamps; we take the
+    date part so the cutoff matches parse_uf_date's start-of-day-UTC semantics
+    ("last engagement ON the cutoff day is still ACTIVE").
+
+    Returns (datetime_or_None, source_label). None means nothing resolved — the
+    caller should ask for an explicit date.
+    """
+    key = (arg or "end").strip().lower()
+    term_end = ((course.get("term") or {}).get("end_at") or "")
+    if key in ("end", "auto"):
+        course_end = course.get("end_at") or ""
+        if course_end:
+            return parse_uf_date(course_end[:10]), "Canvas course end date"
+        return parse_uf_date(term_end[:10]), "Canvas term end date"
+    if key in ("term-end", "term"):
+        return parse_uf_date(term_end[:10]), "Canvas term end date"
+    return parse_uf_date(arg), "explicit --uf-date"
+
+
 def parse_iso_utc(s: str | None) -> datetime | None:
     """Parse a Canvas ISO timestamp to a UTC-aware datetime.
 
@@ -490,11 +515,13 @@ def main() -> int:
                     "for the course's enrolled students. Outputs PDF + MD "
                     "to ~/Downloads/ (NEVER the repo) for FERPA reasons.")
     ap.add_argument("--version", action="version", version=f"canvas-toolbox {__version__}")
-    ap.add_argument("--uf-date", required=True,
-                    help="UF cutoff date (YYYY-MM-DD). Students whose last "
-                         "engagement is BEFORE this date get classified as "
-                         "UW or UF (depending on passing-score); students "
-                         "with engagement >= this date are ACTIVE.")
+    ap.add_argument("--uf-date", default=None,
+                    help="UF cutoff. YYYY-MM-DD for an explicit date; or 'end' "
+                         "(the default) to use the course's Canvas end date, "
+                         "falling back to the term end date; or 'term-end' to "
+                         "force the term end date. Students whose last engagement "
+                         "is BEFORE the cutoff get UW/UF (depending on "
+                         "passing-score); engagement >= the cutoff is ACTIVE.")
     ap.add_argument("--course-id", default=None,
                     help="Override CANVAS_COURSE_ID from .env.")
     ap.add_argument("--passing-score", type=float, default=60.0,
@@ -508,12 +535,6 @@ def main() -> int:
                     help="Print classification counts only; no file written.")
     args = ap.parse_args()
 
-    uf_date = parse_uf_date(args.uf_date)
-    if uf_date is None:
-        print(f"ERROR: invalid --uf-date {args.uf_date!r}. Use YYYY-MM-DD.",
-              file=sys.stderr)
-        return 1
-
     tok, base, cid = _env_canvas(args.course_id)
     missing = [k for k, v in (("CANVAS_API_TOKEN", tok),
                               ("CANVAS_BASE_URL", base),
@@ -525,21 +546,36 @@ def main() -> int:
 
     headers = {"Authorization": f"Bearer {tok}"}
 
-    # Course metadata for the report title
+    # Course metadata — title, and the end date we may derive the UF cutoff from.
     try:
         r = requests.get(f"{base}/api/v1/courses/{cid}",
-                         headers=headers, timeout=_TIMEOUT)
+                         headers=headers, params={"include[]": "term"}, timeout=_TIMEOUT)
         r.raise_for_status()
-        course_title = (r.json() or {}).get("name", f"Course {cid}")
+        course = r.json() or {}
+        course_title = course.get("name", f"Course {cid}")
     except (requests.HTTPError, requests.RequestException) as e:
         print(f"ERROR: course metadata fetch failed ({type(e).__name__}: {e}).",
               file=sys.stderr)
         return 1
 
+    # Resolve the UF cutoff — from Canvas course/term settings by default, or an
+    # explicit --uf-date. Prints the source so the classification date is auditable.
+    uf_date, uf_source = resolve_uf_cutoff(args.uf_date, course)
+    if uf_date is None:
+        if uf_source == "explicit --uf-date":
+            print(f"ERROR: invalid --uf-date {args.uf_date!r}. Use YYYY-MM-DD, "
+                  "'end', or 'term-end'.", file=sys.stderr)
+        else:
+            print("ERROR: Canvas has no course or term end date set for this course, "
+                  "so the UF cutoff can't be derived. Pass --uf-date YYYY-MM-DD.",
+                  file=sys.stderr)
+        return 1
+    uf_date_str = uf_date.strftime("%Y-%m-%d")
+
     print(f"Course Engagement Audit (Title IV verified {_TITLE_IV_VERIFIED_DATE})")
     print(f"  Course: {course_title}")
     print(f"  Course ID: {cid}")
-    print(f"  UF cutoff: {args.uf_date}")
+    print(f"  UF cutoff: {uf_date_str}  (source: {uf_source})")
     print(f"  Passing score: {args.passing_score}")
     print()
 
@@ -697,7 +733,7 @@ def main() -> int:
     # Step 5: Render report
     generated_at = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
     md_content = render_report_md(
-        named_rows, course_title, cid, args.uf_date, generated_at, args.passing_score,
+        named_rows, course_title, cid, uf_date_str, generated_at, args.passing_score,
     )
 
     # Step 6: Write to ~/Downloads/ — NEVER the repo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.34"
+version = "1.7.35"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## What

The Title IV engagement audit required `--uf-date YYYY-MM-DD`, so a grader either stopped to ask the instructor for a date or guessed one. But the tool already fetches the course object — the end date (`end_at`) was sitting right there, thrown away.

## Change

`--uf-date` is now optional:
- **no value** (or `end`) → the course Canvas `end_at`, falling back to the **term** end date
- `term-end` → force the term end date
- explicit `YYYY-MM-DD` → still wins

The resolved cutoff + its source print in the header (`UF cutoff: 2026-07-25 (source: Canvas course end date)`) so the classification date stays auditable. If Canvas has neither a course nor term end date, it asks for an explicit date instead of guessing.

Answers the field ask: *"check the end date of the course in canvas settings"* — now it does, automatically.

## Tests
7 new for `resolve_uf_cutoff` (course-end default, term fallback, keyword forcing, explicit-wins, no-dates, invalid-explicit labeling). Suite: 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)