### PR TITLE
feat(grader_fetch_gradebook): mirror the live Canvas gradebook locally, de-identified

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -86,7 +86,9 @@ tag prints in the pre-push banner. It won't stack if you switch graders mid-stre
 For a No-Submission column (often weighted 100%) that you compute from a syllabus
 table and refresh weekly — instructor-computed, value-only, roster-keyed. It
 sidesteps Canvas's auto-zero and the regrade gate. It **computes nothing** — your
-script produces the values; the tool pushes them, dry-run by default, with strict
+script produces the values (from the gradebook — `grader_fetch_gradebook.py` mirrors
+it locally, de-identified and cached, as that upstream input); the tool pushes them,
+dry-run by default, with strict
 guards (unmatched/ambiguous key → hard fail; out-of-bounds → abort; big drop →
 abort unless `--allow-swings`). `--yes` is allowed (deterministic, value-only) so
 the weekly run can automate.
@@ -121,6 +123,7 @@ grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-
 | Re-grade a resubmission | add `--regrade` |
 | Update the "your grade" column | `grader_standing.py --csv <f> --assignment-id <id> --push` |
 | Rebuild the de-id master | `build_deid_master.py --force` |
+| Mirror the live gradebook locally (feeds standing/reconcile) | `grader_fetch_gradebook.py` |
 
 Full grading knowledge: [`lib/agents/knowledge/grader_hybrid_architecture.md`](../../../lib/agents/knowledge/grader_hybrid_architecture.md)
 and [`lib/agents/knowledge/toolkit_reuse_knowledge.md`](../../../lib/agents/knowledge/toolkit_reuse_knowledge.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.41] — 2026-07-28
