### PR TITLE
feat(cb_update): 'cb re-init' — install skills + heal stale pointer in old course repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.7.43] — 2026-07-28
+
+**New `cb_update.py` (the "cb re-init") — bring an old course-repo init current, and heal the stale pointer the constitution rewrite left behind.**
+
+A field audit of 9 consumer repos found the six operating-mode skills active in **0 of 9** (Claude Code only discovers skills at the *course* root, not the vendored subdir) and a stale grading-protocol pointer — to a heading the 1.7.40 constitution rewrite renamed — in **6 of 9**. A `git pull` can't fix either: it refreshes the vendored toolkit, not the consumer's own files. (The audit's good news: **0 of 9** had any tracked FERPA/toolkit leak — the two-zone gitignore discipline holds in the field.)
+
+`cb_update` closes the gap idempotently and non-destructively, run from a course root:
+- **Skills:** symlinks `<course-root>/.claude/skills/<skill>` → the vendored `canvas-toolbox/.claude/skills/<skill>`, so Claude Code activates them *and* they auto-track future `git pull`s (a symlink, not a drifting copy). A course's own same-named skill is never clobbered; Windows falls back to a copy.
+- **Pointer:** `sync_grading_protocol`'s injected block now points at the constitution + skills index (not the renamed heading), and injection is **self-healing** — a stale marker block is refreshed in place, surrounding course content untouched.
+- **Version:** reports the vendored version and nudges `git pull`.
+
+Dry-run by default; `--apply` writes.
+
+---
+
 ## [1.7.42] — 2026-07-28
 
 **New `grader_quiz_clear_pending.py` — clear an auto-scored quiz stuck in "To Do" on a 0-point manual question.**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -1,0 +1,85 @@
+"""Unit tests — cb_update ("cb re-init"): skill symlinks + pointer refresh.
+
+The field audit found the 6 operating-mode skills active in 0/9 consumer repos and a
+stale pointer in 6/9. These pin the two fixes: install skills at the course root
+(non-clobbering) and refresh the pointer in place.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from cb_update import (  # noqa: E402
+    plan_skill_symlinks,
+    install_skill_symlinks,
+    ensure_gitignore,
+    refresh_pointer,
+)
+
+
+def _fake_course(tmp_path):
+    """A course root with a vendored canvas-toolbox/.claude/skills/<name>/SKILL.md."""
+    for s in ("grading", "audit"):
+        d = tmp_path / "canvas-toolbox" / ".claude" / "skills" / s
+        d.mkdir(parents=True)
+        (d / "SKILL.md").write_text(f"---\nname: {s}\n---\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_plan_targets_are_relative_and_point_into_the_toolkit():
+    plan = plan_skill_symlinks(Path("/course"), "canvas-toolbox", ["grading"])
+    link, rel = plan[0]
+    assert link == Path("/course/.claude/skills/grading")
+    # from <course>/.claude/skills/ up to <course>/ then into the toolkit
+    assert rel == "../../canvas-toolbox/.claude/skills/grading"
+
+
+def test_install_dry_run_writes_nothing(tmp_path):
+    course = _fake_course(tmp_path)
+    plan = plan_skill_symlinks(course, "canvas-toolbox", ["grading"])
+    res = install_skill_symlinks(plan, apply=False)
+    assert res == [("grading", "would-link")]
+    assert not (course / ".claude" / "skills" / "grading").exists()
+
+
+def test_install_creates_symlink_that_resolves_to_the_toolkit_skill(tmp_path):
+    course = _fake_course(tmp_path)
+    plan = plan_skill_symlinks(course, "canvas-toolbox", ["grading"])
+    res = install_skill_symlinks(plan, apply=True)
+    assert res == [("grading", "linked")]
+    link = course / ".claude" / "skills" / "grading"
+    assert link.is_symlink()
+    assert (link / "SKILL.md").read_text(encoding="utf-8").startswith("---")  # resolves
+    # re-run is idempotent
+    assert install_skill_symlinks(plan, apply=True) == [("grading", "present")]
+
+
+def test_install_never_clobbers_a_course_owned_skill(tmp_path):
+    course = _fake_course(tmp_path)
+    owned = course / ".claude" / "skills" / "grading"
+    owned.mkdir(parents=True)
+    (owned / "SKILL.md").write_text("course's own\n", encoding="utf-8")
+    plan = plan_skill_symlinks(course, "canvas-toolbox", ["grading"])
+    assert install_skill_symlinks(plan, apply=True) == [("grading", "skip-course-owns")]
+    assert (owned / "SKILL.md").read_text(encoding="utf-8") == "course's own\n"  # intact
+
+
+def test_ensure_gitignore_adds_skills_line_once(tmp_path):
+    assert ensure_gitignore(tmp_path, apply=True) == "added"
+    assert ".claude/skills/" in (tmp_path / ".gitignore").read_text(encoding="utf-8")
+    assert ensure_gitignore(tmp_path, apply=True) == "present"  # idempotent
+
+
+def test_refresh_pointer_injects_into_course_agents(tmp_path):
+    (tmp_path / "AGENTS.md").write_text("# ITM327\n\nCourse context.\n", encoding="utf-8")
+    fname, status = refresh_pointer(tmp_path, apply=True)
+    assert (fname, status) == ("AGENTS.md", "refreshed")
+    body = (tmp_path / "AGENTS.md").read_text(encoding="utf-8")
+    assert ".claude/skills" in body and "Course context." in body  # added, non-clobbering
+    assert refresh_pointer(tmp_path, apply=True)[1] == "present"  # idempotent
+
+
+def test_refresh_pointer_reports_missing_when_no_agents_file(tmp_path):
+    assert refresh_pointer(tmp_path, apply=True)[1] == "missing"

--- a/lib/tests/test_sync_grading_protocol.py
+++ b/lib/tests/test_sync_grading_protocol.py
@@ -16,6 +16,7 @@ from sync_grading_protocol import (  # noqa: E402
     inject_grading_pointer,
     process_agents_file,
     POINTER_MARKER,
+    POINTER_END,
     POINTER_BLOCK,
 )
 
@@ -39,6 +40,20 @@ def test_idempotent_when_marker_present():
     assert changed is False
     assert twice == once
     assert twice.count(POINTER_MARKER) == 1  # not doubled
+
+
+def test_refreshes_a_stale_marker_block_in_place():
+    """A repo carrying an OLD marker block (pre-constitution wording) must be
+    healed in place — the 6-of-9 dangling-pointer case from the field audit."""
+    stale = ("# ITM327\n\n"
+             f"{POINTER_MARKER}\n\n## Grading — HG-5\n\nold pointer to a renamed "
+             f"heading\n\n{POINTER_END}\n\n## Course stuff\n")
+    new, changed = inject_grading_pointer(stale)
+    assert changed is True
+    assert new.count(POINTER_MARKER) == 1              # not doubled
+    assert "renamed heading" not in new                # stale content gone
+    assert ".claude/skills" in new                     # current content in
+    assert "## Course stuff" in new                    # course content untouched
 
 
 def test_prepends_when_no_title():

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""cb_update.py — the "cb re-init": bring an OLD course-repo init current.
+
+cb_init bootstraps a NEW course repo. But a `git pull` only refreshes the vendored
+toolkit code — it can't update a consumer's own course-root files, and it can't make
+new toolkit standards active. So repos initialized months ago drift: the field audit
+found the six operating-mode skills active in **0 of 9** consumer repos, and a stale
+grading-protocol pointer (to a since-renamed heading) in **6 of 9**.
+
+cb_update closes that gap idempotently and NON-destructively:
+
+  1. Skills — symlink `<course-root>/.claude/skills/<skill>` → the vendored
+     `canvas-toolbox/.claude/skills/<skill>` for each toolkit skill, so Claude Code
+     discovers them at the course root (it only looks there, not in the vendored
+     subdir) AND they auto-track future `git pull`s (a symlink, not a copy that
+     drifts). A course's own same-named skill is left untouched.
+  2. Pointer — refresh the sentinel-delimited canvas-toolbox pointer block in the
+     course AGENTS.md (constitution + skills index), healing a stale block in place
+     without touching surrounding course-specific content.
+  3. Version — report the vendored toolkit version and nudge `git pull` if it looks
+     behind.
+
+Dry-run by default; --apply writes. Run from the course root (or its
+canvas-toolbox/ subdir).
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+try:
+    from _env_loader import force_utf8_console
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+try:
+    from __toolbox_version__ import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
+
+from cb_init import detect_course_context, REPO_ROOT
+from sync_grading_protocol import inject_grading_pointer
+
+SKILLS = ["grading", "course-build", "audit", "accommodations", "ferpa-deid", "title-iv"]
+
+
+def plan_skill_symlinks(course_root: Path, toolkit_subdir: str,
+                        skills: list[str]) -> list[tuple[Path, str]]:
+    """(link_path, relative_target) for each skill — pure, testable."""
+    skills_root = course_root / ".claude" / "skills"
+    out = []
+    for s in skills:
+        link = skills_root / s
+        target_abs = course_root / toolkit_subdir / ".claude" / "skills" / s
+        out.append((link, os.path.relpath(target_abs, skills_root)))
+    return out
+
+
+def install_skill_symlinks(plan: list[tuple[Path, str]], apply: bool) -> list[tuple[str, str]]:
+    """Create/refresh each skill symlink. Never clobbers a course-owned real dir.
+    Returns [(skill, status)] where status ∈ present/would-link/linked/copied/
+    skip-course-owns."""
+    results = []
+    for link, rel in plan:
+        name = link.name
+        if link.is_symlink():
+            if os.readlink(link) == rel:
+                results.append((name, "present"))
+                continue          # already correct
+        elif link.exists():
+            results.append((name, "skip-course-owns"))  # a real dir/file — don't touch
+            continue
+        if not apply:
+            results.append((name, "would-link"))
+            continue
+        link.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            if link.is_symlink() or link.exists():
+                link.unlink()
+            link.symlink_to(rel)
+            results.append((name, "linked"))
+        except OSError:
+            # Windows / no-symlink-permission fallback: copy the skill dir.
+            target = (link.parent / rel).resolve()
+            if link.exists():
+                shutil.rmtree(link, ignore_errors=True)
+            if target.is_dir():
+                shutil.copytree(target, link)
+                results.append((name, "copied"))
+            else:
+                results.append((name, "missing-target"))
+    return results
+
+
+def ensure_gitignore(course_root: Path, apply: bool) -> str:
+    """Make sure `.claude/skills/` is gitignored (the symlinks/copies point at the
+    gitignored vendored toolkit; re-created by this tool, not committed)."""
+    gi = course_root / ".gitignore"
+    line = ".claude/skills/"
+    existing = gi.read_text(encoding="utf-8") if gi.is_file() else ""
+    if line in existing.splitlines():
+        return "present"
+    if not apply:
+        return "would-add"
+    with gi.open("a", encoding="utf-8") as fh:
+        if existing and not existing.endswith("\n"):
+            fh.write("\n")
+        fh.write(f"# canvas-toolbox skills (symlinks into the vendored toolkit)\n{line}\n")
+    return "added"
+
+
+def refresh_pointer(course_root: Path, apply: bool) -> tuple[str, str]:
+    """Refresh the constitution+skills pointer block in the course AGENTS.md (or
+    CLAUDE.md). Returns (filename, status ∈ missing/present/refreshed/would-refresh)."""
+    path = course_root / "AGENTS.md"
+    if not path.is_file():
+        alt = course_root / "CLAUDE.md"
+        path = alt if alt.is_file() else path
+    if not path.is_file():
+        return (path.name, "missing")
+    text = path.read_text(encoding="utf-8")
+    new, changed = inject_grading_pointer(text)
+    if not changed:
+        return (path.name, "present")
+    if not apply:
+        return (path.name, "would-refresh")
+    path.write_text(new, encoding="utf-8")
+    return (path.name, "refreshed")
+
+
+def main() -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(
+        description="Bring an old canvas-toolbox course init current (skills + pointer).")
+    ap.add_argument("--apply", action="store_true", help="write changes (else dry-run)")
+    args = ap.parse_args()
+
+    course_root, is_subdir = detect_course_context()
+    if not is_subdir:
+        print("Standalone canvas-toolbox — skills already live at .claude/skills/; "
+              "nothing to re-init. cb_update is for consumer course repos.")
+        return 0
+    toolkit_subdir = REPO_ROOT.name  # e.g. 'canvas-toolbox'
+
+    print(f"cb_update (re-init) for course repo: {course_root}")
+    print(f"  vendored toolkit: {toolkit_subdir}/ @ v{__version__}")
+    print(f"  {'APPLYING' if args.apply else 'DRY RUN — pass --apply to write'}\n")
+
+    plan = plan_skill_symlinks(course_root, toolkit_subdir, SKILLS)
+    print("Skills → .claude/skills/ (so Claude Code activates them here):")
+    for name, status in install_skill_symlinks(plan, args.apply):
+        print(f"  {status:16} {name}")
+    print(f"  gitignore .claude/skills/: {ensure_gitignore(course_root, args.apply)}")
+
+    fname, status = refresh_pointer(course_root, args.apply)
+    print(f"\nConstitution+skills pointer in {fname}: {status}")
+
+    print("\nReminder: `cd " + toolkit_subdir + " && git pull` keeps the toolkit "
+          "(and the symlinked skills) current.")
+    if not args.apply:
+        print("Re-run with --apply to make the changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/tools/sync_grading_protocol.py
+++ b/lib/tools/sync_grading_protocol.py
@@ -40,17 +40,21 @@ POINTER_END = "<!-- /canvas-toolbox:grading-protocol-pointer -->"
 # block (the marker is how this tool detects "already present").
 POINTER_BLOCK = f"""{POINTER_MARKER}
 
-## ⚠️ Grading — HG-5: the instructor decides
+## ⚠️ Using canvas-toolbox — constitution + skills
 
-AI-assisted grading here is **decision support, not autonomy**. Never push AI-drafted
-grades to Canvas without human review: grade → review the feedback →
-`grader_push.py --mark-reviewed` (type `reviewed`) → `--push` (type `push`). `--yes` does
-**not** bypass review on the AI-drafted path — that's enforced in code, not just
-documented (issue #207).
+This course uses **canvas-toolbox**. Its always-on rules — FERPA discipline, the
+Canvas-write safety doctrine + the `grade_guardian` hook, and behavioral principles —
+live in **`canvas-toolbox/AGENTS.md`** (the constitution). Read it. Mode-specific
+procedure lives in **operating-mode skills** under `.claude/skills/`: `grading`,
+`course-build`, `audit`, `accommodations`, `ferpa-deid`, `title-iv`. Load the skill
+that matches your task.
 
-Full protocol + rationale (principle HG-5): see
-**canvas-toolbox/AGENTS.md → "AI Grading Protocol — HG-5"**. When a gate blocks you, the
-fix is to do the review, not to reach for an override flag.
+**Grading is HG-5 — the instructor decides.** AI grading is decision support, not
+autonomy: grade → review the feedback → `grader_push.py --mark-reviewed` (type
+`reviewed`) → `--push` (type `push`). `--yes` does **not** bypass review on the
+AI-drafted path — enforced in code (#207). When a gate blocks you, do the review —
+never stack `--force`/`--regrade`/`--yes` to route around it, and never hand-write a
+Canvas write (the `grade_guardian` hook blocks that at create/edit/run).
 
 {POINTER_END}"""
 
@@ -58,15 +62,22 @@ fix is to do the review, not to reach for an override flag.
 def inject_grading_pointer(text: str) -> tuple[str, bool]:
     """Return (new_text, changed).
 
-    Idempotent: if POINTER_MARKER is already present, returns text unchanged.
-    Otherwise inserts POINTER_BLOCK just after the file's first top-level `# `
-    heading (so it's discoverable near the top), or prepends it if the file has
-    no such heading. Course-specific content around it is left untouched.
+    Idempotent AND self-healing: if the marker block is already present and CURRENT,
+    returns unchanged; if present but STALE (older wording — e.g. a pre-constitution
+    pointer to a heading that has since been renamed), it REFRESHES the block in
+    place. If absent, inserts POINTER_BLOCK just after the file's first top-level
+    `# ` heading (or prepends it if there's none). Course-specific content around the
+    block is never touched.
     """
-    if POINTER_MARKER in text:
-        return text, False
-
     block = POINTER_BLOCK.strip("\n")
+
+    if POINTER_MARKER in text and POINTER_END in text:
+        start = text.index(POINTER_MARKER)
+        end = text.index(POINTER_END) + len(POINTER_END)
+        if text[start:end] == block:
+            return text, False              # already current — no-op
+        return text[:start] + block + text[end:], True   # stale → refresh in place
+
     lines = text.splitlines(keepends=True)
     idx = next((i for i, ln in enumerate(lines) if ln.startswith("# ")), None)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.42"
+version = "1.7.43"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.41"
+version = "1.7.42"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The problem (field audit, 9 consumer repos)

| Finding | Count |
|---|---|
| 6 operating-mode skills **active** at course root | **0/9** |
| **Stale grading pointer** (to a heading 1.7.40 renamed) | **6/9** |
| Tracked FERPA / toolkit leak | **0/9** ✅ |

A `git pull` refreshes the *vendored* toolkit but can't touch a consumer's own course-root files, and Claude Code only discovers skills at the **course root** — not the vendored subdir. So the whole 6-skill architecture was stranded for every consumer, and my own 1.7.40 constitution rewrite left a dangling pointer in 6 repos.

## `cb_update` — the "cb re-init"

cb_init bootstraps a NEW repo; **cb_update brings an OLD one current**, idempotently + non-destructively, from a course root:

1. **Skills** — symlinks `<course-root>/.claude/skills/<skill>` → the vendored `canvas-toolbox/.claude/skills/<skill>`. Claude Code activates them, and they **auto-track future `git pull`s** (a symlink, not a copy that drifts). A course's own same-named skill is **never clobbered**; Windows falls back to a copy.
2. **Pointer** — `sync_grading_protocol`'s block now points at the **constitution + skills index** (not the renamed heading), and injection is **self-healing**: a stale marker block is refreshed *in place*, surrounding course content untouched.
3. **Version** — reports the vendored version + nudges `git pull`.

Dry-run by default; `--apply` writes.

## Tests
7 for cb_update (relative-target computation, dry-run no-op, real symlink creation + resolution on a temp fs, **never clobbers a course-owned skill**, gitignore, pointer refresh/idempotency) + a new `sync_grading_protocol` case pinning the stale-block refresh. cb_init/sync/cb_update suites: 37 passed.

## Rollout
After this merges, each consumer: `cd canvas-toolbox && git pull` then `uv run python canvas-toolbox/lib/tools/cb_update.py --apply`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)