### PR TITLE
refactor(agents): AGENTS.md constitution + 6 operating-mode skills

### DIFF
--- a/.claude/skills/accommodations/SKILL.md
+++ b/.claude/skills/accommodations/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: accommodations
+description: Use for per-student interventions in Canvas — SAS/disability accommodations, quiz time extensions, late-work grace, assignment/date exemptions, group-override recalculation, and submitting on a student's behalf. All are keyed by an opaque --deid-code or --user-id the INSTRUCTOR supplies (you never look up the name). Load this when the task is "give student X extra time / late grace / an override / an exemption", NOT grading and NOT course content.
+---
+
+# Accommodations & student interventions
+
+Per-student operational actions an instructor directs: accommodations, extensions,
+grace, overrides, exemptions. These write to Canvas and are always **instructor-
+initiated for a specific student**.
+
+> The **constitution** (AGENTS.md) binds you: the instructor looks up the student
+> in the local `.deid_master.csv` and hands you ONLY the opaque `deid_code` or
+> numeric `user_id`. You use it as-is — **no re-identification, never a name.**
+
+## The identity contract
+
+Every tool here accepts `--deid-code <S-XXXXXX>` or `--user-id <n>` directly. You do
+**not** read `.deid_master.csv` to "look up" the student — that's a FERPA Zone-2
+violation. If the instructor says "give Sydney extra time," ask them for Sydney's
+deid_code or user_id; you never resolve the name yourself.
+
+Output discipline: ✅ "Applied 1.5× time for deid_code S-95DBB6" · ❌ "…for Sydney."
+
+## Tools
+
+| Intervention | Tool |
+|---|---|
+| Quiz time extension (e.g. 1.5× / 2× on timed quizzes) | `student_quiz_time_extension.py --deid-code <code> --multiplier 1.5 --all-timed --apply` |
+| Late-work grace / reopen past-due assignments | `student_late_accommodation.py --deid-code <code> --from-days-ago 14 --apply` |
+| SAS / disability-office accommodation dispatcher (processes letters) | `apply_sas_accommodations.py --apply` |
+| Exempt a student from an assignment by date | `exempt_by_date.py …` |
+| Student can't submit / override not taking effect / force recalc | `fix_group_override_recalc.py --course-id <id> --student-id <id>` |
+| Submit an artifact on a student's behalf | `submit_on_behalf.py …` |
+
+## Discipline
+
+- **`--apply` is the write gate.** Every tool defaults to a dry-run preview; nothing
+  reaches Canvas until `--apply`. Preview first, confirm the target student + change,
+  then apply.
+- **`canvas_course_guard` still applies** — an enrolled-course write is gated; the
+  instructor's own course needs the explicit override the tool documents.
+- **Canvas write lessons that bite here:** overrides + due-date changes need the full
+  `due_at`/`lock_at`/`unlock_at` trio, and a group override sometimes needs a forced
+  recalc before Canvas honors it (`fix_group_override_recalc.py`).
+
+## Quick command map
+
+| Ask | Command |
+|---|---|
+| "Give student X 1.5× on all quizzes" | `student_quiz_time_extension.py --deid-code <code> --multiplier 1.5 --all-timed --apply` |
+| "Let student X submit late" | `student_late_accommodation.py --deid-code <code> --from-days-ago 14 --apply` |
+| "Process the SAS letters" | `apply_sas_accommodations.py --apply` |
+| "Student X still can't submit" | `fix_group_override_recalc.py --course-id <id> --student-id <id>` |

--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: audit
+description: Use for READ-MOSTLY analysis of a Canvas course's design quality — one-command health checks (course_audit), post-push structural checks (course_quality_check), the 8-framework instructional-design audit stack, rubric quality/coverage, and blueprint exception reports. Load this when the task is "check / audit / report on" a course's structure or instructional design. (For Title IV engagement / unofficial-withdrawal compliance, use the `title-iv` skill instead.)
+---
+
+# Audit
+
+Analyze course structure, instructional-design quality, and Title IV engagement.
+These tools mostly **read**; they surface problems, they don't apply fixes.
+
+> The **constitution** (AGENTS.md) binds you: FERPA Zone-2 files are never read, and
+> reports containing student names are written OUTSIDE the repo (see Title IV below).
+
+## Structural + quality audits
+
+| Task | Tool |
+|---|---|
+| One-command pre-semester health check (rubrics / CLOs / syllabus / workload) | `course_audit.py --course-id <id>` |
+| Post-push structural audit (duplicates, floating items, date windows) | `course_quality_check.py` |
+| Rubric quality + coverage | `rubric_quality_audit.py` |
+| Blueprint sync exceptions (silent per-section skips) | `blueprint_exception_report.py` |
+
+Validate the audit **baseline** before proposing a redesign — check
+`.canvas/audit/<course_id>.json`. Ground pedagogical findings in the knowledge
+base and cite the framework used.
+
+## The 8-framework instructional-design stack
+
+Audits score against: Cognitive Load, Hattie 3-Phase, Three Domains, BYUI Taxonomy
+Explorer, Experiential Learning, Designer Thinking, Course Design Language, and the
+Toyota A3. References live in [`lib/agents/knowledge/README.md`](../../../lib/agents/knowledge/README.md).
+
+## Title IV engagement → a separate skill
+
+The last-date-of-engagement / unofficial-withdrawal audit
+(`course_engagement_audit.py`) is **federal-compliance** work with its own stakes and
+vocabulary — it lives in the **`title-iv`** skill, not here. Load that skill for
+"who stopped participating", UW/UF, R2T4, or last-date-of-attendance work.
+
+## Quick command map
+
+| Ask | Command |
+|---|---|
+| "Audit the course" / "health check" | `course_audit.py --course-id <id>` |
+| "Check quality after a push" | `course_quality_check.py` |
+| "Check the rubrics" | `rubric_quality_audit.py` / `rubric_coverage_audit.py` |

--- a/.claude/skills/course-build/SKILL.md
+++ b/.claude/skills/course-build/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: course-build
+description: Use for building and syncing Canvas course CONTENT — mirroring a course to/from local files (canvas_sync pull/push/build), master→blueprint→section propagation (blueprint_sync), module prerequisites/completion settings (module_settings_sync), multi-course orchestration, and offline (.imscc) editing. Load this when the task is "make Canvas match the local source" or "propagate content across sections" — NOT grading and NOT read-only auditing.
+---
+
+# Course Build (CI / sync)
+
+Manage Canvas course content as code: mirror to local files, edit locally, and push
+approved changes back through the Canvas REST API.
+
+> The **constitution** (AGENTS.md) binds you: confirm scope before any write, and
+> Canvas writes go through the toolkit (never a hand-rolled API call). This skill is
+> the content-sync *how*.
+
+## Core principle — local is the source of truth
+
+The local working folder is authoritative; **Canvas is the sync target.** Pull to
+mirror, edit locally, push to apply. Canvas has no version history — the local
+files + git are your history.
+
+## The multi-course model
+
+| Term | What | `.env` id | Folder |
+|---|---|---|---|
+| **Master** | Template course where authoring happens | `MASTER_COURSE_ID` | `master/` (or `course/` legacy) |
+| **Blueprint** | Canvas Blueprint sections clone from (online programs) | `BLUEPRINT_COURSE_ID` | `blueprint/` |
+| **Section** | Live per-semester course (S1, S2…) | `S1_COURSE_ID`, … | `s1/`, `s2/` |
+
+**Confirm scope before every write** — master vs blueprint vs section. A stale
+`.env` can silently target the wrong course (Canvas API lesson L12); `canvas_course_guard`
+defends against it, but naming the target explicitly is on you.
+
+## Tools
+
+| Task | Tool |
+|---|---|
+| Mirror one course (pull/push/build) | `canvas_sync.py --pull` / `--push` / `--build` |
+| Master → Blueprint propagation | `blueprint_sync.py` |
+| Validate a blueprint sync | `validate_blueprint_sync.py` + `blueprint_exception_report.py` |
+| Module prerequisites / completion | `module_settings_sync.py` |
+| Multi-course wrapper | `sync_context.sh` |
+| Post-push structural audit | `course_quality_check.py` *(then hand off to the `audit` skill)* |
+
+**Always run `course_quality_check.py` after a push** to catch duplicates, floating
+items, and date-window problems the write may have introduced.
+
+## Canvas API write lessons that bite content sync
+
+The full catalog is [`lib/agents/knowledge/canvas_api_lessons_learned.md`](../../../lib/agents/knowledge/canvas_api_lessons_learned.md).
+The ones that matter here:
+
+- **Module prerequisites & published state are FORM-ENCODED, not JSON** (L1, L2) —
+  a JSON payload silently no-ops.
+- **Date writes need the `due_at`/`lock_at`/`unlock_at` trio** (L3); discussions use
+  `todo_date`, not `due_at` (L7).
+- **`late_policy` PATCH is admin-only** — 403 for teacher tokens (L4).
+- **Classic quizzes have two IDs** (`quiz_id` + `assignment_id`); `points_possible`
+  reads 0 until questions are pushed (L5, L6).
+- **NewQuiz / ExternalTool items can't be content-pushed via REST** (L8) — sync
+  tools warn-and-skip; edit those in the Canvas UI.
+- **Blueprint resync can spawn `-N` slug orphan Pages and silently revert section
+  page bodies** (L13, L14) — `blueprint_orphan_pages.py` detects both.
+- **Page title collisions auto-suffix** `-2`/`-4` (L15).
+
+Adding content is a **two-step** operation (course item + module item) — a page/
+assignment isn't visible to students until it's also a module item.
+
+## Offline mode (v1.7)
+
+Tools read a local `course/` (from `canvas_sync --pull` or `offline_import` of a
+`.imscc`) and run identically online/offline. The `.imscc` is the source of truth;
+`course/` is the working folder. `imscc_record` patches your `course/` edits back
+into the sidecar `.imscc` faithfully (quiz questions / files / LTI preserved
+byte-for-byte) for re-import via the Canvas UI.
+
+## Quick command map
+
+| Ask | Command |
+|---|---|
+| "Pull the course from Canvas" | `canvas_sync.py --pull` |
+| "Push changes to Canvas" | `canvas_sync.py --push` |
+| "Sync master → blueprint" | `blueprint_sync.py` |
+| "Fix module prerequisites" | `module_settings_sync.py` |