+
+**New `grader_fetch_gradebook.py` — mirror the live Canvas gradebook locally, de-identified and cached.**
+
+The shared gradebook primitive that was missing: one API sweep builds a `user_id`-keyed score matrix (rows = students, columns = assignments, cells = scores) cached under `.canvas/gradebook/`, stamped with `fetched_at`. Any skill can reuse a fresh copy instead of re-hitting Canvas one assignment at a time — it's the upstream input `grader_standing` (the "your grade" column) and `grader_reconcile` need.
+
+**De-identified by default** — no names, so the cache is FERPA Zone-1 (LLM-safe) and every skill can read it; `grader_reidentify_gradebook.py` turns it into a named report when a human needs one. Online mirror (distinct from offline `.imscc` mode). Follows `Link: rel="next"` pagination (issue #67), excludes the Test Student (#61), and skips the fetch when the cache is younger than `--max-age-hours` (default 6; `--force` overrides).
+
+---
+
 ## [1.7.40] — 2026-07-28
 
 **Architecture: AGENTS.md is now a constitution + 6 operating-mode skills.**

--- a/lib/tests/test_grader_fetch_gradebook.py
+++ b/lib/tests/test_grader_fetch_gradebook.py
@@ -1,0 +1,83 @@
+"""Unit tests — grader_fetch_gradebook pure logic (the de-identified gradebook mirror).
+
+Covers the matrix build (de-identification + Test-Student exclusion + duplicate-column
+disambiguation) and the freshness check that lets skills reuse a cache instead of
+re-hitting Canvas.
+"""
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_fetch_gradebook import build_matrix, is_fresh  # noqa: E402
+
+_ASN = [
+    {"id": 10, "name": "KC1", "points_possible": 4, "position": 1},
+    {"id": 11, "name": "KC2", "points_possible": 4, "position": 2},
+]
+
+
+def test_build_matrix_is_deidentified_and_user_keyed():
+    """Rows are keyed by user_id with scores — never a name column (the whole point:
+    Zone-1, LLM-safe)."""
+    scores = {501: {10: 4, 11: 3}, 502: {10: 2}}
+    header, rows = build_matrix(_ASN, scores, exclude=set())
+    assert header == ["user_id", "KC1", "KC2"]
+    assert rows == [[501, 4, 3], [502, 2, ""]]   # missing score → blank, sorted by uid
+
+
+def test_build_matrix_excludes_test_student():
+    scores = {501: {10: 4}, 999: {10: 1}}
+    _, rows = build_matrix(_ASN, scores, exclude={999})
+    assert [r[0] for r in rows] == [501]
+
+
+def test_build_matrix_disambiguates_duplicate_assignment_names():
+    asn = [{"id": 10, "name": "Quiz", "points_possible": 1, "position": 1},
+           {"id": 11, "name": "Quiz", "points_possible": 1, "position": 2}]
+    header, _ = build_matrix(asn, {501: {10: 1, 11: 0}}, exclude=set())
+    assert header == ["user_id", "Quiz", "Quiz (11)"]
+
+
+def test_build_matrix_preserves_given_column_order():
+    """build_matrix follows the assignment order it's handed (fetch_assignments
+    already position-sorts upstream); cells align to that column order."""
+    asn = [{"id": 10, "name": "First", "points_possible": 1, "position": 1},
+           {"id": 11, "name": "Second", "points_possible": 1, "position": 2}]
+    header, rows = build_matrix(asn, {501: {11: 2, 10: 1}}, exclude=set())
+    assert header == ["user_id", "First", "Second"]
+    assert rows == [[501, 1, 2]]  # cell for id 10 under First, id 11 under Second
+
+
+def _write_meta(tmp_path, fetched_at):
+    p = tmp_path / ".fetch_meta.json"
+    p.write_text(json.dumps({"fetched_at": fetched_at}), encoding="utf-8")
+    return p
+
+
+def test_is_fresh_true_when_recent():
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        p = _write_meta(Path(d), (now - timedelta(hours=2)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+        assert is_fresh(p, 6.0, now) is True
+
+
+def test_is_fresh_false_when_stale():
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    import tempfile
+    with tempfile.TemporaryDirectory() as d:
+        p = _write_meta(Path(d), (now - timedelta(hours=8)).strftime("%Y-%m-%dT%H:%M:%SZ"))
+        assert is_fresh(p, 6.0, now) is False
+
+
+def test_is_fresh_false_when_missing_or_malformed(tmp_path):
+    now = datetime(2026, 7, 28, 12, 0, tzinfo=timezone.utc)
+    assert is_fresh(tmp_path / "nope.json", 6.0, now) is False
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    assert is_fresh(bad, 6.0, now) is False

--- a/lib/tools/grader_fetch_gradebook.py
+++ b/lib/tools/grader_fetch_gradebook.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""grader_fetch_gradebook.py — mirror the LIVE Canvas gradebook locally, de-identified.
+
+The shared gradebook primitive. One API sweep → a user_id-keyed score matrix cached
+under `.canvas/gradebook/`, stamped with `fetched_at`, so any skill/tool can reuse a
+fresh copy instead of re-hitting Canvas per assignment. This is the upstream input
+`grader_standing` (the "your grade" column) and `grader_reconcile` actually need: the
+WHOLE multi-assignment gradebook, not one assignment at a time.
+
+ONLINE mirror — distinct from offline `.imscc` mode; it fetches from Canvas over the
+API. **De-identified by DEFAULT**: rows are keyed by Canvas `user_id`, columns are
+assignment names, cells are scores. NO student names → the cache is FERPA Zone-1
+(LLM-safe) and every skill can read it. To turn it into a named report for a human,
+pipe it through `grader_reidentify_gradebook.py` (which reads the local keymap).
+
+Freshness: skips the fetch if the cache is younger than `--max-age-hours` (default 6);
+`--force` always refreshes. The Test Student is excluded (#61).
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+try:
+    from _env_loader import force_utf8_console, load_env
+    load_env()
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+import requests
+
+try:
+    from __toolbox_version__ import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
+
+from grader_push import _env_canvas  # single source of truth for Canvas env
+
+_TIMEOUT = 30
+_DEFAULT_OUT = Path(".canvas/gradebook")
+
+
+def _get_paged(base: str, headers: dict, path: str, params: dict | None = None) -> list:
+    """GET a Canvas collection, following the `Link: rel="next"` header (NOT blind
+    page++ — several endpoints 400 past the last page; issue #67)."""
+    out: list = []
+    p = {**(params or {}), "per_page": 100}
+    url: str | None = f"{base}{path}"
+    while url:
+        r = requests.get(url, headers=headers, params=p if "?" not in url else None,
+                         timeout=_TIMEOUT)
+        r.raise_for_status()
+        batch = r.json() or []
+        out += batch if isinstance(batch, list) else [batch]
+        m = re.search(r'<([^>]+)>;\s*rel="next"', r.headers.get("Link", ""))
+        url = m.group(1) if m else None
+        p = None
+    return out
+
+
+def fetch_assignments(base: str, cid: str, headers: dict) -> list[dict]:
+    """[{id, name, points_possible, position}] in gradebook order."""
+    raw = _get_paged(base, headers, f"/api/v1/courses/{cid}/assignments")
+    cols = [{"id": int(a["id"]), "name": a.get("name") or f"assignment_{a['id']}",
+             "points_possible": a.get("points_possible"),
+             "position": a.get("position") or 0} for a in raw]
+    cols.sort(key=lambda c: c["position"])
+    return cols
+
+
+def fetch_scores_by_user(base: str, cid: str, headers: dict) -> dict:
+    """{user_id: {assignment_id: score}} — one grouped sweep over all students."""
+    raw = _get_paged(base, headers, f"/api/v1/courses/{cid}/students/submissions",
+                     {"student_ids[]": "all", "grouped": "true"})
+    by_user: dict[int, dict] = {}
+    for entry in raw:
+        uid = entry.get("user_id")
+        if uid is None:
+            continue
+        cell = by_user.setdefault(int(uid), {})
+        for s in entry.get("submissions") or []:
+            aid = s.get("assignment_id")
+            if aid is not None:
+                cell[int(aid)] = s.get("score")
+    return by_user
+
+
+def test_student_id(base: str, cid: str, headers: dict) -> int | None:
+    try:
+        r = requests.get(f"{base}/api/v1/courses/{cid}/student_view_student",
+                         headers=headers, timeout=_TIMEOUT)
+        if r.status_code < 400:
+            return int((r.json() or {}).get("id"))
+    except (requests.RequestException, TypeError, ValueError):
+        pass
+    return None
+
+
+def build_matrix(assignments: list[dict], scores_by_user: dict,
+                 exclude: set) -> tuple[list[str], list[list]]:
+    """Header + rows for the de-identified CSV. Columns disambiguate duplicate
+    assignment names by appending the id. Rows sorted by user_id (deterministic)."""
+    seen: dict[str, int] = {}
+    headers_row = ["user_id"]
+    col_order: list[int] = []
+    for a in assignments:
+        name = a["name"]
+        if name in seen:
+            name = f"{name} ({a['id']})"
+        seen[a["name"]] = seen.get(a["name"], 0) + 1
+        headers_row.append(name)
+        col_order.append(a["id"])
+    rows: list[list] = []
+    for uid in sorted(scores_by_user):
+        if uid in exclude:
+            continue
+        cells = scores_by_user[uid]
+        rows.append([uid] + [cells.get(aid, "") for aid in col_order])
+    return headers_row, rows
+
+
+def is_fresh(meta_path: Path, max_age_hours: float, now: datetime) -> bool:
+    """True if a cached meta records a fetch younger than max_age_hours."""
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        fetched = datetime.fromisoformat(meta["fetched_at"].replace("Z", "+00:00"))
+    except (OSError, ValueError, KeyError):
+        return False
+    age_h = (now - fetched).total_seconds() / 3600.0
+    return age_h < max_age_hours
+
+
+def main() -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(
+        description="Mirror the live Canvas gradebook locally (de-identified, cached).")
+    ap.add_argument("--course-id", default=None, help="defaults to $CANVAS_COURSE_ID")
+    ap.add_argument("--out-dir", type=Path, default=_DEFAULT_OUT,
+                    help=f"cache dir (default {str(_DEFAULT_OUT)!r}, gitignored)")
+    ap.add_argument("--max-age-hours", type=float, default=6.0,
+                    help="skip the fetch if the cache is younger than this (default 6)")
+    ap.add_argument("--force", action="store_true", help="refresh even if fresh")
+    ap.add_argument("--version", action="version", version=f"canvas-toolbox {__version__}")
+    args = ap.parse_args()
+
+    tok, env_cid, base = _env_canvas()
+    cid = args.course_id or env_cid
+    if not (tok and base and cid):
+        print("⛔ set CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID (or --course-id).",
+              file=sys.stderr)
+        return 1
+    headers = {"Authorization": f"Bearer {tok}"}
+    now = datetime.now(tz=timezone.utc)
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = args.out_dir / f"gradebook_{cid}.csv"
+    meta_path = args.out_dir / f".fetch_meta_{cid}.json"
+
+    if not args.force and csv_path.exists() and is_fresh(meta_path, args.max_age_hours, now):
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+        print(f"✓ gradebook cache is fresh ({meta.get('fetched_at')}); "
+              f"{meta.get('student_count')} students × {meta.get('assignment_count')} "
+              f"assignments at {csv_path}. Pass --force to refresh.")
+        return 0
+
+    print(f"Mirroring gradebook for course {cid} …")
+    assignments = fetch_assignments(base, cid, headers)
+    scores = fetch_scores_by_user(base, cid, headers)
+    exclude = {tsid} if (tsid := test_student_id(base, cid, headers)) is not None else set()
+    header_row, rows = build_matrix(assignments, scores, exclude)
+
+    with csv_path.open("w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh)
+        w.writerow(header_row)
+        w.writerows(rows)
+
+    meta = {
+        "fetched_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "course_id": str(cid),
+        "assignment_count": len(assignments),
+        "student_count": len(rows),
+        "assignments": [{"id": a["id"], "name": a["name"],
+                         "points_possible": a["points_possible"]} for a in assignments],
+        "deidentified": True,
+    }
+    meta_path.write_text(json.dumps(meta, indent=2), encoding="utf-8")
+
+    print(f"✓ wrote {len(rows)} students × {len(assignments)} assignments → {csv_path}")
+    print(f"  meta → {meta_path} (fetched_at {meta['fetched_at']})")
+    print("  De-identified (user_id-keyed, no names — FERPA Zone-1). For a named report, "
+          "run grader_reidentify_gradebook.py.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.40"
+version = "1.7.41"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.39"
+version = "1.7.40"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What

The shared gradebook primitive that was missing. One API sweep → a `user_id`-keyed **score matrix** (rows = students, columns = assignments, cells = scores) cached under `.canvas/gradebook/` with a `fetched_at` stamp, so any skill reuses a fresh copy instead of re-hitting Canvas one assignment at a time.

It's the upstream input **`grader_standing`** (the "your grade" column) and **`grader_reconcile`** actually need — the *whole* multi-assignment gradebook, not one assignment.

## FERPA design (the key decision)

**De-identified by default** — the cache has `user_id` + scores, no names, so it's **FERPA Zone-1 (LLM-safe)** and every skill can read it. For a named human report, pipe it through the existing `grader_reidentify_gradebook.py`. That's what makes it safely "usable by all skills" — it composes with the existing re-identify tool rather than caching names.

## Behavior

- **Online** mirror (distinct from offline `.imscc` mode).
- `Link: rel="next"` pagination (issue #67 — no blind `page++` crash).
- Excludes the Test Student (#61).
- **Freshness cache:** skips the fetch when the cache is younger than `--max-age-hours` (default 6); `--force` refreshes. Meta JSON records `fetched_at`, counts, and the assignment list.

```
grader_fetch_gradebook.py            # fetch (or reuse if fresh)
grader_fetch_gradebook.py --force    # refresh now
```

## Tests
7: de-identification (user_id-keyed, no name column), Test-Student exclusion, duplicate-column disambiguation, column-order preservation, and the freshness check (fresh/stale/missing/malformed). Wired into the `grading` skill as `grader_standing`'s upstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)