### PR TITLE
feat(grader_quiz_clear_pending): clear auto-scored quizzes stuck on a 0-point manual question

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -113,6 +113,17 @@ grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-
   `.review.csv`, `submissions_raw/`, `feedback/_grader*.csv`) are **never** read or
   displayed. Verify with `wc -l` / `ls`, never `cat`/`head`/`grep`.
 
+## Known case: an auto-scored quiz stuck in "To Do"
+
+A classic quiz with an essay/file-upload question auto-scores on submission
+(`workflow_state: graded`) but stays in the instructor's To-Do because the manual
+question is `pending_review`. **Do NOT reach for grader_push** — `regrade_gate`
+correctly refuses (it's already graded; this isn't a grade push), and stacking
+`--force`/`--regrade` is the wrong move. If that manual question is worth **0 points**,
+use `grader_quiz_clear_pending.py`: it posts a 0 to the 0-point manual question to
+clear the flag — and it *can't change a grade* because it only ever touches 0-point
+questions. If the pending question is worth points, that's real grading → SpeedGrader.
+
 ## Quick command map
 
 | Ask | Command |
@@ -124,6 +135,7 @@ grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-
 | Update the "your grade" column | `grader_standing.py --csv <f> --assignment-id <id> --push` |
 | Rebuild the de-id master | `build_deid_master.py --force` |
 | Mirror the live gradebook locally (feeds standing/reconcile) | `grader_fetch_gradebook.py` |
+| Clear an auto-scored quiz stuck on a 0-point manual question | `grader_quiz_clear_pending.py --assignment-id <id> --apply` |
 
 Full grading knowledge: [`lib/agents/knowledge/grader_hybrid_architecture.md`](../../../lib/agents/knowledge/grader_hybrid_architecture.md)
 and [`lib/agents/knowledge/toolkit_reuse_knowledge.md`](../../../lib/agents/knowledge/toolkit_reuse_knowledge.md).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.42] — 2026-07-28
