### PR TITLE
feat(grader_letter_comments): sanctioned End-Letter comment push (retire fix_push.py)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -122,6 +122,22 @@ grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-
   `.review.csv`, `submissions_raw/`, `feedback/_grader*.csv`) are **never** read or
   displayed. Verify with `wc -l` / `ls`, never `cat`/`head`/`grep`.
 
+## Final-letter grading — split the write, two sanctioned tools
+
+A "final letter" workflow has two Canvas writes; do NOT hand-write a `fix_push.py`
+(the `grade_guardian` hook blocks it, correctly). Keep your course-specific
+computation (the tier/stretch logic in `calc_final_grades.py`), and route both writes:
+
+1. **The grade** (Course Grade column, value-only) → `grader_standing.py` — emit a
+   `user_id,final_grade` CSV, then `--push --yes` (instructor-computed, value-only).
+2. **The comment** (End Letter, comment-only, preserves the existing grade) →
+   `grader_letter_comments.py` — a `user_id,comment` CSV → comment-only writes, no
+   grade change. `--yes` allowed because these are the **instructor's own** notes.
+
+**AI-drafted per-student feedback is NOT a final-letter comment** — that goes through
+`grader_push` (the HG-5 review gate). `grader_letter_comments` is for instructor-
+authored notes only.
+
 ## Known case: an auto-scored quiz stuck in "To Do"
 
 A classic quiz with an essay/file-upload question auto-scores on submission

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.4] — 2026-07-28
+
+**New `grader_letter_comments.py` — the sanctioned End-Letter comment push, so final-letter grading no longer needs a hand-written `fix_push.py`.**
+
+When `grade_guardian` (correctly) blocked a course's `fix_push.py`, the missing piece was exposed: final-letter grading has two writes — the grade (Course Grade, value-only → already covered by `grader_standing`) and a **comment-only** note (End Letter, preserving the existing grade) — and the toolkit had no sanctioned tool for the second. This is it: a roster CSV (`user_id,comment`) → `comment[text_comment]` writes, **never** a `posted_grade`, so a grade is never touched.
+
+The HG-5 line is drawn explicitly: this tool is for **instructor-authored** comments (a final-grade note from the course's script/template), which is why `--yes` is allowed like `grader_standing` — the instructor reviews the previews and consents, no terminal for non-technical faculty. **AI-drafted per-student feedback does not belong here** — it goes through `grader_push` and its review gate. Guards: Test-Student exclusion (#61), hard-fail on unmatched/ambiguous key (never comment on the wrong student), blank-comment skip, dry-run by default. The `grading` skill and reuse doctrine now document the two-tool split so agents retire `fix_push.py` instead of trying to whitelist it.
+
+---
+
 ## [1.8.3] — 2026-07-28
 
 **Windows fix: `cb_update`'s copy-fallback skills now refresh on re-run instead of freezing stale.**

--- a/lib/agents/knowledge/toolkit_reuse_knowledge.md
+++ b/lib/agents/knowledge/toolkit_reuse_knowledge.md
@@ -59,6 +59,7 @@ then retire the local copy and repoint your AGENTS.md at the vendored path.
 |---|---|
 | `grading/push_grades.py` | `grader_push.py` |
 | `grading/push_your_grade.py`, `grading/update_standing.py` (writes a "your grade" column) | `grader_standing.py` — computes nothing; pushes your script's values, dry-run by default |
+| `grading/final_letter/fix_push.py`, `push_final_grades.py` (final-letter grade + End-Letter comment) | **split the write:** `grader_standing.py` for the value (Course Grade) + `grader_letter_comments.py` for the instructor comment (End Letter). Keep `calc_final_grades.py` (course-specific computation); retire the direct writer. |
 | `grading/checks.py` | `grader_signals.py` |
 | `grading/consensus.py` | `grader_consensus.py` |
 | `grading/reidentify.py` | `grader_reidentify.py` |

--- a/lib/tests/test_grader_letter_comments.py
+++ b/lib/tests/test_grader_letter_comments.py
@@ -1,0 +1,48 @@
+"""Unit tests — grader_letter_comments (sanctioned End-Letter comment-only push).
+
+The safety-critical logic: never comment on the wrong (or no) student, never post an
+empty comment, never touch a grade. These pin the resolution + row loading.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grader_letter_comments import load_comment_rows, plan_comments  # noqa: E402
+
+INDEX = {"1001": 1001, "1002": 1002, "dup": None}
+
+
+def test_load_reads_key_and_comment_skips_blank_comment(tmp_path):
+    p = tmp_path / "c.csv"
+    p.write_text("user_id,comment\n1001,Final grade B+. Nice work.\n1002,\n",
+                 encoding="utf-8")
+    rows, key_col, com_col = load_comment_rows(str(p), None, None)
+    assert key_col == "user_id" and com_col == "comment"
+    assert rows == [("1001", "Final grade B+. Nice work.")]  # blank-comment row dropped
+
+
+def test_plan_resolves_and_hard_fails_on_unmatched():
+    plan, problems = plan_comments([("9999", "x")], INDEX)
+    assert plan == [] and problems and "no enrolled student" in problems[0]
+
+
+def test_plan_hard_fails_on_ambiguous_key():
+    plan, problems = plan_comments([("dup", "x")], INDEX)
+    assert plan == [] and "more than one" in problems[0]
+
+
+def test_plan_resolves_valid_rows():
+    plan, problems = plan_comments([("1001", "hi"), ("1002", "yo")], INDEX)
+    assert problems == []
+    assert [(p["uid"], p["comment"]) for p in plan] == [(1001, "hi"), (1002, "yo")]
+
+
+def test_missing_comment_column_is_fatal(tmp_path):
+    import pytest
+    p = tmp_path / "c.csv"
+    p.write_text("user_id,grade\n1001,B\n", encoding="utf-8")
+    with pytest.raises(SystemExit):
+        load_comment_rows(str(p), None, None)

--- a/lib/tools/grader_letter_comments.py
+++ b/lib/tools/grader_letter_comments.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""grader_letter_comments.py — push INSTRUCTOR-authored, comment-only notes to a
+specific Canvas assignment, roster-keyed (the "End Letter" / final-grade-comment step).
+
+WHY THIS EXISTS
+  Final-letter grading has two writes: the GRADE (a value → the Course Grade column —
+  handled by grader_standing) and a COMMENT-ONLY note → an "End Letter" assignment,
+  preserving whatever grade is already there (e.g. a TA's complete/incomplete).
+  Courses hand-wrote a fix_push.py for the comment step; grade_guardian correctly
+  blocks that. This is the sanctioned replacement — a roster CSV (key, comment) →
+  `comment[text_comment]` writes, with NO grade change.
+
+SCOPE — INSTRUCTOR-AUTHORED comments only (the HG-5 line)
+  The comments here are the instructor's own — a final-grade explanation from their
+  script/template — NOT AI-drafted per-student feedback. That's why `--yes` is allowed
+  (like grader_standing): the instructor reviews the previews and consents, no terminal
+  for non-technical faculty. **AI-drafted feedback does NOT belong here** — it goes
+  through grader_push.py, which enforces the HG-5 review gate (#207). Using this tool
+  to push AI-written comments would be a false disclosure and an HG-5 breach.
+
+GUARDS
+  - Comment-ONLY write (never sends posted_grade) → a grade is never changed.
+  - Test Student excluded (#61); unmatched/ambiguous key hard-fails (never comment on
+    the wrong student); dry-run by default; --push to write; --allow-enrolled for your
+    own course (canvas_course_guard).
+  - Prints each comment preview so the instructor reviews the actual TEXT before --yes.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+
+try:
+    from _env_loader import force_utf8_console, load_env
+    load_env()
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+import requests
+
+try:
+    from __toolbox_version__ import __version__
+except ImportError:
+    __version__ = "0.0.0+unknown"
+
+try:
+    from canvas_course_guard import enforce as guard_enforce
+except ImportError:
+    guard_enforce = None
+
+# Reuse the sibling standing tool's env, roster resolution, column picker, and the
+# --yes/TTY decision — one source of truth for the parts that must not drift.
+from grader_standing import (
+    _env_canvas,
+    fetch_roster_index,
+    _pick_column,
+    standing_push_decision,
+)
+
+_TIMEOUT = 30
+_KEY_COLS = ("user_id", "canvas_user_id", "id", "sis_user_id", "sis_id",
+             "login_id", "login", "student_id", "email")
+_COMMENT_COLS = ("comment", "text", "note", "end_letter", "feedback", "message")
+
+
+def load_comment_rows(path, key_override, comment_override):
+    """Read (raw_key, comment) pairs. Fails loudly if either column is missing."""
+    with open(path, newline="", encoding="utf-8-sig") as fh:
+        reader = csv.DictReader(fh)
+        key_col = _pick_column(reader.fieldnames, _KEY_COLS, key_override)
+        com_col = _pick_column(reader.fieldnames, _COMMENT_COLS, comment_override)
+        if not key_col:
+            raise SystemExit(f"⛔ no key column. Have {reader.fieldnames}; expected one "
+                             f"of {_KEY_COLS} or pass --key-column.")
+        if not com_col:
+            raise SystemExit(f"⛔ no comment column. Have {reader.fieldnames}; expected "
+                             f"one of {_COMMENT_COLS} or pass --comment-column.")
+        rows = []
+        for line in reader:
+            key = (line.get(key_col) or "").strip()
+            comment = (line.get(com_col) or "").strip()
+            if key and comment:            # skip blank-comment rows — never post empty
+                rows.append((key, comment))
+    return rows, key_col, com_col
+
+
+def plan_comments(rows, index):
+    """Resolve each row to a user_id. Returns (plan, problems). Hard-fails on any
+    unmatched/ambiguous key — never comment on the wrong (or no) student."""
+    plan, problems = [], []
+    for raw_key, comment in rows:
+        k = raw_key.lower()
+        if k not in index:
+            problems.append(f"key {raw_key!r} matches no enrolled student")
+            continue
+        uid = index[k]
+        if uid is None:
+            problems.append(f"key {raw_key!r} matches more than one student")
+            continue
+        plan.append({"uid": uid, "comment": comment})
+    return plan, problems
+
+
+def main() -> int:
+    force_utf8_console()
+    ap = argparse.ArgumentParser(
+        description="Push instructor-authored comment-only notes to an assignment "
+                    "(no grade change). For AI-drafted feedback use grader_push.")
+    ap.add_argument("--csv", required=True, help="roster CSV: a key column + a comment column")
+    ap.add_argument("--assignment-id", required=True, help="the assignment to comment on")
+    ap.add_argument("--course-id", default=None, help="defaults to $CANVAS_COURSE_ID")
+    ap.add_argument("--key-column", default=None)
+    ap.add_argument("--comment-column", default=None)
+    ap.add_argument("--push", action="store_true", help="actually write (else dry-run)")
+    ap.add_argument("--yes", action="store_true",
+                    help="post without the interactive prompt. Allowed here (comments "
+                         "are instructor-authored, not AI-drafted): use once the "
+                         "instructor has reviewed the previews and consents. NO terminal.")
+    ap.add_argument("--allow-enrolled", action="store_true",
+                    help="bypass canvas_course_guard for your own enrolled course")
+    ap.add_argument("--version", action="version", version=f"canvas-toolbox {__version__}")
+    args = ap.parse_args()
+
+    tok, env_cid, base = _env_canvas()
+    cid = args.course_id or env_cid
+    if not (tok and base and cid):
+        print("⛔ set CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID (or --course-id).",
+              file=sys.stderr)
+        return 1
+    headers = {"Authorization": f"Bearer {tok}"}
+    aid = args.assignment_id
+
+    print("ⓘ This posts INSTRUCTOR-authored comments (no grade change). AI-drafted "
+          "feedback must go through grader_push.py (HG-5 review gate) — not here.\n")
+
+    rows, key_col, com_col = load_comment_rows(args.csv, args.key_column, args.comment_column)
+    index, active = fetch_roster_index(base, cid, headers)
+    plan, problems = plan_comments(rows, index)
+
+    for p in plan:
+        preview = p["comment"].replace("\n", " ")[:70]
+        tag = "  [inactive]" if p["uid"] not in active else ""
+        print(f"  user {p['uid']}: \"{preview}…\"{tag}")
+    for m in problems:
+        print(f"  ⛔ {m}", file=sys.stderr)
+
+    print(f"\n{len(plan)} comment(s) to post, {len(problems)} unmatched.")
+    if problems:
+        print("⛔ Unmatched keys — nothing written. Fix the CSV/roster and re-run.",
+              file=sys.stderr)
+        return 1
+    if not args.push:
+        print("\nDry run — nothing written. Add --push to post.")
+        return 0
+    if not plan:
+        print("Nothing to post.")
+        return 0
+
+    decision = standing_push_decision(args.yes, sys.stdin.isatty())
+    if decision == "needs-yes":
+        print(f"\nThis would post {len(plan)} instructor comment(s) to the LIVE course {cid}.")
+        print(
+            "\nⓘ Non-interactive run. These are INSTRUCTOR-authored comments (not "
+            "AI-drafted), so --yes IS allowed. If the instructor has reviewed the "
+            "previews above and consents, re-run with --yes. Do NOT send them to a "
+            "terminal — our audience is non-technical faculty.",
+            file=sys.stderr,
+        )
+        print("Aborted — re-run with --yes once the instructor confirms the comments.")
+        return 1
+
+    if guard_enforce:
+        guard_enforce(base, headers, cid, mode="write", allow_override=args.allow_enrolled)
+
+    if decision == "prompt":
+        print(f"\nThis posts {len(plan)} instructor comment(s) to the LIVE course {cid}.")
+        if input("Type 'push' to confirm: ").strip().lower() != "push":
+            print("Aborted.")
+            return 1
+
+    posted, failed = 0, 0
+    for p in plan:
+        resp = requests.put(
+            f"{base}/api/v1/courses/{cid}/assignments/{aid}/submissions/{p['uid']}",
+            headers=headers, data={"comment[text_comment]": p["comment"]}, timeout=_TIMEOUT)
+        if resp.status_code < 400:
+            print(f"  commented user {p['uid']}")
+            posted += 1
+        else:
+            print(f"  ⛔ user {p['uid']}: HTTP {resp.status_code} {resp.text[:120]}",
+                  file=sys.stderr)
+            failed += 1
+    print(f"\nPosted {posted} comment(s), failed {failed}. Grades unchanged.")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.3"
+version = "1.8.4"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.2"
+version = "1.8.3"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What & why

When `grade_guardian` (correctly) blocked a course's hand-written `fix_push.py`, it exposed the real gap: **final-letter grading has two writes**, and the toolkit only had a sanctioned tool for one.

| Write | Sanctioned tool |
|---|---|
| The grade (Course Grade, value-only) | `grader_standing.py` (already existed) |
| The **comment** (End Letter, comment-only, preserves the grade) | **`grader_letter_comments.py`** (this PR) |

So the answer to *"whitelist fix_push.py or bypass the hook?"* is **neither** — it's to give the comment step a real home. Roster CSV (`user_id,comment`) → `comment[text_comment]` writes, **never** a `posted_grade`, so a grade is never touched.

## The HG-5 line (drawn explicitly)

This tool is for **instructor-authored** comments — a final-grade note from the course's script/template. That's why `--yes` is allowed (like `grader_standing`): the instructor reviews the previews and consents in chat, **no terminal for non-technical faculty**. **AI-drafted per-student feedback does NOT belong here** — it goes through `grader_push` and its review gate. The docstring, `grading` skill, and reuse doctrine all state this boundary.

## Guards

- Comment-only (never sends `posted_grade`).
- Hard-fail on unmatched/ambiguous key (never comment on the wrong student).
- Test-Student exclusion (#61), blank-comment skip, dry-run by default, `canvas_course_guard`.

## Retiring the bypass

The `grading` skill + migration map now document the split: keep `calc_final_grades.py` (course-specific computation), route the grade → `grader_standing`, the comment → `grader_letter_comments`, and **delete `fix_push.py`**.

## Tests
5: key/comment column detection, blank-comment skip, hard-fail on unmatched + ambiguous keys, valid resolution, missing-column fatal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)