--- a/.claude/skills/ferpa-deid/SKILL.md
+++ b/.claude/skills/ferpa-deid/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ferpa-deid
+description: Use for the de-identification / re-identification WORKFLOW — building the course-wide de-id master, de-identifying submissions or a gradebook (docx/pdf/xlsx/jupyter/databricks/text/comments) before anything reaches the LLM, re-identifying keyed results back to students, and scanning for name leaks. Load this when preparing student artifacts for AI processing or turning keyed results back into a named report. The FERPA *discipline* (never read Zone-2 files) is constitutional and always applies; this skill is the *how* of the de-id machinery.
+---
+
+# FERPA de-identification / re-identification
+
+The machinery that lets student work be processed by an LLM without a name ever
+reaching cloud context: strip identity → opaque keys → process → map keys back
+locally.
+
+> The **constitution** (AGENTS.md) is the law: the name-bearing files
+> (`.deid_master.csv`, `.keymap.json`, `.known_names.txt`, `.review.csv`,
+> `submissions_raw/`, `feedback/_grader*.csv`) are **FERPA Zone-2** and are **never**
+> read or displayed — verify with `wc -l`/`ls`, never `cat`/`head`/`grep`. This
+> skill runs the de-id tools; it never bypasses that rule.
+
+## The two-zone flow
+
+```
+raw submissions (names) ──deidentify──▶ opaque keys ──▶ LLM / analysis
+        ▲                                                     │
+        └────────── reidentify (BY KEY, local) ◀──────────────┘
+```
+
+- **Zone 1 (cloud-safe):** de-identified keys + grades. Fine for the LLM.
+- **Zone 2 (local only, gitignored):** the keymap/master that links keys ↔ names.
+
+## Building the master
+
+`build_deid_master.py` builds the course-wide `.deid_master.csv` — **one row per
+student**, keyed by `user_id`, with a stable opaque `deid_code = sha256(user_id)[:6]`.
+It dedups multi-section students (a student in S1+S2 is otherwise returned twice) and
+auto-derives `.known_names.txt` (the scrub roster). Run `--force` to refresh from
+current enrollment. This is the identity surface every keyed tool and accommodation
+consumes.
+
+## De-identifying artifacts (before the LLM)
+
+`grader_fetch.py` de-identifies submissions automatically, dispatching to the right
+format adapter. The standalone adapters exist for direct/one-off use:
+
+| Artifact | Tool |
+|---|---|
+| Word docs | `grader_deidentify_docx.py` |
+| PDFs | `grader_deidentify_pdf.py` |
+| Excel | `grader_deidentify_xlsx.py` |
+| Jupyter notebooks | `grader_deidentify_jupyter.py` |
+| Databricks exports | `grader_deidentify_databricks.py` |
+| Plain text | `grader_deidentify_text.py` |
+| Canvas submission comments | `grader_deidentify_comments.py` |
+| A gradebook export | `grader_deidentify_gradebook.py` |
+
+## Re-identifying results (BY KEY — never by sort order)
+
+- `grader_reidentify.py` maps `key → user_id` via `.keymap.json`, and is
+  **duplicate-aware** (`user_id → [keys]`): one student legitimately has many keys
+  across submission batches (e.g. `final-review_*` + `fpr_*`). **Never** map by row
+  position / sort order — that misattributes results. If two batches share user_ids,
+  that's expected; the keymap disambiguates.
+- `grader_reidentify_gradebook.py` re-identifies a de-identified gradebook.
+- Re-identified output is Zone-2 — write it outside any cloud-synced or git-tracked
+  path (e.g. `~/Downloads/`), never back into the repo.
+
+## Verifying no leak
+
+`grader_name_leak_check.py` scans keyed/de-identified artifacts for any name that
+slipped through the scrub (against `.known_names.txt`). Run it before handing
+de-identified material to the LLM if you're unsure the scrub was complete.
+
+## Quick command map
+
+| Ask | Command |
+|---|---|
+| "Rebuild the de-id master / student list" | `build_deid_master.py --force` |
+| "De-identify these submissions" | (usually automatic via `grader_fetch.py`) |
+| "Turn the keyed results back into names" | `grader_reidentify.py --challenge-dir grading/<name>` |
+| "Check nothing leaked a name" | `grader_name_leak_check.py …` |

