### PR TITLE
fix(grade_guardian): block RUNNING an existing bypass script (the third leg)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.36] — 2026-07-27
+
+**`grade_guardian` now blocks *running* an existing bypass script — the third and last leg.**
+
+The guard covered creating a bypass script (Write, fixed in 1.7.34) and editing one (Edit), but not **running** one that already exists: `python fix_push.py` has no write verb in the command — the `requests.put` is hidden in the file. That gap was behind a cluster of field failures that all share one root cause (a grade write that skipped grader_push, so none of its protections applied): **duplicate comments** (bypassed the duplicate-comment Andon), **grades on Test Student** (bypassed the #61 exclusion), and **wrong grade scales** (bypassed grade validation).
+
+Now, for a `python x.py` / `uv run … x.py` command, the guard reads `x.py` and blocks it if the body carries the Canvas grade-write signature — skipping `lib/tools/` (the reviewed tooling legitimately writes to Canvas). Same regex-not-a-firewall limit as the rest of the guard (obfuscation like `exec(open(...))` still slips), but it decisively stops a plain `python push.py`, the actual field pattern. Fails open on an unreadable path — never bricks a session.
+
+This neutralizes bypass scripts that already exist in a repo, not just new ones. `cd canvas-toolbox && git pull` to 1.7.36 to get it.
+
+---
+
 ## [1.7.35] — 2026-07-27
 
 **`course_engagement_audit` derives the UF cutoff from the Canvas course end date — no more hand-supplied date.**

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -14,7 +14,12 @@ _TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
 if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
-from grade_guardian import evaluate, ensure_hook, hook_command  # noqa: E402
+from grade_guardian import (evaluate, ensure_hook, hook_command,  # noqa: E402
+                            _extract_script_paths)
+
+_BYPASS_BODY = ('import requests\n'
+                'requests.put("https://x.instructure.com/api/v1/courses/1/assignments/2/'
+                'submissions/3", data={"submission[posted_grade]": "90"})\n')
 
 HOOK = _TOOLS_DIR / "grade_guardian.py"
 
@@ -118,6 +123,56 @@ def test_denies_bypass_script_regardless_of_body_key():
 def test_denies_edit_that_introduces_a_canvas_write():
     body = 'requests.post("https://x.instructure.com/api/v1/courses/1/assignments/2/submissions/3")'
     assert evaluate("Edit", {"file_path": "grading/kc3/hack.py", "new_string": body}) is not None
+
+
+# --- DENY: RUNNING an existing bypass script (the run-catch, third leg) --------
+
+def test_extract_script_paths_finds_py_tokens_not_dot_python():
+    paths = _extract_script_paths("uv run python ./g/fix_push.py --course S1")
+    assert "./g/fix_push.py" in paths
+    # `python` / `.python` must NOT be captured as a script path
+    assert not any(p.endswith("python") for p in _extract_script_paths("python3 foo"))
+
+
+def test_denies_running_existing_bypass_script(tmp_path):
+    """The gap that stacked comments + graded Test Student in the field: an already-
+    existing hand-written push script, RUN via `python x.py`. The command string has
+    no write verb; the write is inside the file. The guard reads it and blocks."""
+    script = tmp_path / "fix_push.py"
+    script.write_text(_BYPASS_BODY, encoding="utf-8")
+    reason = evaluate("Bash", {"command": f"uv run python {script} --course S1"})
+    assert reason is not None
+    assert "grader_push.py" in reason
+
+
+def test_denies_running_bypass_script_via_relative_path(tmp_path, monkeypatch):
+    """Relative script paths resolve against CLAUDE_PROJECT_DIR (how Claude Code
+    runs commands from the repo root)."""
+    (tmp_path / "grading").mkdir()
+    (tmp_path / "grading" / "push.py").write_text(_BYPASS_BODY, encoding="utf-8")
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    assert evaluate("Bash", {"command": "python grading/push.py"}) is not None
+
+
+def test_allows_running_ordinary_python_script(tmp_path):
+    """A non-Canvas script (no write signature) runs freely — no over-blocking."""
+    script = tmp_path / "analyze.py"
+    script.write_text("import pandas as pd\nprint('hello')\n", encoding="utf-8")
+    assert evaluate("Bash", {"command": f"python {script}"}) is None
+
+
+def test_run_catch_fails_open_on_unreadable_script():
+    """A path that doesn't resolve → can't read the body → ALLOW (fail open); the
+    guard must never brick a session because a path didn't exist."""
+    assert evaluate("Bash", {"command": "python /nope/does_not_exist.py"}) is None
+
+
+def test_run_catch_does_not_reread_grader_push(tmp_path, monkeypatch):
+    """grader_push.py under lib/tools/ legitimately contains Canvas writes — running
+    it must stay exempt (the run-catch skips lib/tools/ before reading)."""
+    monkeypatch.setenv("CLAUDE_PROJECT_DIR", str(tmp_path))
+    assert evaluate("Bash", {"command":
+        "uv run python canvas-toolbox/lib/tools/grader_push.py --push"}) is None
 
 
 def test_denies_reading_ferpa_zone2_files():

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -13,8 +13,11 @@ WHY THIS EXISTS
 WHAT IT DENIES
   - Bash: a direct Canvas grade/comment write in the command string (a write verb
     — requests.put/post, curl/wget -X PUT/POST — aimed at a Canvas submissions
-    endpoint or grade payload). Invocations of the sanctioned tools under
-    lib/tools/ are exempt.
+    endpoint or grade payload). ALSO the RUN of an existing bypass script: for a
+    `python x.py` / `uv run … x.py` command it reads x.py and blocks if the file
+    body carries that write signature (the create/edit hooks can't catch a script
+    that already exists, and the write is hidden inside the file). Invocations of
+    the sanctioned tools under lib/tools/ are exempt.
   - Write/Edit: creating/editing a file (outside lib/tools/) whose contents carry
     that same Canvas-write signature — this catches the bypass SCRIPT at creation,
     which is the only reliable catch (a Bash hook can't see inside `python x.py`).
@@ -79,6 +82,37 @@ _FERPA_PATH = re.compile(
 )
 
 
+# A `*.py` token in a shell command — `python push.py`, `uv run … x.py`. The `\b`
+# after `.py` avoids matching `.python`. Quotes/pipes/parens bound the token.
+_SCRIPT_TOKEN = re.compile(r"[^\s;|&'\"()]+\.py\b")
+_MAX_SCRIPT_BYTES = 200_000
+
+
+def _extract_script_paths(cmd: str) -> list:
+    """Every `*.py` path token a shell command runs (deduped, order-preserved)."""
+    return list(dict.fromkeys(_SCRIPT_TOKEN.findall(cmd)))
+
+
+def _read_script(path: str) -> str:
+    """Best-effort read of a script the command executes, so the run-catch can see a
+    Canvas write hidden INSIDE the file. Resolves a relative path against
+    CLAUDE_PROJECT_DIR and CWD. Returns "" on any failure — fail OPEN, never brick a
+    session because a path didn't resolve."""
+    import os
+    tried = []
+    for base in ("", os.environ.get("CLAUDE_PROJECT_DIR") or "", os.getcwd()):
+        c = path if (not base or os.path.isabs(path)) else os.path.join(base, path)
+        if c in tried:
+            continue
+        tried.append(c)
+        try:
+            with open(c, "r", encoding="utf-8", errors="ignore") as fh:
+                return fh.read(_MAX_SCRIPT_BYTES)
+        except (OSError, ValueError):
+            continue
+    return ""
+
+
 def _redirect(what: str) -> str:
     return (
         f"⛔ Blocked {what}. Grades reach Canvas ONLY through grader_push.py, which "
@@ -104,6 +138,20 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
             return None  # invoking the sanctioned tools is the safe path
         if _WRITE_VERB.search(cmd) and _CANVAS_CTX.search(cmd):
             return _redirect("a direct Canvas grade write in a shell command")
+        # Run-catch: executing an EXISTING script whose BODY writes to Canvas. The
+        # create (Write) / edit (Edit) hooks can't catch a script that already
+        # exists, and the command string alone hides the write inside the file —
+        # `python push.py` has no write verb. Read each *.py the command runs (skip
+        # the sanctioned lib/tools/, which legitimately contains Canvas writes) and
+        # block if its body carries the grade-write signature. This is the same
+        # regex-not-a-firewall limit noted above; it decisively stops a plain
+        # `python push.py` bypass, the actual field failure mode.
+        for script in _extract_script_paths(cmd):
+            if "/lib/tools/" in ("/" + script.replace("\\", "/")):
+                continue  # the reviewed tooling — running it is the safe path
+            body = _read_script(script)
+            if body and _WRITE_VERB.search(body) and _CANVAS_CTX.search(body):
+                return _redirect(f"running {script} — it writes grades to Canvas directly")
         return None
 
     if tool_name in ("Write", "Edit"):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.35"
+version = "1.7.36"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.34"
+version = "1.7.35"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The gap

The guardian covered two of three vectors for a Canvas write that skips grader_push:
- **create** a bypass script (Write) — fixed in #239
- **edit** one (Edit) — already worked
- **run** an existing one — **not covered**

`python fix_push.py` has no write verb in the command; the `requests.put` is hidden in the file. So an already-existing bypass script ran freely.

## Why it matters (one root cause, three symptoms)

Every recent field failure traces to a grade write that skipped grader_push, so none of its protections applied:
- **duplicate comments** — bypassed the duplicate-comment Andon (#207)
- **grades on Test Student** — bypassed the #61 default exclusion
- **0-4 vs 0-100 scale** — bypassed grade validation

grader_push already prevents all three. The fix forces execution back through it.

## The change

For a `python x.py` / `uv run … x.py` command, read `x.py` and block if the body carries the Canvas grade-write signature — skipping `lib/tools/` (the reviewed tooling legitimately writes to Canvas). Resolves relative paths against `CLAUDE_PROJECT_DIR` + CWD. **Fails open** on an unreadable path.

## Proof (real hook binary)

```
run existing bypass script  -> exit 2 (blocked)
run grader_push (lib/tools) -> exit 0 (allowed)
```

## Honest limit

Still regex-on-content — obfuscation (`exec(open(...))`, base64) slips, same caveat the guard already documents. It decisively stops a plain `python push.py`, the actual field pattern.

## Tests
7 new (run-catch block, relative-path resolution, ordinary-script allow, fail-open, grader_push-exempt, token extraction). Guardian suite: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)