### PR TITLE
fix(build_deid_master): dedup by user_id — multi-section students duplicated rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.39] — 2026-07-28
+
+**`build_deid_master` now dedups by user_id — a multi-section student no longer produces duplicate rows in `.deid_master.csv`.**
+
+The de-id master's contract is *one row per student*, but it built one row per record from Canvas `/courses/:id/users`, which returns a student **once per section**. So a student in two sections (S1 + S2 — a common shape) got **duplicate user_id rows**, which silently breaks downstream identity joins. `detect_collisions` couldn't catch it — it flags *different* user_ids sharing a code, the opposite case.
+
+Now `dedupe_users` collapses duplicates to one entry per user_id, **merging their enrollments** so `withdrawn` stays correct (active in any section wins), and logs how many were collapsed.
+
+Not a bug in re-identification: `grader_reidentify.py` was already keyed and duplicate-aware (`user_id → [keys]`), so mapping identities by *key* — never by sort order — remains the correct path for per-submission data where one student legitimately has many keys.
+
+---
+
 ## [1.7.38] — 2026-07-27
 
 **A disclosure-tag menu — say honestly what graded the work vs what wrote the comment.**

--- a/lib/tests/test_build_deid_master_helpers.py
+++ b/lib/tests/test_build_deid_master_helpers.py
@@ -19,12 +19,56 @@ if str(_TOOLS_DIR) not in sys.path:
 from build_deid_master import (  # noqa: E402
     StudentRow,
     deid_code_for,
+    dedupe_users,
     detect_collisions,
     is_withdrawn,
     render_csv_rows,
     render_known_names_lines,
     student_to_row,
 )
+
+
+# ---------------------------------------------------------------------------
+# dedupe_users — one row per student even when Canvas returns a multi-section
+# student more than once (the .deid_master duplicate-user_id bug)
+# ---------------------------------------------------------------------------
+
+def test_dedupe_users_collapses_multi_section_student():
+    """A student in two sections is returned twice by /users → must become ONE
+    entry, else .deid_master.csv gets duplicate user_id rows."""
+    users = [
+        {"id": 1, "sortable_name": "A, A", "enrollments": [{"enrollment_state": "active"}]},
+        {"id": 1, "sortable_name": "A, A", "enrollments": [{"enrollment_state": "active"}]},
+        {"id": 2, "sortable_name": "B, B", "enrollments": [{"enrollment_state": "active"}]},
+    ]
+    unique, collapsed = dedupe_users(users)
+    assert collapsed == 1
+    assert sorted(int(u["id"]) for u in unique) == [1, 2]
+
+
+def test_dedupe_users_merges_enrollments_so_active_wins():
+    """Merged enrollments must let is_withdrawn see BOTH states — active in one
+    section overrides inactive in another (student is NOT withdrawn)."""
+    users = [
+        {"id": 5, "sortable_name": "C, C", "enrollments": [{"enrollment_state": "inactive"}]},
+        {"id": 5, "sortable_name": "C, C", "enrollments": [{"enrollment_state": "active"}]},
+    ]
+    unique, _ = dedupe_users(users)
+    assert len(unique) == 1
+    row = student_to_row(unique[0], "S-", 6)
+    assert row.withdrawn == 0  # active section wins → not withdrawn
+
+
+def test_dedupe_users_no_duplicates_is_a_noop():
+    users = [{"id": 1, "enrollments": []}, {"id": 2, "enrollments": []}]
+    unique, collapsed = dedupe_users(users)
+    assert collapsed == 0 and len(unique) == 2
+
+
+def test_dedupe_users_skips_record_with_bad_id():
+    users = [{"id": 1, "enrollments": []}, {"sortable_name": "no id"}, {"id": "x"}]
+    unique, _ = dedupe_users(users)
+    assert [int(u["id"]) for u in unique] == [1]
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/build_deid_master.py
+++ b/lib/tools/build_deid_master.py
@@ -149,6 +149,33 @@ def student_to_row(user: dict, prefix: str, hash_bits: int) -> StudentRow:
     )
 
 
+def dedupe_users(users: list[dict]) -> tuple[list[dict], int]:
+    """Collapse users Canvas returns more than once. `/courses/:id/users` yields a
+    student once PER SECTION, so a multi-section student (e.g. S1 + S2) comes back
+    twice. Keep one entry per user_id and MERGE their enrollments so is_withdrawn
+    sees every state (active in any section wins). Returns (unique, n_collapsed).
+
+    Without this, a multi-section student gets DUPLICATE rows in .deid_master.csv —
+    duplicate user_ids that silently break downstream identity joins, since the
+    master's contract is ONE row per student. detect_collisions can't catch it: it
+    flags DIFFERENT user_ids sharing a code, not the same user_id appearing twice.
+    """
+    by_uid: dict[int, dict] = {}
+    collapsed = 0
+    for u in users:
+        try:
+            uid = int(u["id"])
+        except (KeyError, TypeError, ValueError):
+            continue
+        if uid in by_uid:
+            by_uid[uid]["enrollments"] = (
+                (by_uid[uid].get("enrollments") or []) + (u.get("enrollments") or []))
+            collapsed += 1
+        else:
+            by_uid[uid] = {**u, "enrollments": list(u.get("enrollments") or [])}
+    return list(by_uid.values()), collapsed
+
+
 def detect_collisions(rows: list[StudentRow]) -> list[tuple[str, list[int]]]:
     """Return [(deid_code, [user_id, user_id, ...])] for every code that
     appears more than once. Empty list = no collisions.
@@ -302,6 +329,10 @@ def main() -> int:
     print(f"Fetching all students (active + invited + inactive + completed)...")
     users = fetch_all_students(base_url, course_id, token)
     print(f"  {len(users)} student records returned")
+    users, collapsed = dedupe_users(users)
+    if collapsed:
+        print(f"  collapsed {collapsed} duplicate record(s) from multi-section "
+              f"enrollments → {len(users)} unique students (one row per student)")
 
     rows = [student_to_row(u, args.prefix, args.hash_bits) for u in users]
     collisions = detect_collisions(rows)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.38"
+version = "1.7.39"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.37"
+version = "1.7.38"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The possible bug — confirmed, but narrower than it looked

Reported symptom: duplicate user_ids in `.deid_master.csv`. Two findings:

### Not a bug: re-identification is already correct
`grader_reidentify.py` maps identities **by key**, and is duplicate-aware — `build_user_to_keys` returns `user_id → [keys]` precisely because *"multiple submissions from the same student CAN map to the same user_id."* So the toolkit **never** maps by sort order. For per-submission data (`final-review_*` + `fpr_*`), one student legitimately having several keys is expected, and keyed re-identification handles it. The sort-order approach in the field was an improvised workaround, not how the tool works.

### Real bug: the master duplicated multi-section students
`.deid_master.csv`'s contract is **one row per student**, but `build_deid_master` built one row per record from `/courses/:id/users` — which returns a student **once per section**. A student in two sections (S1 + S2 — common) produced **duplicate user_id rows**, silently breaking downstream identity joins. `detect_collisions` couldn't catch it (it flags *different* user_ids sharing a code — the opposite).

## Fix
`dedupe_users` collapses to one entry per user_id, **merging enrollments** so `withdrawn` stays correct (active in any section wins), and logs the collapse count.

## Tests
4 new: collapse multi-section, merge-so-active-wins, no-dup no-op, skip-bad-id. Suite: 36 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)