### PR TITLE
fix(grader_standing): guide agents to --yes, not a terminal (non-technical faculty)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -90,8 +90,17 @@ script produces the values (from the gradebook — `grader_fetch_gradebook.py` m
 it locally, de-identified and cached, as that upstream input); the tool pushes them,
 dry-run by default, with strict
 guards (unmatched/ambiguous key → hard fail; out-of-bounds → abort; big drop →
-abort unless `--allow-swings`). `--yes` is allowed (deterministic, value-only) so
-the weekly run can automate.
+abort unless `--allow-swings`).
+
+**Confirming a standing push — use `--yes`, NOT a terminal.** Because standing is
+value-only and instructor-computed (no AI-drafted feedback to review), `--yes` is
+**allowed** here — the safe side of HG-5, unlike grader_push. The right flow: run the
+dry-run, **show the instructor the `old → new` preview**, and when they confirm
+(e.g. they say "push"), **re-run with `--yes` yourself**. Do **not** tell the
+instructor to open a terminal and type `push` — our audience is non-technical
+faculty; that's a dead end. Their confirmation of the preview *is* the attestation;
+`--yes` captures it. (You still never generate the grades yourself and `--yes` them —
+the values come from the instructor's script/CSV.)
 
 ```
 grader_standing.py --csv standing.csv --assignment-id <id>                    # dry-run diff

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,6 +129,15 @@ Verify; on a defect, fix it, verify with real data, then add an automated guard.
 Dependencies (`markdownify`, etc.) live in the uv venv; system `python3`/`pytest`
 reports false failures from missing modules.
 
+**Audience = non-technical faculty.** Complete actions *for* them; never hand an
+instructor a terminal command to copy-paste, `cd` into, or type a confirmation at.
+If a tool refuses non-interactive input, that's a signal to find the sanctioned
+non-interactive path (e.g. grader_standing's `--yes` for value-only pushes) or to
+surface a plain-language choice — not to send a non-technical user to a terminal.
+The exception is a genuine human-review gate on **AI-drafted** grades (grader_push
+HG-5), where the instructor's terminal confirmation is the point; there, do the
+review together in chat and hand off only that final confirmation.
+
 Project-specific rules (detail: [`lib/agents/knowledge/working_style_canvas_toolbox.md`](lib/agents/knowledge/working_style_canvas_toolbox.md)):
 local files are the source of truth (Canvas is the sync target); ground pedagogical
 work in the knowledge base; match Canvas objects by title, not ID; keep institutional

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.2] — 2026-07-28
+
+**`grader_standing` no longer dead-ends non-technical faculty at a terminal — it guides the agent to `--yes`.**
+
+Field report: an agent computed a "your grade" standing push (17 students, previewed and correct), the instructor said "push" in chat three times, and the agent kept telling them to *open a terminal and type push* — a total dead end for non-technical faculty. The cause: grader_standing borrowed grader_push's TTY-only confirmation message, even though **`--yes` is allowed for grader_standing** (it's value-only, instructor-computed — not AI-drafted feedback, so it's on the safe side of HG-5).
+
+Fix: on a non-interactive run without `--yes`, grader_standing now tells the agent to **re-run with `--yes` once the instructor confirms the preview** — explicitly "do NOT send them to a terminal." The instructor reviewing the `old → new` preview in chat *is* the attestation; `--yes` captures it. The `grading` skill and the constitution now carry the rule: **audience = non-technical faculty; complete actions for them, never hand them a terminal command** — the one exception being the genuine human-review gate on AI-drafted grades (grader_push HG-5).
+
+To post the field case immediately: add `--yes` to the command.
+
+---
+
 ## [1.8.1] — 2026-07-28
 
 **`cb_update --pull` and phrase-routing — "update cb" now maps to one command, not an improvised `git pull` in the wrong repo.**

--- a/lib/tests/test_grader_standing.py
+++ b/lib/tests/test_grader_standing.py
@@ -16,7 +16,26 @@ from grader_standing import (  # noqa: E402
     _pick_column,
     load_standing_rows,
     plan_writes,
+    standing_push_decision,
 )
+
+
+# --- standing_push_decision: --yes is the sanctioned path (value-only), and a
+# non-interactive agent run must be guided to it, NOT dead-ended at a terminal ----
+
+def test_standing_push_decision_yes_always_skips():
+    assert standing_push_decision(yes=True, is_tty=False) == "skip"
+    assert standing_push_decision(yes=True, is_tty=True) == "skip"
+
+
+def test_standing_push_decision_interactive_prompts():
+    assert standing_push_decision(yes=False, is_tty=True) == "prompt"
+
+
+def test_standing_push_decision_agent_run_guided_to_yes_not_terminal():
+    """The bug: an agent hit the non-TTY prompt and told non-technical faculty to
+    open a terminal. It must instead be guided to --yes (allowed for value-only)."""
+    assert standing_push_decision(yes=False, is_tty=False) == "needs-yes"
 
 
 # --- _pick_column: auto-detect, override, case-insensitivity ---------------

--- a/lib/tools/grader_standing.py
+++ b/lib/tools/grader_standing.py
@@ -81,8 +81,25 @@ from grader_push import (
     fetch_submissions,
     assignment_posts_manually,
     post_assignment_grades,
-    require_typed_confirmation,
 )
+
+
+def standing_push_decision(yes: bool, is_tty: bool) -> str:
+    """How to gate a value-only standing push:
+      'skip'      — --yes given. ALLOWED here: standing is instructor-computed,
+                    value-only (the 'your grade' column), NOT AI-drafted feedback,
+                    so there's no AI judgment for a human to review — the safe side
+                    of HG-5. --yes captures the instructor's consent to the preview.
+      'prompt'    — interactive terminal: ask the human to type 'push'.
+      'needs-yes' — non-interactive AND no --yes: an agent can't type at a prompt,
+                    and our audience (non-technical faculty) won't open a terminal.
+                    Guide the agent to re-run with --yes once the instructor has
+                    reviewed the preview and consents — do NOT send anyone to a
+                    terminal to copy-paste.
+    """
+    if yes:
+        return "skip"
+    return "prompt" if is_tty else "needs-yes"
 
 _TIMEOUT = 30
 _KEY_COLS = ("user_id", "canvas_user_id", "id", "sis_user_id", "sis_id",
@@ -233,7 +250,10 @@ def main() -> int:
                     help="proceed despite big-drop warnings (out-of-bounds still aborts)")
     ap.add_argument("--push", action="store_true", help="actually write (else dry-run)")
     ap.add_argument("--yes", action="store_true",
-                    help="skip the typed confirmation — for automated weekly runs")
+                    help="post without the interactive prompt. Allowed here (standing "
+                         "is value-only, instructor-computed — not AI-drafted): use for "
+                         "automated runs OR once the instructor has reviewed the "
+                         "preview and consents. NO terminal needed.")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="bypass canvas_course_guard for your own enrolled course")
     ap.add_argument("--post", action="store_true",
@@ -308,9 +328,23 @@ def main() -> int:
     if guard_enforce:
         guard_enforce(base, headers, cid, mode="write", allow_override=args.allow_enrolled)
 
-    if not args.yes:
+    decision = standing_push_decision(args.yes, sys.stdin.isatty())
+    if decision == "needs-yes":
+        print(f"\nThis would write {len(writes)} standing grade(s) to the LIVE course {cid}.")
+        print(
+            "\nⓘ Non-interactive run. grader_standing posts INSTRUCTOR-computed, "
+            "value-only grades (the 'your grade' column) — not AI-drafted feedback — "
+            "so --yes IS allowed here (unlike grader_push). If the instructor has "
+            "reviewed the preview above and consents, re-run with --yes to post. Do "
+            "NOT send them to a terminal to type 'push' — our audience is non-technical "
+            "faculty; complete the post for them once they confirm.",
+            file=sys.stderr,
+        )
+        print("Aborted — re-run with --yes once the instructor confirms the preview.")
+        return 1
+    if decision == "prompt":
         print(f"\nThis writes {len(writes)} standing grade(s) to the LIVE course {cid}.")
-        if not require_typed_confirmation("Type 'push' to confirm: ", "push"):
+        if input("Type 'push' to confirm: ").strip().lower() != "push":
             print("Aborted.")
             return 1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.1"
+version = "1.8.2"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.0"
+version = "1.8.2"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The bug (field report)

An agent computed a "your grade" standing push (17 students, previewed + correct). The instructor said **"push"** in chat three times. The agent kept replying *"open your terminal, cd, run this command, and type push"* — a **dead end for non-technical faculty**.

## Root cause

grader_standing borrowed grader_push's TTY-only confirmation — but **`--yes` is *allowed* for grader_standing.** Standing is value-only and instructor-computed (the "your grade" column), *not* AI-drafted feedback, so there's no AI judgment for a human to review — it's the safe side of HG-5. The agent should have just used `--yes`; the tool's message sent it to a terminal instead.

## Fix

On a non-interactive run without `--yes`, grader_standing now returns **`needs-yes`** and tells the agent: *re-run with `--yes` once the instructor confirms the preview — do NOT send them to a terminal.* The instructor reviewing the `old → new` preview in chat **is** the attestation; `--yes` captures it. (The agent still never generates the grades itself and `--yes`es them — values come from the instructor's script/CSV.)

New `standing_push_decision(yes, is_tty)` → `skip`/`prompt`/`needs-yes`, pure + tested.

## Broader rule (constitution + grading skill)

**Audience = non-technical faculty; complete actions *for* them, never hand a terminal command.** The one exception is the genuine human-review gate on **AI-drafted** grades (grader_push HG-5), where the terminal confirmation is the point.

## Immediate unblock

The field case posts right now by adding `--yes`:
```
grader_standing.py --csv .review_yourgrade.csv --assignment-id 16994751 --push --yes --allow-enrolled
```

## Tests
3 for `standing_push_decision` (yes→skip, tty→prompt, agent-run→needs-yes). Suite: 19 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)