+
+**New `grader_quiz_clear_pending.py` — clear an auto-scored quiz stuck in "To Do" on a 0-point manual question.**
+
+A classic quiz with an essay/file-upload question auto-scores on submission (`workflow_state: graded`) but lingers in the instructor's To-Do because the manual question is `pending_review`. `grader_push` can't help (regrade_gate correctly refuses an already-graded submission), and `grader_audit_workflow` deliberately won't touch a moderation queue. When that question is worth **0 points**, this tool posts a 0 to it — marking it graded and clearing the flag.
+
+**It can never change a grade:** the hard invariant is that it only ever posts to a *manual* question worth *0 points*. Anything worth points is real grading and is refused (→ SpeedGrader). Dry-run by default; `--apply` writes; `canvas_course_guard` gates the live-course write. Classic quizzes only (New Quizzes can't be graded via this API). The `grading` skill now documents the case so agents stop stacking `--force`/`--regrade` at grader_push for it.
+
+---
+
 ## [1.7.41] — 2026-07-28
 
 **New `grader_fetch_gradebook.py` — mirror the live Canvas gradebook locally, de-identified and cached.**

--- a/lib/tests/test_grader_quiz_clear_pending.py
+++ b/lib/tests/test_grader_quiz_clear_pending.py
@@ -1,0 +1,58 @@
+"""Unit tests — grader_quiz_clear_pending safety filters.
+
+The whole tool rests on one invariant: it only ever posts a score to a MANUAL
+question worth ZERO points, so it can never change a grade. These tests pin that
+filter (and the pending-submission selector) hard.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_quiz_clear_pending import zero_point_manual_qids, pending_submissions  # noqa: E402
+
+
+def test_selects_zero_point_essay_and_file_upload():
+    qs = [
+        {"id": 1, "question_type": "essay_question", "points_possible": 0},
+        {"id": 2, "question_type": "file_upload_question", "points_possible": 0},
+    ]
+    assert zero_point_manual_qids(qs) == [1, 2]
+
+
+def test_never_touches_a_scored_manual_question():
+    """The safety invariant: a manual question worth > 0 is REAL grading — excluded."""
+    qs = [
+        {"id": 1, "question_type": "essay_question", "points_possible": 5},   # scored → skip
+        {"id": 2, "question_type": "essay_question", "points_possible": 0},   # 0-pt → target
+    ]
+    assert zero_point_manual_qids(qs) == [2]
+
+
+def test_ignores_auto_gradable_questions_even_at_zero_points():
+    """Only manual types cause pending_review; a 0-point multiple-choice is not ours."""
+    qs = [
+        {"id": 1, "question_type": "multiple_choice_question", "points_possible": 0},
+        {"id": 2, "question_type": "true_false_question", "points_possible": 0},
+    ]
+    assert zero_point_manual_qids(qs) == []
+
+
+def test_handles_missing_or_bad_points_field():
+    qs = [
+        {"id": 1, "question_type": "essay_question"},                 # no points → treated 0
+        {"id": 2, "question_type": "essay_question", "points_possible": "x"},  # junk → 0
+        {"id": 3, "question_type": "essay_question", "points_possible": None},
+    ]
+    assert zero_point_manual_qids(qs) == [1, 2, 3]
+
+
+def test_pending_submissions_selects_only_pending_review():
+    subs = [
+        {"id": 10, "user_id": 501, "workflow_state": "graded"},
+        {"id": 11, "user_id": 502, "workflow_state": "pending_review"},
+        {"id": 12, "user_id": 503, "workflow_state": "complete"},
+    ]
+    assert [s["user_id"] for s in pending_submissions(subs)] == [502]

--- a/lib/tools/grader_quiz_clear_pending.py
+++ b/lib/tools/grader_quiz_clear_pending.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""grader_quiz_clear_pending.py — clear the "needs grading" flag on auto-scored
+classic quizzes stuck on a ZERO-POINT manual-review question.
+
+THE PROBLEM
+  A classic quiz with an essay / file-upload question auto-scores on submission
+  (workflow_state 'graded', graded_at set), but Canvas still lists it in the
+  instructor's To-Do because the manual question is 'pending_review'. When that
+  question is worth 0 points there is nothing to actually grade — the instructor
+  just needs the flag cleared. grader_push can't help (regrade_gate correctly
+  refuses an already-graded submission; this isn't a grade push), and
+  grader_audit_workflow deliberately won't touch a moderation queue.
+
+WHAT IT DOES
+  Finds classic-quiz submissions in 'pending_review' and posts a score of 0 to the
+  ZERO-POINT manual questions holding them there — which marks them graded and clears
+  the To-Do. Dry-run by default; --apply to write; --allow-enrolled for your own
+  live course.
+
+SAFETY INVARIANT — it can NEVER change a grade
+  It only ever touches a question whose points_possible == 0. Posting 0 to a 0-point
+  question cannot alter a student's score; it only clears the needs-grading flag.
+  Any question worth > 0 points is real grading and belongs in the review -> push
+  flow, not here — this tool refuses to touch it. Classic quizzes only (New Quizzes
+  can't be graded via this API).
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+try:
+    from _env_loader import force_utf8_console, load_env
+    load_env()
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+import requests
+
+try:
+    from __toolbox_version__ import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
+
+try:
+    from canvas_course_guard import enforce as guard_enforce
+except ImportError:
+    guard_enforce = None
+
+from grader_push import _env_canvas
+
+_TIMEOUT = 30
+# Classic-quiz question types that require MANUAL grading (auto-gradable types never
+# cause pending_review). A 0-point one of these is the target.
+_MANUAL_TYPES = {"essay_question", "file_upload_question"}
+
+
+def zero_point_manual_qids(questions: list[dict]) -> list[int]:
+    """Question ids that are manual-review AND worth 0 points — the ONLY questions
+    this tool may post a score to. A manual question worth > 0 is real grading and is
+    intentionally excluded (the safety invariant lives here)."""
+    out = []
+    for q in questions:
+        try:
+            pts = float(q.get("points_possible") or 0)
+        except (TypeError, ValueError):
+            pts = 0.0
+        if q.get("question_type") in _MANUAL_TYPES and pts == 0.0 and q.get("id") is not None:
+            out.append(int(q["id"]))
+    return out
+
+
+def pending_submissions(submissions: list[dict]) -> list[dict]:
+    """Quiz submissions awaiting manual review (the ones cluttering the To-Do)."""
+    return [s for s in submissions
+            if (s.get("workflow_state") or "").lower() == "pending_review"]
+
+
+def _get(base, cid, headers, path, key=None):
+    r = requests.get(f"{base}/api/v1/courses/{cid}{path}", headers=headers,
+                     params={"per_page": 100}, timeout=_TIMEOUT)
+    r.raise_for_status()
+    data = r.json()
+    return (data or {}).get(key, []) if key else (data or [])
+
+
+def resolve_quiz_id(base, cid, headers, assignment_id, quiz_id):
+    if quiz_id:
+        return int(quiz_id)
+    a = requests.get(f"{base}/api/v1/courses/{cid}/assignments/{assignment_id}",
+                     headers=headers, timeout=_TIMEOUT)
+    a.raise_for_status()
+    qid = (a.json() or {}).get("quiz_id")
+    if not qid:
+        print(f"⛔ assignment {assignment_id} is not a classic quiz (no quiz_id). "
+              "New Quizzes can't be graded via this API.", file=sys.stderr)
+        return None
+    return int(qid)
+
+
+def main() -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(
+        description="Clear the needs-grading flag on classic quizzes stuck on a "
+                    "0-point manual question (posts 0 — cannot change a grade).")
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--assignment-id", help="the quiz's assignment id")
+    g.add_argument("--quiz-id", help="the classic quiz id directly")
+    ap.add_argument("--course-id", default=None, help="defaults to $CANVAS_COURSE_ID")
+    ap.add_argument("--apply", action="store_true", help="actually post the 0s (else dry-run)")
+    ap.add_argument("--allow-enrolled", action="store_true",
+                    help="bypass canvas_course_guard for your own enrolled course")
+    ap.add_argument("--version", action="version", version=f"canvas-toolbox {__version__}")
+    args = ap.parse_args()
+
+    tok, env_cid, base = _env_canvas()
+    cid = args.course_id or env_cid
+    if not (tok and base and cid):
+        print("⛔ set CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID (or --course-id).",
+              file=sys.stderr)
+        return 1
+    headers = {"Authorization": f"Bearer {tok}"}
+
+    qid = resolve_quiz_id(base, cid, headers, args.assignment_id, args.quiz_id)
+    if qid is None:
+        return 1
+
+    questions = _get(base, cid, headers, f"/quizzes/{qid}/questions")
+    zero_qids = zero_point_manual_qids(questions)
+    if not zero_qids:
+        print(f"No 0-point manual questions on quiz {qid}. Any pending review here is "
+              "REAL grading — not this tool's job. Nothing to do.")
+        return 0
+
+    subs = _get(base, cid, headers, f"/quizzes/{qid}/submissions", key="quiz_submissions")
+    pending = pending_submissions(subs)
+    print(f"Quiz {qid}: {len(zero_qids)} zero-point manual question(s) "
+          f"{zero_qids}; {len(pending)} submission(s) pending review.")
+    for s in pending:
+        print(f"  [{'apply' if args.apply else 'dry '}] user {s.get('user_id')}: "
+              f"post 0 to question(s) {zero_qids} (attempt {s.get('attempt')})")
+
+    if not pending:
+        print("Nothing pending — To-Do is clear.")
+        return 0
+    if not args.apply:
+        print("\nDry run — nothing written. Add --apply to clear the flag.")
+        return 0
+
+    if guard_enforce:
+        guard_enforce(base, headers, cid, mode="write", allow_override=args.allow_enrolled)
+
+    cleared, failed = 0, 0
+    for s in pending:
+        body = {"quiz_submissions": [{"attempt": s.get("attempt"),
+                                      "questions": {str(q): {"score": 0} for q in zero_qids}}]}
+        r = requests.put(f"{base}/api/v1/courses/{cid}/quizzes/{qid}/submissions/{s.get('id')}",
+                         headers=headers, json=body, timeout=_TIMEOUT)
+        if r.status_code < 400:
+            print(f"  cleared user {s.get('user_id')}")
+            cleared += 1
+        else:
+            print(f"  ⛔ user {s.get('user_id')}: HTTP {r.status_code} {r.text[:120]}",
+                  file=sys.stderr)
+            failed += 1
+    print(f"\nCleared {cleared}, failed {failed}. Re-check your Canvas To-Do.")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.41"
+version = "1.7.42"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.40"
+version = "1.7.41"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The case

A classic quiz with an essay/file-upload question auto-scores on submission (`workflow_state: graded`, `graded_at` set) but lingers in the instructor's **To-Do** because the manual question is `pending_review`. When that question is worth **0 points**, there's nothing to grade — the flag just needs clearing.

Neither existing tool fits: `grader_push`'s `regrade_gate` correctly refuses an already-graded submission (this isn't a grade push), and `grader_audit_workflow` deliberately excludes moderation queues. So agents were stacking `--force`/`--regrade` at grader_push — the wrong move.

## The tool

Finds `pending_review` classic-quiz submissions and posts a **0** to the 0-point manual questions holding them there, clearing the To-Do.

## Hard safety invariant — it can NEVER change a grade

It only ever posts to a **manual** question worth **0 points**. Posting 0 to a 0-point question cannot alter a score. Any question worth > 0 is real grading and is **refused** (→ SpeedGrader). That invariant lives in `zero_point_manual_qids` and is the most-tested thing here.

- Dry-run by default; `--apply` writes; `--allow-enrolled` for your own live course (via `canvas_course_guard`).
- Classic quizzes only (New Quizzes can't be graded via this API).
- FERPA-safe output (user_id, no names).

```
grader_quiz_clear_pending.py --assignment-id <id>           # dry-run
grader_quiz_clear_pending.py --assignment-id <id> --apply --allow-enrolled
```

## Tests
5: selects 0-point essay/file-upload, **never touches a scored manual question**, ignores auto-gradable types even at 0 points, handles missing/bad points fields, and the pending-review selector. The `grading` skill documents the case so agents stop flailing at grader_push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)