--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: grading
+description: Use for ANY grading work in a Canvas course — fetching submissions, running consensus grading, reviewing feedback, pushing grades/comments to Canvas (grader_push), the "your grade" standing column (grader_standing), de-identifying submissions before the LLM, or re-identifying results. Carries the HG-5 human-in-the-loop protocol, the push gates, the disclosure-tag menu, and the FERPA de-id/re-id flow. Load this before touching any grade that could reach a student.
+---
+
+# Grading
+
+Grading with AI is **decision support, not autonomy.** A human decides every grade
+that reaches a student. This skill is the operating manual for that discipline.
+
+> The **constitution** (AGENTS.md) already binds you at all times: never read FERPA
+> Zone-2 files, and grades reach Canvas ONLY through a sanctioned `lib/tools/`
+> writer. This skill is the *how*; those are the *never*.
+
+## HG-5 — the instructor is the top layer
+
+Principle **HG-5** of the [hybrid grading architecture](../../../lib/agents/knowledge/grader_hybrid_architecture.md):
+the agent drafts; the instructor reviews and confirms; only then does anything post.
+
+### The push protocol — never skip a step
+
+1. **Grade** — `grader_fetch.py --challenge-dir grading/<name>` → 3-pass consensus
+   (`grader_grade.py --bulk` → `grader_consensus.py`). Single-pass LLM grading
+   drifts; consensus is the default.
+2. **Review** — a **human** reads `feedback/_all_comments.md` + each per-student
+   `<KEY>.md`. This is the gate, not a formality.
+3. **Attest** — `grader_push.py --challenge-dir grading/<name> --mark-reviewed`.
+   The human types `reviewed`. The marker auto-invalidates if any feedback file
+   changes afterward.
+4. **Push** — `grader_push.py --challenge-dir grading/<name> --push`. The human
+   types `push` at the confirmation.
+
+## What the code enforces (so the protocol isn't docs-only)
+
+- **`--yes` cannot bypass human review on the AI-drafted path.** With per-student
+  comment files, `--yes` is refused at *both* `--mark-reviewed` (#97) and the final
+  `--push` (#207, HG-5). The value-only / human-graded path (no comment files) keeps
+  `--yes` — there the human *is* the grader.
+- **Confirmation requires a real terminal (#241).** The `reviewed`/`push` prompts
+  refuse piped/redirected stdin — `echo push | grader_push …` no longer satisfies
+  the gate. If you are an assistant and hit this prompt, **hand the command to the
+  instructor to run in their terminal**; do not pipe an answer and do not stack
+  `--yes`/`--regrade`/`--grade-only`/`--allow-enrolled` to force it.
+- **Duplicate-comment Andon.** Canvas *appends* comments, so re-runs stack them.
+  Default mode refuses an already-graded submission; `--regrade` admits ONLY
+  genuine resubmissions and *supersedes* (deletes old grader comments) rather than
+  appending.
+- **Disclosure is mandatory** (see the menu below), appended automatically.
+
+**Do not** run `grader_push.py --yes --push` to "just get the grades in." That is
+the exact HG-5 breach an [RCA](https://github.com/chaz-clark/canvas-toolbox/issues/207)
+was written about — students received AI-drafted grades with no review. If a gate
+blocks you, the fix is to *do the review*, not to reach for an override.
+
+## Never hand-write a Canvas write (the field failure mode)
+
+Grades and comments reach Canvas **only** through `grader_push.py` (feedback) or
+`grader_standing.py` (the standing column) — never a custom `requests`/`curl`
+script, an inline `python -c`, or a `/tmp/*.py`. A direct write skips **every**
+safeguard at once: the review gate, the duplicate-comment Andon, Test-Student
+exclusion (#61), grade validation, `canvas_course_guard`, the disclosure tag.
+Duplicate comments, grades on Test Student, and wrong grade scales in the field
+were **all** hand-written scripts bypassing the tool.
+
+The `grade_guardian` PreToolUse hook enforces this deterministically — it blocks
+**creating** such a script (Write), **editing** one (Edit), and **running** one
+(`python x.py` whose body writes to Canvas). If it blocks you: use the tool, or
+surface the blocker to the instructor. Do **not** route around it.
+
+## The disclosure-tag menu — say honestly what graded vs commented
+
+`--disclosure` picks the provenance tag appended to each comment:
+
+| kind | tag students see | when |
+|---|---|---|
+| `ai` *(default)* | `— AI drafted, instructor reviewed` | AI suggested grade + wrote comment |
+| `hybrid` | `— script graded, AI-drafted comment, instructor approved` | script graded, AI wrote the comment |
+| `script` | `— script graded, instructor reviewed` | script graded, no AI in the comment |
+
+A course that grades one way every time can set `CANVAS_DISCLOSURE_DEFAULT=hybrid`
+in its `.env` and skip the flag; an explicit `--disclosure` still wins. The chosen
+tag prints in the pre-push banner. It won't stack if you switch graders mid-stream.
+
+## grader_standing — the "your grade" column
+
+For a No-Submission column (often weighted 100%) that you compute from a syllabus
+table and refresh weekly — instructor-computed, value-only, roster-keyed. It
+sidesteps Canvas's auto-zero and the regrade gate. It **computes nothing** — your
+script produces the values; the tool pushes them, dry-run by default, with strict
+guards (unmatched/ambiguous key → hard fail; out-of-bounds → abort; big drop →
+abort unless `--allow-swings`). `--yes` is allowed (deterministic, value-only) so
+the weekly run can automate.
+
+```
+grader_standing.py --csv standing.csv --assignment-id <id>                    # dry-run diff
+grader_standing.py --csv standing.csv --assignment-id <id> --push --allow-enrolled
+grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-enrolled   # weekly
+```
+
+## FERPA during grading — de-identify before the LLM, re-identify by key
+
+- `grader_fetch.py` de-identifies submissions (strips names → opaque keys) before
+  anything reaches the LLM. Names live only in the gitignored keymap/master.
+- **Re-identify by KEY, never by sort order.** `grader_reidentify.py` maps
+  `key → user_id` via `.keymap.json`, and is duplicate-aware (`user_id → [keys]`) —
+  one student legitimately has many keys across submission batches. Positional /
+  sort-order mapping is wrong and will misattribute grades.
+- `build_deid_master.py` builds the course-wide `.deid_master.csv` (one row per
+  student, keyed by user_id; dedups multi-section students).
+- Zone-2 files (`.deid_master.csv`, `.keymap.json`, `.known_names.txt`,
+  `.review.csv`, `submissions_raw/`, `feedback/_grader*.csv`) are **never** read or
+  displayed. Verify with `wc -l` / `ls`, never `cat`/`head`/`grep`.
+
+## Quick command map
+
+| Ask | Command |
+|---|---|
+| Grade an assignment | `grader_fetch.py --challenge-dir grading/<name>` → consensus |
+| Attest review | `grader_push.py --challenge-dir grading/<name> --mark-reviewed` |
+| Push feedback | `grader_push.py --challenge-dir grading/<name> --push` |
+| Re-grade a resubmission | add `--regrade` |
+| Update the "your grade" column | `grader_standing.py --csv <f> --assignment-id <id> --push` |
+| Rebuild the de-id master | `build_deid_master.py --force` |
+
+Full grading knowledge: [`lib/agents/knowledge/grader_hybrid_architecture.md`](../../../lib/agents/knowledge/grader_hybrid_architecture.md)
+and [`lib/agents/knowledge/toolkit_reuse_knowledge.md`](../../../lib/agents/knowledge/toolkit_reuse_knowledge.md).

--- a/.claude/skills/title-iv/SKILL.md
+++ b/.claude/skills/title-iv/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: title-iv
+description: Use for federal Title IV compliance — the last-date-of-academic-engagement / unofficial-withdrawal audit (course_engagement_audit), the cached Title IV snapshot (update_title_iv_snapshot), and AI-engagement classification. Load this when the task mentions Title IV, R2T4, unofficial withdrawal (UW/UF), last date of attendance/engagement, or "who stopped participating." This is a compliance domain, distinct from general course auditing — the classifications carry federal-aid consequences.
+---
+
+# Title IV engagement & unofficial-withdrawal compliance
+
+Federal financial-aid compliance (34 CFR 668.22 / R2T4): determine each student's
+**last date of academically related activity** and flag unofficial withdrawals. This
+is a **compliance** domain, not a general course audit — a wrong classification has
+federal-aid consequences, so the tool surfaces candidates and the registrar/financial-
+aid office makes the determination.
+
+> The **constitution** (AGENTS.md) binds you: named reports are written OUTSIDE the
+> repo (never a cloud-synced or git-tracked path), and console output is
+> de-identified (user_id, never names).
+
+## The classifier — `course_engagement_audit.py`
+
+Classifies enrolled students:
+
+- **NEVER_PARTICIPATED** — no engagement on record (logging in ≠ engagement; there
+  must be a submission, quiz attempt, or discussion entry).
+- **UW** (Unofficial Withdrawal) — last engagement before the UF cutoff, passing-or-
+  unknown grade.
+- **UF** (Unofficial Fail) — UW *and* a failing grade → R2T4 candidate.
+- **INACTIVE_ENROLLMENT** — dropped/concluded in Canvas; surfaced for review, **not**
+  auto-classified (may be an already-processed *official* withdrawal — the registrar/
+  FA office decides).
+
+## Key behaviors
+
+- **UF cutoff auto-derives from Canvas.** No `--uf-date`? It uses the course's Canvas
+  end date, falling back to the term end date (`--uf-date end` / `term-end` / an
+  explicit `YYYY-MM-DD`). The resolved date + its source print in the header, so the
+  classification date is auditable.
+- **Inactive students are included by default** — the exact population an engagement
+  audit exists to review. `--active-only` excludes them.
+- **FERPA output discipline:** the named report is written to `~/Downloads/`, never
+  inside the repo. Re-identification happens only at the final write step, keyed, to a
+  file outside any cloud-synced / git-tracked location.
+
+```
+course_engagement_audit.py                       # cutoff = Canvas course end date
+course_engagement_audit.py --uf-date 2026-07-25  # explicit cutoff
+course_engagement_audit.py --active-only         # skip the inactive-review section
+```
+
+## Supporting tools
+
+- `update_title_iv_snapshot.py` — fetch + cache the canonical Title IV snapshot for a
+  course (the reference state a report is computed against).
+- `ai_engagement_classifier.py` — pluggable engagement-taxonomy over a student↔AI
+  transcript, for courses that count AI-tutor interaction as academically related
+  activity.
+
+## Regulatory note
+
+The distance-education R2T4 final rules took effect **2026-07-01**. Re-verify the
+tool's classification rules against the then-current FSA Handbook (Vol. 5, Ch. 1) if
+you're reading this well after that date — federal definitions of "academic
+engagement" evolve.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 ---
 name: canvas-toolbox-agents
-description: AGENTS.md for the `canvas-toolbox` repo — a Canvas LMS course-management & audit toolkit. Working style, handoff recognition, learning loop, audit-tool catalog, and external-system lessons.
-version: "0.1"
+description: Constitution for the `canvas-toolbox` repo — a Canvas LMS course-management & audit toolkit. The always-on rules that govern EVERY session (FERPA discipline, the Canvas-write safety doctrine, behavioral principles, git/handoff conventions) plus the index of operating-mode skills. Mode-specific procedure lives in the skills, not here.
+version: "0.2"
 author: chaz-clark
 license: MIT
 metadata:
@@ -11,499 +11,243 @@ metadata:
 
 # Canvas Toolbox
 
-A Canvas LMS course management toolkit — mirrors live Canvas courses to local files, audits structure against an 8-framework instructional-design stack, and applies instructor-approved changes via the Canvas REST API.
+A Canvas LMS course-management toolkit — mirrors live Canvas courses to local files,
+audits structure against an 8-framework instructional-design stack, and applies
+instructor-approved changes via the Canvas REST API.
 
-## Project Purpose
+**This is**: a toolkit for managing Canvas courses as code (mirror, edit, audit,
+push), an 8-framework audit engine, and a multi-course orchestration system.
+Tool-agnostic (any LLM tool that reads AGENTS.md); built for BYU-Idaho but
+institution-agnostic.
 
-**This is**:
-- A toolkit for managing Canvas courses as code (mirror, edit, audit, push)
-- An 8-framework instructional-design audit engine (Cognitive Load, Hattie 3-Phase, Three Domains, BYUI Taxonomy Explorer, Experiential Learning, Designer Thinking, Course Design Language, Toyota A3)
-- A multi-course orchestration system (master + blueprint + per-section live courses)
-- Tool-agnostic — works with any LLM coding tool that reads AGENTS.md
-- Originally built for BYU-Idaho; designed to be institution-agnostic
+**This is NOT**: a Canvas replacement, a student-facing tool, a VCS for Canvas
+content, or a NewQuiz/ExternalTool editor (REST API limits).
 
-**This is NOT**:
-- A Canvas replacement or LMS
-- A student-facing tool
-- A version-control system for Canvas content (no commit history, no branching, no conflict detection)
-- A NewQuiz or ExternalTool editor (Canvas REST API limitation)
-
-**Audience**: Instructors and instructional designers who edit Canvas courses, want auditable structure, and use LLM coding tools for course design work.
+**Audience**: instructors and instructional designers who edit Canvas courses and
+use LLM coding tools for course-design work.
 
 ---
 
-## ⚠️ AI Agent FERPA Discipline
+## How this file works — constitution + skills
 
-**If you are an AI agent working in this repo or a course repo using this toolkit**, the following files are **FERPA Zone 2** and you **MUST NEVER READ THEM**:
+**This file is the constitution: the always-on rules that bind you in EVERY session,
+whatever the task.** The step-by-step procedure for each kind of work lives in a
+**skill** that loads on demand. Read the constitution always; load the skill for the
+mode you're in.
 
-- `grading/.deid_master.csv` — **user_id to name map** (most common violation)
-- `grading/.known_names.txt` — full course roster (names)
-- `grading/*/.keymap.json` — de-id key to filename+user_id map
+### Skills — the operating modes
+
+Load the matching skill *before* doing that kind of work — it carries the full
+playbook (tools, gates, order of operations) so you don't operate from half-memory.
+
+| Skill | Load it for | Examples |
+|---|---|---|
+| **`grading`** | Any grade that could reach a student | fetch → consensus → review → push; `grader_standing`; disclosure menu |
+| **`course-build`** | Making Canvas match local content | `canvas_sync`, `blueprint_sync`, module settings, offline/`.imscc` |
+| **`audit`** | Read-mostly course-design analysis | `course_audit`, quality check, 8 frameworks, rubric coverage/quality |
+| **`accommodations`** | Per-student interventions | time extensions, late grace, SAS letters, overrides, exemptions, submit-on-behalf |
+| **`ferpa-deid`** | De-id/re-id machinery | `build_deid_master`, de-identify artifacts, re-identify by key, name-leak check |
+| **`title-iv`** | Federal engagement / withdrawal compliance | `course_engagement_audit` (UW/UF/R2T4), Title IV snapshot |
+
+Meta/lifecycle tools (`cb_init` setup, `cb_report_bug`, `vote_feature`) are governed
+here in the constitution, not a skill.
+
+---
+
+## ⚠️ FERPA discipline (constitutional — never overridden)
+
+**These files are FERPA Zone 2. NEVER READ OR DISPLAY THEM** — not with Read, `cat`,
+`head`, `tail`, or bare `grep`. They must never enter LLM context, logs, or any cloud
+surface:
+
+- `grading/.deid_master.csv` — user_id ↔ name map (most common violation)
+- `grading/.known_names.txt` — full roster (names)
+- `grading/*/.keymap.json` — de-id key ↔ filename+user_id
 - `grading/**/.fetch_log.json` — fetch keymap with names
-- `grading/*/.review.csv` — re-identified grading results
+- `grading/*/.review.csv` — re-identified results
 - `grading/*/feedback/_grader*.csv` — grading sheets with names
-- `grading/**/submissions_raw/**` — raw submissions with potential name leaks
+- `grading/**/submissions_raw/**` — raw submissions (potential name leaks)
 
-**Tool discipline — never read or display these files:**
+**Verify with `wc -l` or `ls` only.** To confirm a code exists, filter columns:
+`grep "S-95DBB6" grading/.deid_master.csv | cut -d',' -f1,2` (shows deid_code +
+user_id, never the `sortable_name` column). Redirect to `/dev/null` or `cut` to
+columns 1,2 — never display raw rows.
 
-Trust the tool's summary output. Never use Read, cat, head, tail, grep, or any other file-reading command on these files. They must NEVER enter LLM context, logs, or any cloud surface. For file verification, use only `wc -l` or `ls -la`.
+**Use codes, not names.** Tools accept `--deid-code`/`--user-id`; the *human* looks
+up the identifier locally and hands you the opaque code. You never re-identify.
+✅ "Reopened for user_id 280379" · ❌ "Reopened for Sam Bradshaw (280379)". If asked
+"who is user_id 280379?" → "I don't have the name mapping (FERPA Zone 2); check
+`grading/.deid_master.csv` locally."
 
-**Bash command discipline for .deid_master.csv:**
-
-```bash
-# ✅ SAFE: Check file exists (no output displayed)
-ls grading/.deid_master.csv >/dev/null 2>&1 && echo "✓ Found"
-
-# ✅ SAFE: Count entries (no PII displayed)
-wc -l grading/.deid_master.csv
-
-# ✅ SAFE: Verify specific deid code exists (only show deid_code + user_id columns)
-grep "DS-95DBB6" grading/.deid_master.csv | cut -d',' -f1,2
-# Output: DS-95DBB6,173819 (no name)
-
-# ❌ VIOLATION: These commands display the sortable_name column (FERPA Zone 2)
-head grading/.deid_master.csv
-cat grading/.deid_master.csv
-tail grading/.deid_master.csv
-grep "pattern" grading/.deid_master.csv  # without cut to filter columns
-```
-
-**The sortable_name column is FERPA Zone 2.** All bash commands on `.deid_master.csv` must either:
-- Redirect output to /dev/null (no display), OR
-- Use `cut -d',' -f1,2` to show ONLY deid_code + user_id columns
-
-When testing or verifying, use `wc -l` or existence checks. Never display file contents.
-
-**Why you don't need Zone 2 files:**
-
-Accommodation tools (`student_late_accommodation.py`, `student_quiz_time_extension.py`, `apply_sas_accommodations.py`) accept `--user-id` and `--deid-code` directly. The **human instructor** looks up the identifier locally in `.deid_master.csv` and hands you ONLY the opaque code or numeric user_id. You use it as-is; **no re-identification needed**.
-
-**Output discipline:**
-
-- ✅ CORRECT: "Reopened for user_id 280379"
-- ✅ CORRECT: "Applied 1.5x time extension for deid_code S-95DBB6"
-- ❌ VIOLATION: "Reopened for Sam Bradshaw (280379)"
-- ❌ VIOLATION: Reading `.deid_master.csv` to "look up" the user
-
-**If the instructor asks "who is user_id 280379?"** — respond: "I don't have access to the name mapping file (FERPA Zone 2). Please check `grading/.deid_master.csv` locally."
-
-**Incident history:**
-
-- 2026-07-01: AI agent read `.deid_master.csv` during accommodation workflow, surfaced student name in response. Initial FERPA section added.
-- 2026-07-02: AI agent ran `build_deid_master.py` successfully (FERPA-clean output), then displayed `head -5 grading/.deid_master.csv` showing real student names. Enhanced with explicit file patterns and tool discipline (issue #131).
+*Two real incidents (2026-07-01, 2026-07-02) came from an agent reading/`head`-ing
+`.deid_master.csv` and surfacing a name. That is the failure this rule prevents.*
 
 ---
 
-## ⚠️ AI Grading Protocol — HG-5: the instructor is the top layer
+## ⚠️ Canvas writes go through the toolkit (constitutional — never overridden)
 
-**Grading with AI is decision support, not autonomy. A human decides every grade that reaches a student.** This is principle **HG-5** of the [hybrid grading architecture](lib/agents/knowledge/grader_hybrid_architecture.md) (`HG-1..HG-5`). The agent drafts; the instructor reviews and confirms; only then does anything post to Canvas.
+**Grades and comments reach Canvas ONLY through a sanctioned `lib/tools/` writer:**
+`grader_push.py` (submission feedback) or `grader_standing.py` (the standing column).
+**Never** hand-write a Canvas grade/comment write — no custom `requests`/`curl`, no
+inline `python -c`, no `/tmp/*.py`. A direct write skips *every* safeguard at once
+(review gate, duplicate-comment Andon, Test-Student exclusion, grade validation,
+`canvas_course_guard`, disclosure). Duplicate comments, grades on Test Student, and
+wrong grade scales in the field were **all** hand-written scripts bypassing the tool.
 
-**The push protocol (never skip a step):**
+Before implementing *any* Canvas operation: **search `lib/tools/` first**; if a tool
+exists, use it; if none does, propose one and ask — don't improvise a write.
 
-1. **Grade** — `grader_fetch.py` → 3-pass consensus (`grader_grade.py --bulk` → `grader_consensus.py`). Single-pass LLM grading drifts; consensus is the default.
-2. **Review** — a human reads `feedback/_all_comments.md` + each per-student `<KEY>.md`. This is the gate, not a formality.
-3. **Attest** — `grader_push.py --challenge-dir grading/<name> --mark-reviewed`. The human types `reviewed`. The marker auto-invalidates if any feedback file changes afterward.
-4. **Push** — `grader_push.py --challenge-dir grading/<name> --push`. The human types `push` at the confirmation.
+**The `grade_guardian` PreToolUse hook enforces this deterministically** — it blocks
+*creating* a bypass script (Write), *editing* one (Edit), and *running* one
+(`python x.py` whose body writes to Canvas). If it blocks you: use the tool, or
+surface the blocker to the instructor. **Do not route around it, and do not stack
+`--yes`/`--regrade`/`--allow-enrolled` to force a gate** — a blocked gate means "get
+the human," not "add a flag." (Deep grading protocol: the `grading` skill.)
 
-**What the code enforces (so the protocol isn't docs-only):**
-
-- **`--yes` cannot bypass human review on the AI-drafted path.** On any run with per-student comment files (the LLM-comment path), `--yes` is refused at *both* `--mark-reviewed` (#97) *and* the final `--push` confirmation (#207, HG-5). An agent can pass `--yes`; a human must physically type `reviewed` then `push`. The value-only / human-graded path (no comment files) keeps `--yes` — there the human *is* the grader.
-- **Disclosure is mandatory and canonical.** Every AI-drafted comment ships with `— AI drafted, instructor reviewed`, appended automatically at send-time. Deprecated tag formats (older emoji/underscore variants) refuse the push (#207); override with `--allow-bad-disclosure-tags` only if you truly mean to.
-
-**Do not** run `grader_push.py --yes --push` to "just get the grades in." That is the exact HG-5 breach an [RCA](https://github.com/chaz-clark/canvas-toolbox/issues/207) was written about — 12 students received AI-drafted grades with no instructor review. If a gate blocks you, the fix is to *do the review*, not to reach for an override flag.
-
-**Never hand-write a Canvas write (issue #213).** Grades and comments reach Canvas **only** through `grader_push.py` — never a custom `requests`/`curl` script, an inline `python -c`, or a `/tmp/*.py`. Before implementing *any* Canvas operation:
-
-1. **Search `lib/tools/` first** for an existing tool; read its docstring for prerequisites. "Push grades" → `grader_push.py`, not a fresh API script.
-2. **If a tool exists, use it.** A direct API call skips every safety gate (`.reviewed`, consensus, `canvas_course_guard`, idempotency, disclosure) — that's how 46 grades once shipped un-reviewed.
-3. **If none exists, propose one and ask** — don't improvise a direct write.
-
-The `grade_guardian` PreToolUse hook enforces this deterministically; if it blocks you, use the tool or surface the blocker to the instructor — do **not** route around it. (The S1–S4 sprint direct-API push was a one-off workaround for a `submission_file` mapping bug — **not** the pattern for KCs / quizzes / reviews.)
+Confirm scope before every write — master vs blueprint vs section. `request_confirmation()`
+is required before Canvas writes.
 
 ---
 
-## Common Tasks Quick Reference
+## Working style
 
-**When the instructor asks you to:**
+Every contributor — human or LLM — operates under the behavioral discipline in
+`Make-AI-Agents/knowledge/behavioral_discipline.md` (when the upstream clone is
+populated) or the equivalent loaded via the host tool's skill system: read before
+claiming, plan before acting, stop on the first defect, find root causes, generate
+exactly what was asked (no speculative additions), mistake-proof outputs, and respect
+intent without drift. The four **no-override** principles apply unconditionally:
+**P-001 Read Before Claiming, P-003 Stop on Defect, P-007 Pull Don't Push, P-010
+Respect Intent.**
 
-| Request | Command |
-|---------|---------|
-| "Sync students" / "Pull student list" / "Update enrollment" / "Sync all students" / "Update the deid master" / "Rebuild the student list" | `uv run python lib/tools/build_deid_master.py --force` |
-| "Pull the course from Canvas" / "Sync course content" | `uv run python lib/tools/canvas_sync.py --pull` |
-| "Audit the course" / "Check course quality" / "Run a health check" | `uv run python lib/tools/course_audit.py --course-id <id>` |
-| "Grade this assignment" / "Grade KC1" / "Start grading" / "Fetch submissions for grading" | `uv run python lib/tools/grader_fetch.py --challenge-dir grading/<name>` then 3-pass consensus grading |
-| "Push grades to Canvas" / "Upload grades" / "Post the grades" | `uv run python lib/tools/grader_push.py --challenge-dir grading/<name> --mark-reviewed` |
-| "Run a UW check" / "Last participation report" / "Check who's still active" / "Find students who stopped participating" / "Title IV report" | `uv run python lib/tools/course_engagement_audit.py --uf-date YYYY-MM-DD` |
-| "Give student X extra time on quizzes" / "Apply 1.5x time for student X" / "Give double time on all quizzes" / "Apply quiz time extension" | `uv run python lib/tools/student_quiz_time_extension.py --deid-code <code> --multiplier 1.5 --all-timed --apply` |
-| "Let student X submit late" / "Give late-work grace" / "Reopen assignments for student X" / "Drop the deadline for student X" | `uv run python lib/tools/student_late_accommodation.py --deid-code <code> --from-days-ago 14 --apply` |
-| "Apply SAS accommodations" / "Run the accommodation dispatcher" / "Process accommodation letters" | `uv run python lib/tools/apply_sas_accommodations.py --apply` |
-| "Student still can't submit" / "Override isn't working" / "Fix assignment access for student X" / "Force Canvas to recalculate" | `uv run python lib/tools/fix_group_override_recalc.py --course-id <id> --student-id <id>` |
-| "Push changes to Canvas" | `uv run python lib/tools/canvas_sync.py --push` |
+**Toyota Production System discipline:** *Genchi Gembutsu* (verify with real data —
+when you say "probably", STOP and check), *Jidoka* (write tests with code; a red test
+blocks progress), *Poka-yoke* (design mistakes out). Quality loop: Prevent → Detect →
+Verify; on a defect, fix it, verify with real data, then add an automated guard.
 
-**Note:** `build_deid_master.py` creates `grading/.deid_master.csv` from current Canvas enrollment. It's the source of truth for student de-identification codes used by accommodation tools.
+**Always run via `uv run`** (`uv run pytest lib/tests -q`, `uv run python lib/tools/…`).
+Dependencies (`markdownify`, etc.) live in the uv venv; system `python3`/`pytest`
+reports false failures from missing modules.
 
----
-
-## Structure
-
-```
-canvas_toolbox/
-├── lib/                   ← pull-safe toolkit code — always updated by git pull, never edit in place
-│   ├── agents/            ← agent specs, knowledge references, templates
-│   │   ├── canvas_*.md/.json
-│   │   ├── knowledge/     ← instructional-design references (see knowledge/README.md)
-│   │   ├── templates/     ← reusable HTML/JSON artifacts (see templates/README.md)
-│   │   └── AGENT_LAYERS.md ← runtime / capability / specification taxonomy
-│   ├── tools/             ← Python CLI scripts (uv run python canvas_toolbox/lib/tools/<script>)
-│   │   ├── canvas_sync.py
-│   │   ├── sync_context.sh ← multi-course wrapper
-│   │   ├── blueprint_sync.py
-│   │   ├── course_mirror.py
-│   │   ├── course_quality_check.py
-│   │   ├── canvas_quiz_questions.py
-│   │   └── canvas_api_tool.py
-│   └── tests/             ← regression tests (pytest)
-├── scaffold/              ← copy-once starters for your course repo (copy to your repo root, then own them)
-│   ├── gitignore          ← rename to .gitignore in your course repo
-│   └── .env.example       ← copy to .env and fill in credentials + course IDs
-├── examples/              ← reference material (read-only — never auto-synced)
-│   └── setup_notes/       ← example instructor setup notes
-├── course_src/            ← markdown authoring workspace (gitignored, --build compiles to course/)
-├── Make-AI-Agents/        ← local clone of upstream tool (gitignored, separate dev tool)
-├── gh-issues-agent/       ← local clone of upstream tool (gitignored, separate dev tool)
-├── handoff/               ← local clone of upstream tool (gitignored, separate dev tool)
-├── master/                ← master course working dir (gitignored, multi-course mode)
-├── s1/, s2/, s3/          ← per-section working dirs (gitignored)
-├── course/                ← legacy single-course mirror (gitignored)
-├── .canvas/               ← runtime indexes and logs (gitignored)
-├── AGENTS.md              ← this file
-└── README.md              ← user-facing documentation and command reference
-```
-
-> **Cloudflare Workers moved out (2026-07-12).** The bug-intake + voting workers (formerly `infra/`) now live in the **`edge-infra`** sister repo (`chaz-clark/edge-infra`, private), alongside the new `heartbeat-worker`. It's a *peer* repo, not cloned here. The deployed `canvas-toolbox-bugs` worker is unaffected; redeploy from `edge-infra/workers/bug-intake-worker/`.
-
-**Consumer usage (v1.6+)**: clone `canvas_toolbox` into your course folder (`git clone https://github.com/chaz-clark/canvas_toolbox.git canvas_toolbox`), then run `uv run python canvas_toolbox/lib/tools/cb_init.py` which auto-creates course files (.env, .gitignore, AGENTS.md) at course root. Tools run from course root: `uv run python canvas_toolbox/lib/tools/<script>`. Update safely: `cd canvas_toolbox && git pull origin main` — only toolkit code updates; your course files are untouched.
-
-v1.6 architecture moves all course files to course root (DS460/), not inside canvas_toolbox/. The toolkit is gitignored; course context lives in course-root AGENTS.md. Migration from v1.5: cb-init detects old .env location and offers to migrate.
-
-For full setup and command reference, see [`README.md`](README.md). For agent-engineering taxonomy (Runtime / Capability / Specification / Tool layers), see [`lib/agents/AGENT_LAYERS.md`](lib/agents/AGENT_LAYERS.md).
-
-## Working Style
-
-This project follows the behavioral discipline defined in `Make-AI-Agents/knowledge/behavioral_discipline.md` (when the upstream `Make-AI-Agents` clone is populated locally — see Existing Tooling) or the equivalent discipline loaded via the host tool's skill system.
-
-In short, every contributor — human or LLM — operates under these principles: read before claiming, plan before acting on changes, stop on the first defect rather than papering over, find root causes for bugs, document non-trivial changes in a structured form, generate exactly what was asked (no speculative additions), produce mistake-proof outputs, reflect and tell the user about non-obvious learnings, and respect the user's intent without substitution or drift.
-
-For the full principles and override rules, see `knowledge/behavioral_discipline.md` → "The Ten Principles". The four no-override principles (P-001 Read Before Claiming, P-003 Stop on Defect, P-007 Pull Don't Push, P-010 Respect Intent) apply unconditionally.
-
-**Project-specific rules** (summaries — see [`lib/agents/knowledge/working_style_canvas_toolbox.md`](lib/agents/knowledge/working_style_canvas_toolbox.md) for detailed explanations + motivating cases):
-
-- Local files are source of truth (Canvas is sync target)
-- Ground pedagogical work in knowledge base (cite frameworks used)
-- Validate audit baseline before redesign (check `.canvas/audit/<course_id>.json`)
-- Canvas IDs are course-specific (match by title, not ID)
-- Adding content requires course + module steps
-- Confirm scope before any write (master vs blueprint vs sections)
-- `request_confirmation()` required before Canvas writes
-- Run `course_quality_check.py` after every push
-- Completion requirements enable prerequisite chain
-- Keep institutional facts out of committed files (institution-agnostic)
-- Sandbox-first testing before handoffs
-- Surface-before-apply on every state change (including GitHub issues)
-- `git push` after every commit (no local-only commits)
-- Placeholder names must be visibly fake (`"Sarah" (fake name)`)
-- Deterministic-first grader design (Python over LLM when deterministic)
-
-## Quality Discipline (Toyota Production System)
-
-AI agents working in this repo must follow three core quality principles:
-
-### 1. Genchi Gembutsu (現地現物) - Go and See
-
-**Don't assume, verify with real data:**
-- Test with REAL user data, not synthetic fixtures
-- When uncertain about format, examine actual files
-- Verify in real environment, don't trust docs alone
-- Read actual code before claiming understanding
-
-**Behavioral trigger**: When you catch yourself saying "probably" or "should" → STOP and verify
-
-### 2. Jidoka (自働化) - Built-in Quality / Stop on Defect
-
-**Build quality in, stop when defect detected:**
-- Write tests WITH code, not after
-- Red tests block progress - fix immediately, don't defer
-- Validation runs automatically (not manual step)
-- Can't merge/export with errors (blocked by design)
-
-**Behavioral trigger**: When you want to say "we'll fix this later" → STOP and fix now
-
-**Aligns with**: P-003 Stop on Defect
-
-### 3. Poka-yoke (ポカヨケ) - Mistake-Proofing
-
-**Design so mistakes can't happen:**
-- Automate validation (no manual steps)
-- Use pre-commit hooks to catch errors
-- Type hints catch errors at write-time
-- Block operations that would create defects
-- **Always run via `uv run`** (`uv run pytest lib/tests -q`, `uv run python lib/tools/...`) — dependencies (`markdownify`, etc.) live in the uv venv; system `python3`/`pytest` will report false failures from missing modules.
-
-**Behavioral trigger**: When manual verification required → Design it out
+Project-specific rules (detail: [`lib/agents/knowledge/working_style_canvas_toolbox.md`](lib/agents/knowledge/working_style_canvas_toolbox.md)):
+local files are the source of truth (Canvas is the sync target); ground pedagogical
+work in the knowledge base; match Canvas objects by title, not ID; keep institutional
+facts out of committed files; placeholder names must be visibly fake (`"Sarah" (fake
+name)`); deterministic-first grader design (Python over LLM when deterministic).
 
 ---
 
-## Quality Loop
+## Git & versioning
 
-These three work together:
+Trunk-based: branch off `main`, PR, squash-merge, delete branch, sync local `main`.
+`main` always works. **Bump `pyproject.toml` version IN THE PR** — patch by default,
+minor for a medium shift, major for a breaking change; docs-only may leave it. On
+merge, `.github/workflows/version-bump.yml` auto-tags `vX.Y.Z`. Consumers track
+`main` via `git pull`, so the version is a milestone + drift marker, not a per-merge
+gate.
+
+---
+
+## Repo structure & consumer model
 
 ```
-Prevent (Poka-yoke) → Detect (Jidoka) → Verify (Genchi Gembutsu)
-         ↑______________________________________________|
+canvas-toolbox/
+├── lib/
+│   ├── agents/            ← agent specs, knowledge/, templates/, AGENT_LAYERS.md
+│   ├── tools/             ← Python CLIs (uv run python lib/tools/<script>)
+│   └── tests/             ← pytest
+├── .claude/skills/        ← operating-mode skills (grading, course-build, audit, …)
+├── scaffold/              ← copy-once starters (.gitignore, .env.example)
+├── docs/, examples/, README.md, CHANGELOG.md
 ```
 
-When you find a defect:
-1. **Fix it** (Jidoka - stop and correct)
-2. **Verify the fix** (Genchi Gembutsu - test with real data)
-3. **Prevent recurrence** (Poka-yoke - add automated check)
+**Consumer usage (v1.6+):** a course repo clones `canvas-toolbox` into its root
+(gitignored), runs `cb_init.py` to create course files (.env, .gitignore, AGENTS.md)
+at course root, and runs tools from there: `uv run python canvas-toolbox/lib/tools/<script>`.
+Update: `cd canvas-toolbox && git pull` — toolkit code updates; course files
+untouched. When in a consumer repo and `canvas-toolbox/` is behind latest, surface
+[`docs/UPGRADING.md`](docs/UPGRADING.md).
 
-## Handoff document recognition
+Full setup/command reference: [`README.md`](README.md). Agent-layer taxonomy:
+[`lib/agents/AGENT_LAYERS.md`](lib/agents/AGENT_LAYERS.md).
 
-This repo participates in the cross-repo `handoff` convention (canonical spec: [`handoff/CONVENTION.md`](https://github.com/chaz-clark/handoff/blob/main/CONVENTION.md)). When operating in this repo, treat the following file patterns as **handoff documents** — structured artifacts with a lifecycle, NOT prose conversation:
+---
 
-| Path pattern | What it is |
-|---|---|
-| `handoffs/HANDOFF_<topic>.md` | Outgoing `request`-direction handoff (canonical copy; dropped into producer's root after authoring) |
-| `handoffs/<YYYY-MM-DD>_<topic>.md` | Incoming `deliver`-direction handoff (canonical consumer record) |
-| `<CONSUMER>_HANDOFF_<topic>.md` at repo root | Incoming `request`-direction handoff dropped by another consumer for us to apply |
-| `<PRODUCER>_DELIVERS_<topic>.md` at repo root | Visibility copy of an incoming `deliver` handoff (canonical is in `handoffs/`) |
-| `handoffs/parkinglot.md` | `internal` handoff — near-term parked ideas ("good idea, busy now"); deferred by design |
-| `handoffs/long-term-parking.md` | `internal` handoff — far/someday parked ideas (evidence-gated, pie-in-the-sky); deferred by design |
+## Handoff recognition
 
-### Seven rules for handling a handoff document
+This repo participates in the cross-repo `handoff` convention (canonical:
+[`handoff/CONVENTION.md`](https://github.com/chaz-clark/handoff/blob/main/CONVENTION.md)).
+Treat `handoffs/<YYYY-MM-DD>_<topic>.md` (deliver), `handoffs/HANDOFF_<topic>.md`
+(request), and root `<X>_HANDOFF_<topic>.md` as structured artifacts with a lifecycle,
+not prose. Essentials:
 
-1. **Read the metadata header first.** Every handoff opens with bold-labeled fields: `Date`, `Author`, `Direction`, `Status`, `Origin`, `Origin-Commit`, `Topic`. Optional: `Sensitivity`, `Companions`. If any required field is missing, STOP and ask the human user.
+- **Read the metadata header first** (Date/Author/Direction/Status/Origin/Topic); a
+  missing required field → STOP and ask.
+- **Act only on `Status: delivered`.** Skip `draft`/`applying`/`applied`/`archived`/
+  `superseded`. `parkinglot.md` / `long-term-parking.md` (`internal`) are deferred by
+  design — act only on human direction or a met `Trigger:`.
+- **Surface before applying** — summarize what changes, get per-decision approval
+  (never bulk auto-apply). **On apply, set `Status: applied`** + a Lifecycle marker.
+- **STOP on missing referenced artifacts** — don't infer or fabricate.
 
-2. **Act only on `Status: delivered`.** Skip `draft` (not ready), `applying` (someone else is on it), and `applied` / `archived` / `superseded` (done or moot). If `Sensitivity: restricted` or `internal-only`, escalate to the human before any cross-repo action.
+---
 
-3. **Surface before applying.** Summarize the handoff's request or delivery to the human user — what's being asked, what files/repos are affected, what the apply step would change. Get per-decision approval. The convention is per-proposal-approval, not bulk auto-apply.
+## Continuous improvement
 
-4. **Update Status on apply.** After committing the change the handoff requests, edit the handoff doc: set `Status: applied`. Add a `## Lifecycle marker` entry with the apply date (and optionally the commit hash). The handoff doc is mutable in place — there's no side channel for state.
+Two capture channels. **`cb_report_bug.py`** files a scrubbed, maintainer-routed
+issue (no GitHub account needed) — title prefix `bug:` or `enhancement:`. **`lib/agents/knowledge/learned/`**
+holds durable session lessons; a lesson referenced a second time is the signal to
+file it as an enhancement. Bias toward surfacing (one skippable line at the end of a
+response) when a tool exits non-zero unexpectedly, output feels off, or the operator
+wants unimplemented behavior. Don't surface when a FERPA/push gate fires correctly or
+the operator supplied wrong inputs.
 
-5. **STOP on missing referenced artifacts.** If the handoff names files, commits, agents, or paths that don't exist locally, halt and ask the human. Do not infer; do not fabricate. The handoff's `Origin-Commit` field is your traceability anchor — clone the authoring repo at that SHA if you need to verify referenced state.
+**Security issues are NOT bugs** — a PII leak, an exposed token, or a bypassed FERPA
+gate goes to [`SECURITY.md`](.github/SECURITY.md) (private email), never the public
+`cb_report_bug.py`.
 
-6. **Before authoring an outbound handoff**, read the target producer's `REPO_CARD.md` if it exists at the producer's root. Confirm:
-   - `Status: accepting` (not `freeze` or `archived`).
-   - Your intended handoff type is in `Accepts-handoff-types`.
-   - Drop at the path named in `Drop-location` (default `./` = repo root).
+**Maintainer-only:** AGENTS.md is public. Secrets/runbooks → `docs/dev/` (gitignored).
+Dev tools (gitignored) → add to `.gitignore` on creation.
 
-   If no `REPO_CARD.md` exists at the target, default to dropping at the producer's repo root for `request` direction; for `deliver` direction, drop into the consumer's `handoffs/` folder.
-
-7. **Do not auto-act on `parked` items.** `parkinglot.md` and `long-term-parking.md` (`Direction: internal`) are this repo's own deferred-idea backlog — deferred *by design*. Act on a parked item only when the human directs it, or when its `Trigger:` condition is genuinely met. When you do, pull it into active work or graduate it (into a GitHub issue, or a cross-repo `request`/`deliver` handoff), then set that item's `Status: superseded` with a `Companions:` pointer to where it went. Never silently work a parked item just because you saw it.
-
-### Quick lookup — Status enum
-
-| Status | Meaning | Should I act? |
-|---|---|---|
-| `draft` | Author still composing | No — wait for `delivered` |
-| `delivered` | Awaiting recipient review | **Yes** — apply path |
-| `applying` | Someone is already on it | No — don't double-apply |
-| `applied` | Work landed in receiving repo | No — past terminal |
-| `archived` | Settled, transient copies deleted | No — past terminal |
-| `superseded` | Replaced by a newer handoff | No — follow `Companions: superseded-by` |
-| `parked` | Internal deferred idea, awaiting its `Trigger:` | No — act only on Trigger or human direction |
-
-### Quick lookup — Direction enum
-
-| Direction | Who authored | Where the canonical lives |
-|---|---|---|
-| `request` | Consumer (this repo, requesting from a producer) | `<consumer>/handoffs/HANDOFF_<topic>.md` |
-| `deliver` | Producer (another repo, delivering to consumer) | `<consumer>/handoffs/<YYYY-MM-DD>_<topic>.md` |
-| `internal` | This repo (handoff to a future session of itself) | `handoffs/parkinglot.md`, `handoffs/long-term-parking.md` |
-
-## Learning loop
-
-Session insight → durable knowledge.
-
-- **Capture trigger.** When an interaction surfaces a non-obvious fact, a recurring trap, or a validated approach that future sessions should not have to rediscover, the operator (or agent, on confirmation) writes a small Markdown file to `lib/agents/knowledge/learned/`.
-- **File shape.** Each file carries agentskills.io frontmatter (`name`, `description`, `version`, `author`, `license`, `metadata`). Body is the lesson itself — what was learned, why, how to apply it.
-- **Promotion rule.** When a file in `lib/agents/knowledge/learned/` has been referenced twice, promote it to a first-class file under `lib/agents/knowledge/`. Promotion is a deliberate act, not automatic — confirm with the operator.
-- **Boundary.** `lib/agents/knowledge/learned/` is for *this repo's* lessons. Cross-repo lessons go through the handoff convention above, not this lane.
-
-> Path note: this repo's canonical knowledge directory is `lib/agents/knowledge/` (not `knowledge/` at root, which the make_AGENTS template assumes). The learned lane sits alongside the other knowledge files at `lib/agents/knowledge/learned/`.
-
-## Continuous improvement — bugs + enhancements
-
-The toolkit ships with TWO complementary capture mechanisms; the agent's job is to recognize the moment and route appropriately.
-
-### Channel 1 — `cb_report_bug.py` (immediate, external)
-
-A one-command CLI that files a scrubbed report on `chaz-clark/canvas-toolbox` via the Cloudflare-fronted intake worker (now in the `edge-infra` sister repo — private — at `workers/bug-intake-worker/`). **No GitHub account needed on the operator's side.** Use for:
-
-- **Bugs** — something broke, something surprised you, something diverged from documented behavior. Title prefix: `bug:`.
-- **Enhancements** — operator articulated something the tool doesn't yet do, OR a recurring friction has been captured in `learned/` at least once already (the Hermes promotion threshold). Title prefix: `enhancement:`.
-
-The maintainer triages bug-vs-enhancement at the issue level. The CLI doesn't need a flag — the title's prefix is the signal. A GitHub Action auto-labels every filed issue `agent-submitted` for filtering.
-
-### Channel 2 — `lib/agents/knowledge/learned/` (patient, internal)
-
-The Hermes Learning loop (Sprint B, see above). When the friction is interesting but you're not sure it rises to "file it now" — capture it here as a durable lesson. The promotion rule applies: a learned entry that gets **referenced a second time** is the agent's signal to surface filing as an enhancement via Channel 1.
-
-### Surfacing guidelines
-
-**Bias toward surfacing.** A low-quality report costs ~10s to close; a real bug never filed costs much more. When in doubt, offer filing.
-
-**DO surface when:** Tool exits non-zero (not config error), output "feels off", documented behavior diverges, Canvas API fails unexpectedly, operator wants unimplemented behavior, `learned/` entry referenced twice (Hermes promotion threshold).
-
-**DON'T surface when:** FERPA/push gates fire correctly, operator config gaps (missing env var/keymap), agent supplied wrong inputs (retry with correction first).
-
-### How to surface
-
-ONE line at the end of the agent's response, clear and skippable.
-
-For bugs:
-> _If this looks like a toolkit bug rather than a config issue, `uv run python lib/tools/cb_report_bug.py --from <log path> --title "bug: <short title>"` files it scrubbed + maintainer-routed. No GitHub account needed._
-
-For enhancements:
-> _This looks like an enhancement candidate. If the toolkit should grow this behavior, `uv run python lib/tools/cb_report_bug.py --title "enhancement: <short title>"` files it for the maintainer to triage._
-
-For repeated friction crossing the Hermes promotion threshold:
-> _This is the second time this friction has shown up (first capture at `lib/agents/knowledge/learned/<earlier>.md`). That's the Hermes promotion threshold — worth filing as an enhancement via `cb_report_bug.py` so the toolkit can grow to handle it natively._
-
-### Bundling discipline
-
-Propose a specific title — that's the maintainer's primary triage signal. "test bug" is useless; "bug: grader_push 4xx on KC1 assignment 16958677" is actionable. Suggest `--from <log path>` when a log exists. The CLI auto-bundles toolkit version, Python version, platform, sanitized cwd, and the last 150 log lines; it opens `$EDITOR` for the operator's "what I expected vs what happened" detail before posting.
-
-### Roadmap voting — community prioritization
-
-When the operator wants a feature on the [roadmap](docs/ROADMAP.md), offer to vote via `lib/tools/vote_feature.py`. This signals demand without requiring GitHub accounts.
-
-**Offer when:** Operator wants/needs a roadmap feature (e.g., "what do I need to pass?" → grade-forecast).
-
-**How:** `uv run python lib/tools/vote_feature.py --feature-id <id>` after confirmation. Use `--list` to show all features with current vote counts and IDs. Feature IDs are kept in sync with `lib/tools/vote_feature.py` (source of truth).
-
-### Adopter upgrade discoverability
-
-When you're working in a CONSUMER repo (m119-master, ds460-master,
-ds250-onln-master, itm327-master, aol-student, etc.) and you notice
-`canvas-toolbox/` is at an older version than the latest, surface
-[`UPGRADING.md`](docs/UPGRADING.md) in the canvas-toolbox repo. It carries
-the scenario-driven migration guide (vs. [`CHANGELOG.md`](CHANGELOG.md)
-which is the per-version mechanical record). One-line check:
-
-```bash
-uv run python canvas-toolbox/lib/tools/grader_fetch.py --version
-```
-
-If the printed version is behind the latest (currently **v1.7.0**),
-the upgrade is usually a clean `cd canvas-toolbox && git pull && uv sync`.
-UPGRADING.md flags behavior changes the operator might notice (the
-v0.40+ Test Student exclusion, the v0.41-0.42 push guards, the
-v0.50 bug-intake CLI). The toolkit does not auto-upgrade; that's by
-design (operator control). But agents can and should notice the gap.
-
-### Security issues are NOT bugs
-
-If you find (or the operator surfaces) a path that LEAKS student PII,
-exposes the bug-intake worker's PAT, or otherwise bypasses a FERPA
-gate — **don't file via `cb_report_bug.py`** (it files publicly).
-Follow [`SECURITY.md`](.github/SECURITY.md) instead: email the maintainer
-directly. The public intake channel is for bugs + enhancements; the
-private channel is for security.
-
-### Dev tools & docs — maintainer-only
-
-**IMPORTANT:** AGENTS.md is public. Secrets/credentials → `docs/dev/` (gitignored). Workflow instructions → AGENTS.md.
-
-**Dev tools** (lib/tools/, gitignored): `add_roadmap_feature.py` (voting system updater). When creating: add to `.gitignore` immediately, update this list, include docstring.
-
-**Dev docs** (docs/dev/, gitignored): Deployment runbooks with real tokens, API key procedures, private architecture. Public architecture/workflow stays in AGENTS.md.
+---
 
 ## Active Context
 
-_Last updated: 2026-07-12_
+_Last updated: 2026-07-28._ Latest few releases only; full history in
+[`CHANGELOG.md`](CHANGELOG.md).
 
-Latest 3 releases only — full detail for every version is in [`CHANGELOG.md`](CHANGELOG.md). On each release, add the new entry on top and rotate the oldest out. Kept to ≤3 entries / ≤100 lines / ≤10k tokens for active development phase (faster HERMES cycle during beta/sprint cadence).
+- **v1.7.31–1.7.39 (grading-safety + tooling train, 2026-07-27/28):** TTY-only push
+  confirmation (#241); `grader_standing` standing-column tool; `grade_guardian` now
+  catches bypass scripts at create/edit **and run**; engagement-audit auto-dates from
+  Canvas + includes inactive students; disclosure-tag menu (`--disclosure
+  ai|hybrid|script`); `build_deid_master` dedups multi-section students.
+- **v1.7 offline mode (v1.7.0, 2026-07-12):** tools read a local `course/`; 7 audits
+  gained `--local`; `.imscc` round-trip (`offline_import` → edit → `imscc_record`).
+- **v1.6 course-centric architecture (v1.6.0, 2026-07-07):** course files live at
+  course root, not inside canvas-toolbox/; `cb_init` auto-detects context.
 
-**Versioning policy (2026-07-13):** SemVer with a continuous-patch cadence — bump `pyproject.toml` **in the PR itself**: **patch** (3rd) by default, **minor** (2nd) for a medium shift (like the v1.7 offline suite), **major** (1st) for a breaking change; a docs-only PR may leave it unchanged. On merge, [`.github/workflows/version-bump.yml`](.github/workflows/version-bump.yml) auto-tags the commit `vX.Y.Z` from `pyproject` (skips if the tag already exists). The bump rides the protected-PR flow — the bot can't commit to `main`, but tags aren't branch-protected. Consumers track `main` via `git pull`, so the version is a milestone + drift-detection marker, not a per-merge gate.
+---
 
-### Recent: v1.7 offline mode (v1.7.0, 2026-07-12)
-
-Offline mode: tools read a local `course/` (from `canvas_sync --pull` or `offline_import` of a `.imscc`), running identically online/offline. 7 audits gained `--local` with exact parity (workload / syllabus / accessibility / content_representation / grading_structure / rubric_coverage / rubric_quality); offline foundation (`CANVAS_MODE`; gradebook de-id / re-id / apply; `.imscc` date-shift; the `course/` loader; `offline_import`). Also: `clo_catalog_import` (Kuali catalog → Canvas Outcomes), institution-agnostic `syllabus_audit`, and the Cloudflare Workers migrated out to the `edge-infra` sister repo. Proven both ways that a `.imscc` carries course-owned outcomes (export + import round-trip).
-
-**Offline write (v1.7.7):** `course/` is the working folder (iterate freely); the `.imscc` is the source of truth. `offline_import` saves the original as the sidecar `course/.source.imscc`. When done, `imscc_record` patches your `course/` edits into that sidecar in place — faithful (quiz questions / files / LTI preserved byte-for-byte; it patches, never rebuilds) — for re-import via the Canvas UI.
-
-### Recent: v1.6 course-centric architecture (v1.6.0, 2026-07-07)
-
-Major architecture refactor: course files (.env, AGENTS.md, course/, grading/, handoffs/) now live at course root (DS460/), not inside canvas-toolbox/. cb-init auto-detects subdirectory context and creates files in the right location. Includes v1.5 → v1.6 migration detection for .env relocation. 13-step cb-init (was 9): adds .gitignore creation, canvas-sync --pull, course-level AGENTS.md stub generation, and opt-in handoffs/ directory (--with-handoffs flag). Eliminates multi-course "which canvas-toolbox is this?" confusion. Tools continue to run from course root unchanged. Full backward compatibility for standalone mode.
-
-### Earlier: AGENTS.md trimmed to rotating latest-5 + CI guard (v0.72.3, 2026-06-29)
-
-Active Context had grown into a 182 KB append-only release log (past host-tool read limits). Trimmed to latest 5 entries; full history moved to CHANGELOG. CI guard enforces rotation/size thresholds. Also repaired 25 stale relative links (doc moves + `lib/agents/`).
-
-_Earlier releases (v0.72.0 and back) live in the [CHANGELOG](CHANGELOG.md)._
-
-
-## Domain Terms
+## Domain terms
 
 | Term | Definition |
 |---|---|
-| **Master** | The template course where authoring happens. One per course. Identified by `MASTER_COURSE_ID` in `.env`. Folder: `master/` (or `course/` in legacy single-course mode). |
-| **Blueprint** | A Canvas Blueprint course that semester sections clone from. Optional — only used by online programs. Identified by `BLUEPRINT_COURSE_ID`. Folder: `blueprint/`. |
-| **Section** | A live student-facing course for a specific semester (S1, S2, S3...). Cloned from blueprint or master. Identified by `S1_COURSE_ID`, `S2_COURSE_ID`, etc. Folders: `s1/`, `s2/`, `s3/`. |
-| **Sprint module** | A weekly or bi-weekly module containing related content. Sequential by default; can have prerequisites that lock later sprints until prior items are completed. |
-| **Module item** | An entry inside a module — Page, Assignment, Quiz, Discussion, ExternalTool, ExternalUrl, or SubHeader. Has its own `module_item_id` distinct from the underlying content's `canvas_id`. |
-| **NewQuiz** | Canvas's newer quiz engine (LTI-based). Cannot be content-pushed via REST API — must be edited in Canvas UI. Distinct from Classic Quiz. |
-| **Classic Quiz** | Canvas's original quiz engine. Has both a `quiz_id` (in `/quizzes`) and an underlying `assignment_id` (in `/assignments` with `submission_types: ["online_quiz"]`). REST API works fully. |
-| **Source of truth** | The local working folder (`master/course/` in multi-course mode, `course/` in single-course). Canvas is the sync *target*. |
+| **Master** | Template course where authoring happens. `MASTER_COURSE_ID`; folder `master/`. |
+| **Blueprint** | Canvas Blueprint sections clone from (online programs). `BLUEPRINT_COURSE_ID`; `blueprint/`. |
+| **Section** | Live per-semester course (S1, S2…). `S1_COURSE_ID`…; `s1/`, `s2/`. |
+| **NewQuiz** | LTI-based quiz engine; can't be content-pushed via REST (edit in UI). |
+| **Classic Quiz** | Original engine; has both `quiz_id` and an underlying `assignment_id`; REST works. |
+| **Source of truth** | The local working folder; Canvas is the sync *target*. |
 
-## External System Lessons
+---
 
-Canvas API has multiple non-obvious behaviors the toolkit discovered through production use. The full catalog of 17 lessons (each with behavior, why-it-matters, defense, and provenance) has been migrated to the dedicated knowledge file [`lib/agents/knowledge/canvas_api_lessons_learned.md`](lib/agents/knowledge/canvas_api_lessons_learned.md) (2026-05-21). It pairs with [`lib/agents/knowledge/canvas_api_knowledge.md`](lib/agents/knowledge/canvas_api_knowledge.md), which holds the Canvas-documented surface (strict source discipline: only Instructure-authored docs in that file; only empirical findings in the lessons file).
+## References
 
-Always read both knowledge files when planning a Canvas write or audit. The 17 lessons are abbreviated here as a navigation index — full content + defense citations live in the knowledge file:
-
-| # | Lesson (one-liner) | Defending tool |
-|---|---|---|
-| L1 | Module prerequisites silently fail with JSON payload (use form-encoded) | `module_settings_sync.py` |
-| L2 | Module published state is form-encoded too | `module_settings_sync.py`, `blueprint_sync.py` |
-| L3 | Date writes need the `due_at`/`lock_at`/`unlock_at` trio | `canvas_semester_setup.md` agent |
-| L4 | `late_policy` PATCH returns 403 for teacher tokens (admin-only) | `canvas_new_course_setup.md` agent |
-| L5 | Classic quiz `points_possible` shows 0 after question push | `canvas_quiz_questions.py` |
-| L6 | Classic quizzes have two IDs (`quiz_id` + `assignment_id`) | `course_quality_check.py` |
-| L7 | Discussions use `todo_date`, not `due_at` | `canvas_sync.py` |
-| L8 | NewQuiz / ExternalTool items can't be content-pushed via REST | sync tools (warn-and-skip) |
-| L9 | Workaround: `GET /assignments?include[]=rubric` for student tokens | `course_quality_check.py` |
-| L10 | Empty modules are a sync artifact (cascade of L8) | `course_quality_check.py` |
-| L11 | Blueprint migration reports `state: completed` with silent per-section skips | `blueprint_exception_report.py` (#28) |
-| L12 | A stale `.env` can silently target the wrong course (ITM-327 amplification) | `canvas_course_guard.py` (#27) |
-| L13 | Canvas creates `-N` slug orphan Pages on Blueprint resync | `blueprint_orphan_pages.py` Detector A (#29 Phase 1) |
-| L14 | Canvas's lock-state-only sync can silently revert section page bodies | `blueprint_orphan_pages.py` Detector B (#29 Phase 1) + operator warning |
-| L15 | Page title collision → auto-suffix (`-2`/`-4`/`-5`) | `canvas_pages.upsert_page()` (#26) |
-| L16 | Clearing a module-item completion requirement needs the whole object blanked | `module_settings_sync.py` (#25) |
-| L17 | Blueprint `asset_type` vocab differs by endpoint (snake_case `unsynced_changes` vs CamelCase migration-details) | `blueprint_presync_check.py` (#36/#37) + `blueprint_exception_report.py` (#28) |
-
-## Existing Tooling
-
-**Full catalog:** [lib/tools/README.md](lib/tools/README.md)
-
-**Most commonly used:**
-- `canvas_sync.py` — Single-course mirror (pull/push/build)
-- `course_audit.py` — One-command pre-semester health check (rubrics/CLOs/syllabus/workload)
-- `course_quality_check.py` — Post-push structural audit (duplicates, floating items, date windows)
-- `blueprint_sync.py` — Master → Blueprint sync (content + settings)
-- `validate_blueprint_sync.py` + `blueprint_exception_report.py` — Post-Blueprint-sync validation
-- `module_settings_sync.py` — Module prerequisite/completion reconciliation
-
-**Related agents:** `canvas_course_expert`, `canvas_schedule_auditor`, `canvas_blueprint_sync`, `canvas_semester_setup`, `canvas_new_course_setup` (see [lib/agents/](lib/agents/))
-
-**Knowledge base:** [lib/agents/knowledge/README.md](lib/agents/knowledge/README.md) (frameworks), [AGENT_LAYERS.md](lib/agents/AGENT_LAYERS.md) (taxonomy)
-
-**Populating upstream clones** (gitignored, local only):
-```bash
-git clone https://github.com/chaz-clark/Make-AI-Agents.git make-ai-agents
-git clone https://github.com/chaz-clark/gh_issues_agent.git gh-issues-agent
-git clone https://github.com/chaz-clark/handoff.git
-```
-
-Each is a real git clone with its own `.git/` directory. Edits flow upstream (edit at the source repo's local clone, not here). Future updates: `cd <dir> && git pull origin main`.
+- **Canvas API knowledge:** [`lib/agents/knowledge/canvas_api_knowledge.md`](lib/agents/knowledge/canvas_api_knowledge.md)
+  (documented surface) + [`canvas_api_lessons_learned.md`](lib/agents/knowledge/canvas_api_lessons_learned.md)
+  (17 empirical lessons — form-encoding, date trios, quiz dual-IDs, blueprint orphans).
+  Read both before a Canvas write or audit; the relevant ones are surfaced in the
+  `course-build` and `audit` skills.
+- **Instructional-design frameworks:** [`lib/agents/knowledge/README.md`](lib/agents/knowledge/README.md).
+- **Tool catalog:** [`lib/tools/README.md`](lib/tools/README.md).
+- **Toolkit reuse doctrine:** [`lib/agents/knowledge/toolkit_reuse_knowledge.md`](lib/agents/knowledge/toolkit_reuse_knowledge.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.40] — 2026-07-28
+
+**Architecture: AGENTS.md is now a constitution + 6 operating-mode skills.**
+
+A single 509-line AGENTS.md loaded *every* session — grading, course-build, CI, all of it — and the grading discipline that matters most got diluted in a 5,200-word file. Following Anthropic's Agent Skills model (metadata always-loaded ≈100 tokens; instructions load only when triggered), the toolkit now splits along that seam:
+
+- **AGENTS.md is the constitution** — the always-on law: FERPA discipline, the Canvas-write safety doctrine + `grade_guardian`, behavioral principles, git/handoff conventions, and the skills index. Slimmed to **253 lines / 1,674 words (−68% words)**.
+- **`.claude/skills/` holds six operating-mode skills**, each loaded on demand: `grading`, `course-build`, `audit`, `accommodations`, `ferpa-deid`, `title-iv`.
+
+The six were derived by clustering all 98 tools by cohesion, not intuition. Two evidence-based calls: **Title IV is its own skill** (a federal-compliance domain distinct from course-design auditing), and **offline/`.imscc` folds into `course-build`** (same "build the course" role, different transport). Safety-critical rules stay constitutional and always-on; only mode-specific *procedure* moved to skills.
+
+Follow-up (not in this PR): `cb_init` should surface the skills at a consumer course-repo's root so they activate in course sessions too.
+
+---
+
 ## [1.7.39] — 2026-07-28
 
 **`build_deid_master` now dedups by user_id — a multi-section student no longer produces duplicate rows in `.deid_master.csv`.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.39"
+version = "1.7.40"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.38"
+version = "1.7.39"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What

Split the 509-line AGENTS.md along Anthropic's Agent Skills seam: **AGENTS.md becomes the constitution** (always-on law), and each operating mode becomes a **skill** that loads on demand.

- **AGENTS.md** (253 lines, **−68% words**): FERPA discipline, the Canvas-write safety doctrine + `grade_guardian`, behavioral principles, git/handoff conventions, and the **skills index**. Safety-critical rules stay constitutional and always-on.
- **`.claude/skills/`** (6 skills, load on trigger): `grading`, `course-build`, `audit`, `accommodations`, `ferpa-deid`, `title-iv`.

## How the six were chosen (data, not intuition)

Clustered all **98 tools** by cohesion (workflow phase, object, read/write, shared inputs). Grounded in the Anthropic Skills doc (metadata ≈100 tokens always-loaded → granularity is cheap; the constraint is *one coherent role per skill*; 3–6 is the healthy band). Two evidence-based calls:

- **`title-iv` split out of `audit`** — a federal-compliance domain (R2T4/UF/UW, Downloads-only output, federal stakes), recognized by the user as its own mode.
- **offline/`.imscc` folds *into* `course-build`** — same "build the course" role, different transport; not a distinct mode.

## Safety preserved

Every non-negotiable stays in the constitution, always-on: the FERPA Zone-2 file list, "grades reach Canvas only through a sanctioned writer", the guardian's create/edit/run enforcement, and "don't stack override flags to force a gate." Only *procedure* moved to skills.

## Verified

`test_agents_active_context` + `test_sync_grading_protocol` pass; all 6 skills have valid frontmatter (name matches dir, description present).

## Follow-up (not here)

`cb_init` should surface the skills at a consumer course-repo root so they activate in course sessions (skills at `canvas-toolbox/.claude/skills/` are only auto-discovered for sessions rooted in the toolkit itself).

🤖 Generated with [Claude Code](https://claude.com/claude-code)