### PR TITLE
chore(release): cut 1.8.0 — operating-mode skills architecture milestone

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,10 +141,14 @@ name)`); deterministic-first grader design (Python over LLM when deterministic).
 
 Trunk-based: branch off `main`, PR, squash-merge, delete branch, sync local `main`.
 `main` always works. **Bump `pyproject.toml` version IN THE PR** — patch by default,
-minor for a medium shift, major for a breaking change; docs-only may leave it. On
-merge, `.github/workflows/version-bump.yml` auto-tags `vX.Y.Z`. Consumers track
-`main` via `git pull`, so the version is a milestone + drift marker, not a per-merge
-gate.
+minor for a medium shift, major for a breaking change; docs-only may leave it. A
+change to the toolkit's **shape** — a new architecture (like the operating-mode
+skills split), a new subsystem, a consumer-facing reorganization — is a **minor**
+even if it's "just docs / just files": bump the 2nd digit when the toolkit
+*reorganizes*, not only when behavior changes. (The skills split shipped as a patch
+by oversight; 1.8.0 is its milestone.) On merge,
+`.github/workflows/version-bump.yml` auto-tags `vX.Y.Z`. Consumers track `main` via
+`git pull`, so the version is a milestone + drift marker, not a per-merge gate.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.0] — 2026-07-28
+
+**Milestone: the operating-mode skills architecture.**
+
+canvas-toolbox is now organized as a **constitution + skills**. The always-on safety law (FERPA discipline, the Canvas-write doctrine + `grade_guardian`, behavioral principles) lives in `AGENTS.md`; each operating mode is a **skill** that loads on demand: `grading`, `course-build`, `audit`, `accommodations`, `ferpa-deid`, `title-iv`. This is a structural shift on the scale of the v1.7 offline suite, so it earns the minor rev. The pieces are complete and stable as of 1.8.0 — the constitution split + six skills (shipped 1.7.40) and the `cb_update` propagation tool (1.7.43).
+
+**Consumers must re-init — a plain `git pull` is no longer enough.** Skills only activate once they're symlinked at the course root:
+
+```
+cd canvas-toolbox && git pull && cd ..
+uv run python canvas-toolbox/lib/tools/cb_update.py --apply
+```
+
+That installs the skills and heals the grading-protocol pointer. No breaking API changes — tools are unchanged; this is a documentation/architecture reorganization plus the propagation tooling.
+
+---
+
 ## [1.7.43] — 2026-07-28
 
 **New `cb_update.py` (the "cb re-init") — bring an old course-repo init current, and heal the stale pointer the constitution rewrite left behind.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.7.43"
+version = "1.8.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.7.42"
+version = "1.7.43"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Why 1.8.0

Our own versioning policy: *minor for a medium shift (like the v1.7 offline suite).* The **constitution + 6-skill restructure** (shipped 1.7.40) is exactly that scale — arguably bigger — but went out as a **patch** by oversight. Its final piece, the `cb_update` propagation tool, landed in 1.7.43, so the feature line is complete and stable. **1.8.0 marks the milestone.**

## What 1.8.0 represents

The operating-mode skills architecture: `AGENTS.md` is the always-on **constitution**; each mode (`grading`, `course-build`, `audit`, `accommodations`, `ferpa-deid`, `title-iv`) is a **skill** that loads on demand; `cb_update` propagates them to consumer repos.

**No breaking API changes** — tools are unchanged. It's a documentation/architecture reorganization + propagation tooling, so it's a *minor*, not a major.

## Consumers must re-init

```
cd canvas-toolbox && git pull && cd ..
uv run python canvas-toolbox/lib/tools/cb_update.py --apply
```

## Also: sharpened the policy

The constitution's versioning rule now says a change to the toolkit's **shape** (new architecture/subsystem/consumer-facing reorg) is a **minor** even if it's "just docs/files" — so a structural shift gets the 2nd-digit bump proactively, not retroactively.

🤖 Generated with [Claude Code](https://claude.com/claude-code)