### PR TITLE
fix(cb_update): refresh Windows copy-fallback skills; OS-agnostic tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.3] — 2026-07-28
+
+**Windows fix: `cb_update`'s copy-fallback skills now refresh on re-run instead of freezing stale.**
+
+On Windows without symlink permission, `cb_update` copies the skills into the course root (fallback). But a copy is a real directory, so the *next* run mistook it for a course-owned skill and skipped it — meaning Windows consumers' skills would freeze at first-copy and go stale after every `git pull`. Now a copy is marked (`.cb_managed`), so re-runs refresh it while still never touching a genuinely course-owned skill. Its tests were also made OS-agnostic (relpath separator; symlink-or-copy outcome) so they hold on Windows, not just posix — which is how the bug was found.
+
+---
+
 ## [1.8.2] — 2026-07-28
 
 **`grader_standing` no longer dead-ends non-technical faculty at a terminal — it guides the agent to `--yes`.**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -4,6 +4,7 @@ The field audit found the 6 operating-mode skills active in 0/9 consumer repos a
 stale pointer in 6/9. These pin the two fixes: install skills at the course root
 (non-clobbering) and refresh the pointer in place.
 """
+import os
 import sys
 from pathlib import Path
 
@@ -32,28 +33,61 @@ def test_plan_targets_are_relative_and_point_into_the_toolkit():
     plan = plan_skill_symlinks(Path("/course"), "canvas-toolbox", ["grading"])
     link, rel = plan[0]
     assert link == Path("/course/.claude/skills/grading")
-    # from <course>/.claude/skills/ up to <course>/ then into the toolkit
-    assert rel == "../../canvas-toolbox/.claude/skills/grading"
+    # from <course>/.claude/skills/ up to <course>/ then into the toolkit.
+    # Normalize the separator so this holds on Windows (relpath yields '\\').
+    assert rel.replace(os.sep, "/") == "../../canvas-toolbox/.claude/skills/grading"
 
 
 def test_install_dry_run_writes_nothing(tmp_path):
     course = _fake_course(tmp_path)
     plan = plan_skill_symlinks(course, "canvas-toolbox", ["grading"])
     res = install_skill_symlinks(plan, apply=False)
-    assert res == [("grading", "would-link")]
+    assert res == [("grading", "would-install")]
     assert not (course / ".claude" / "skills" / "grading").exists()
 
 
-def test_install_creates_symlink_that_resolves_to_the_toolkit_skill(tmp_path):
+def test_windows_copy_fallback_is_marked_and_refreshed(tmp_path, monkeypatch):
+    """No-symlink environment (Windows w/o dev mode): fall back to a COPY, mark it
+    ours, and REFRESH it on re-run — the bug was a re-run mistaking the copy for a
+    course-owned skill and freezing it stale after every git pull."""
     course = _fake_course(tmp_path)
     plan = plan_skill_symlinks(course, "canvas-toolbox", ["grading"])
-    res = install_skill_symlinks(plan, apply=True)
-    assert res == [("grading", "linked")]
+    monkeypatch.setattr(Path, "symlink_to",
+                        lambda self, target: (_ for _ in ()).throw(OSError("no symlink")))
+    assert install_skill_symlinks(plan, apply=True) == [("grading", "copied")]
     link = course / ".claude" / "skills" / "grading"
-    assert link.is_symlink()
+    assert link.is_dir() and not link.is_symlink()
+    assert (link / "SKILL.md").exists()          # copied content present
+    assert (link / ".cb_managed").is_file()       # marked as ours
+    # re-run REFRESHES the copy (does NOT skip it as course-owned)
+    assert install_skill_symlinks(plan, apply=True) == [("grading", "copied")]
+
+
+def test_course_owned_dir_without_marker_is_never_touched(tmp_path, monkeypatch):
+    """A real skill dir the course made (no marker) is left alone even in the
+    no-symlink path — we only refresh copies WE made."""
+    course = _fake_course(tmp_path)
+    owned = course / ".claude" / "skills" / "grading"
+    owned.mkdir(parents=True)
+    (owned / "SKILL.md").write_text("course's own\n", encoding="utf-8")  # no .cb_managed
+    monkeypatch.setattr(Path, "symlink_to",
+                        lambda self, target: (_ for _ in ()).throw(OSError("no symlink")))
+    plan = plan_skill_symlinks(course, "canvas-toolbox", ["grading"])
+    assert install_skill_symlinks(plan, apply=True) == [("grading", "skip-course-owns")]
+    assert (owned / "SKILL.md").read_text(encoding="utf-8") == "course's own\n"
+
+
+def test_install_makes_the_skill_resolvable_and_stable(tmp_path):
+    """OS-agnostic guarantee: after install the skill is readable at the course root
+    (symlink where supported, copy on Windows), and a re-run is stable."""
+    course = _fake_course(tmp_path)
+    plan = plan_skill_symlinks(course, "canvas-toolbox", ["grading"])
+    status = install_skill_symlinks(plan, apply=True)[0][1]
+    assert status in ("linked", "copied")     # symlink on posix, copy fallback on Windows
+    link = course / ".claude" / "skills" / "grading"
     assert (link / "SKILL.md").read_text(encoding="utf-8").startswith("---")  # resolves
-    # re-run is idempotent
-    assert install_skill_symlinks(plan, apply=True) == [("grading", "present")]
+    # re-run is stable: a correct symlink → 'present'; a copy → refreshed
+    assert install_skill_symlinks(plan, apply=True)[0][1] in ("present", "copied")
 
 
 def test_install_never_clobbers_a_course_owned_skill(tmp_path):

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -63,36 +63,48 @@ def plan_skill_symlinks(course_root: Path, toolkit_subdir: str,
     return out
 
 
+_MARKER = ".cb_managed"  # dropped in a Windows copy so re-runs know it's ours to refresh
+
+
+def _managed_copy(link: Path) -> bool:
+    """True if `link` is a real dir we previously copied (Windows symlink fallback) —
+    so a re-run REFRESHES it instead of mistaking it for a course-owned skill."""
+    return link.is_dir() and not link.is_symlink() and (link / _MARKER).is_file()
+
+
 def install_skill_symlinks(plan: list[tuple[Path, str]], apply: bool) -> list[tuple[str, str]]:
-    """Create/refresh each skill symlink. Never clobbers a course-owned real dir.
-    Returns [(skill, status)] where status ∈ present/would-link/linked/copied/
-    skip-course-owns."""
+    """Create/refresh each skill link. Never clobbers a course-OWNED real dir (one
+    without our marker). Returns [(skill, status)] where status ∈ present/
+    would-install/linked/copied/skip-course-owns/missing-target."""
     results = []
     for link, rel in plan:
         name = link.name
-        if link.is_symlink():
-            if os.readlink(link) == rel:
-                results.append((name, "present"))
-                continue          # already correct
-        elif link.exists():
-            results.append((name, "skip-course-owns"))  # a real dir/file — don't touch
+        if link.is_symlink() and os.readlink(link) == rel:
+            results.append((name, "present"))
+            continue                                   # correct symlink — done
+        if link.exists() and not link.is_symlink() and not _managed_copy(link):
+            results.append((name, "skip-course-owns"))  # real dir, no marker — theirs
             continue
+        # absent, a stale/wrong symlink, or OUR prior copy → (re)install
         if not apply:
-            results.append((name, "would-link"))
+            results.append((name, "would-install"))
             continue
         link.parent.mkdir(parents=True, exist_ok=True)
+        if link.is_symlink() or (link.exists() and not link.is_dir()):
+            link.unlink()
+        elif link.is_dir():
+            shutil.rmtree(link, ignore_errors=True)   # our stale copy
         try:
-            if link.is_symlink() or link.exists():
-                link.unlink()
             link.symlink_to(rel)
             results.append((name, "linked"))
         except OSError:
-            # Windows / no-symlink-permission fallback: copy the skill dir.
+            # Windows / no-symlink-permission fallback: copy + mark it ours.
             target = (link.parent / rel).resolve()
-            if link.exists():
-                shutil.rmtree(link, ignore_errors=True)
             if target.is_dir():
                 shutil.copytree(target, link)
+                (link / _MARKER).write_text(
+                    "Managed by cb_update (Windows copy fallback); refreshed on re-run.\n",
+                    encoding="utf-8")
                 results.append((name, "copied"))
             else:
                 results.append((name, "missing-target"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.2"
+version = "1.8.3"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## The Windows bug (found by looking at my own code through a Windows lens)

On Windows without symlink permission, `cb_update` **copies** the skills into the course root (fallback). But a copy is a *real directory* — so on the next run the old logic saw it, thought *"the course owns this,"* and **skipped it**. Result: Windows consumers' skills would freeze at first-copy and go **stale after every `git pull`**, silently.

## Fix

Mark our copies with a `.cb_managed` sentinel. A re-run **refreshes** a marked copy, while still **never touching** a genuinely course-owned skill (no marker). Symlink path unchanged (posix).

## The tests were Windows-fragile too — now fixed

Two of my own cb_update tests wouldn't have held on Windows:
- the relpath assertion used `/`, but `os.path.relpath` yields `\` on Windows → now separator-normalized;
- the symlink test assumed symlinks work → now accepts **linked-or-copied** and verifies the skill *resolves* either way.

Plus a **forced-copy-path test** (monkeypatch `symlink_to` to raise) that exercises the Windows branch on any OS — copy → marked → refreshed on re-run → course-owned dirs still untouched.

## Note

This is exactly the case for Windows CI: the freeze bug + two fragile tests were invisible from a Mac. Recommend adding `windows-latest` to the CI matrix as a follow-up (see PR discussion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)