### PR TITLE
feat(grader_reidentify): shift-left grading_type validation at .review.csv creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.5] — 2026-07-28
+
+**Shift-left: catch an illegal grade at `.review.csv` creation, not at push (field-proposed).**
+
+`grader_push` validates a score against the assignment's `grading_type` (#99) — so `incomplete` on a `points` assignment is correctly refused. But that check only fired at *push* time; the bad value sailed all the way into `.review.csv` first, making it unclear where it came from. A course agent proposed catching it earlier, in `grader_reidentify`. The instinct was right; the placement needed care, because `grader_reidentify` is a pure *offline* join and can't call Canvas for the grading_type.
+
+The fix respects that: `grader_fetch` now caches the assignment's grading rules to `.assignment_meta.json` (grading_type, points_possible, name — **no student data, so Zone-1**), and `grader_reidentify` validates each summary score against it **offline**, erroring early with a clear per-key message (`KC1-A: 'incomplete' — not a legal grade for grading_type=points`) before writing `.review.csv`. It reuses grader_push's `validate_grade_for_grading_type` so the two tools never disagree, and it no-ops safely when the cache is absent (push stays the backstop).
+
+---
+
 ## [1.8.4] — 2026-07-28
 
 **New `grader_letter_comments.py` — the sanctioned End-Letter comment push, so final-letter grading no longer needs a hand-written `fix_push.py`.**

--- a/lib/tests/test_grader_reidentify_helpers.py
+++ b/lib/tests/test_grader_reidentify_helpers.py
@@ -20,7 +20,39 @@ from grader_reidentify import (  # noqa: E402
     build_user_to_keys,
     pick_group_representatives_from_context,
     mirror_group_rows,
+    validate_summary_scores,
 )
+
+
+# ---------------------------------------------------------------------------
+# validate_summary_scores — shift-left grading_type validation (catch 'incomplete'
+# on a points assignment at .review.csv creation, not at push)
+# ---------------------------------------------------------------------------
+
+def test_flags_incomplete_on_a_points_assignment():
+    scores = {"KC1-A": {"score": "incomplete"}, "KC1-B": {"score": "4"}}
+    bad = validate_summary_scores(scores, "points")
+    assert [b[0] for b in bad] == ["KC1-A"]          # only the illegal one
+    assert bad[0][1] == "incomplete"
+
+
+def test_complete_incomplete_ok_on_pass_fail():
+    scores = {"A": {"score": "complete"}, "B": {"score": "incomplete"}}
+    assert validate_summary_scores(scores, "pass_fail") == []
+
+
+def test_numeric_ok_on_points():
+    assert validate_summary_scores({"A": {"score": "3.5"}}, "points") == []
+
+
+def test_empty_and_absent_scores_are_skipped():
+    scores = {"A": {"score": ""}, "B": {"score": "   "}, "C": {}}
+    assert validate_summary_scores(scores, "points") == []
+
+
+def test_no_grading_type_means_no_validation():
+    # grader_fetch didn't cache the rules → don't guess, let push be the backstop
+    assert validate_summary_scores({"A": {"score": "incomplete"}}, None) == []
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grader_fetch.py
+++ b/lib/tools/grader_fetch.py
@@ -1287,6 +1287,20 @@ def main() -> int:
               "token scope.", file=sys.stderr)
         return 2
 
+    # Cache the assignment's grading rules (grading_type, points_possible, name) —
+    # NO student data, so Zone-1. Lets offline tools (grader_reidentify) validate
+    # scores against grading_type without a Canvas call: catch 'incomplete' on a
+    # `points` assignment at .review.csv creation, not at push (issue #99, shift-left).
+    try:
+        (cd / ".assignment_meta.json").write_text(json.dumps({
+            "assignment_id": str(args.assignment_id),
+            "grading_type": asg_meta.get("grading_type"),
+            "points_possible": asg_meta.get("points_possible"),
+            "name": asg_meta.get("name"),
+        }, indent=2), encoding="utf-8")
+    except OSError:
+        pass
+
     # Issue #102: capture the student-facing task definition as the
     # rubric-authoritative spec. The Canvas description is often just a
     # pointer to a course-site page where the real spec lives — follow the

--- a/lib/tools/grader_reidentify.py
+++ b/lib/tools/grader_reidentify.py
@@ -55,6 +55,30 @@ try:
 except ImportError:
     __version__ = "0.0.0+unknown"
 
+try:
+    # Reuse grader_push's validator so the two tools never disagree on what's legal.
+    from grader_push import validate_grade_for_grading_type
+except ImportError:
+    validate_grade_for_grading_type = None
+
+
+def validate_summary_scores(scores: dict, grading_type) -> list:
+    """Return [(key, score, reason)] for summary scores that are INVALID for the
+    assignment's grading_type — the shift-left catch. Sentinels (held/blank/
+    parenthesized note) and an unknown/absent grading_type pass; this only flags a
+    genuinely-illegal value, e.g. 'incomplete' on a `points` assignment."""
+    if not validate_grade_for_grading_type or not grading_type:
+        return []
+    bad = []
+    for key, row in scores.items():
+        score = (row.get("score") or "").strip()
+        if not score:
+            continue
+        status, text = validate_grade_for_grading_type(score, grading_type)
+        if status == "invalid":
+            bad.append((key, score, text))
+    return bad
+
 
 # Issue #100: filename → user_id parser. Matches the same shape that
 # grader_fetch writes to submissions_raw/: <prefix>_<uid>(_<suffix>)?.<ext>.
@@ -209,6 +233,24 @@ def main() -> int:
     with summary.open(encoding="utf-8") as fh:
         for row in csv.DictReader(fh):
             scores[row.get("key", "")] = row
+
+    # Shift-left validation: a score illegal for the grading_type (e.g. 'incomplete'
+    # on a `points` assignment) used to sail into .review.csv and only fail at push.
+    # If grader_fetch cached the grading rules (.assignment_meta.json — Zone-1, no
+    # names), catch it HERE — before the review sheet is written.
+    meta_path = base / ".assignment_meta.json"
+    if meta_path.exists():
+        try:
+            gt = json.loads(meta_path.read_text(encoding="utf-8")).get("grading_type")
+        except (OSError, ValueError):
+            gt = None
+        bad = validate_summary_scores(scores, gt)
+        if bad:
+            print(f"⛔ {len(bad)} score(s) invalid for grading_type={gt!r} — fix "
+                  f"{args.summary} before re-running (nothing written):", file=sys.stderr)
+            for key, score, reason in bad:
+                print(f"     {key}: {score!r} — {reason}", file=sys.stderr)
+            return 1
 
     fbdir = base / "feedback"
     rows = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.4"
+version = "1.8.5"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.3"
+version = "1.8.4"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Field-proposed, refined

A course agent hit this: `incomplete` on a `points` assignment got into `.review.csv`, then `grader_push` refused it at push (correct — #99). The agent proposed catching it earlier in `grader_reidentify`. **Right instinct**, but the placement needed care: `grader_reidentify` is a pure *offline* join (keymap + summary → review sheet) and can't call Canvas for the grading_type.

## The fix (respects the offline design)

1. **`grader_fetch`** already fetches the assignment object — it now **caches the grading rules** to `.assignment_meta.json` (`grading_type`, `points_possible`, `name`). **No student data → Zone-1**, safe to read.
2. **`grader_reidentify`** validates each summary score against that cache **offline**, and errors *before* writing `.review.csv`:
   ```
   ⛔ 1 score(s) invalid for grading_type='points' — fix feedback/_summary.csv (nothing written):
        KC1-A: 'incomplete' — not a legal grade for grading_type=points
   ```

Reuses grader_push's `validate_grade_for_grading_type` so the two tools **never disagree** on what's legal. No-ops safely when the cache is absent (offline / pre-1.8.5), so push stays the backstop.

## Why this is better than validating at push only

The error now points at the *source* (`feedback/_summary.csv`) at the moment it's introduced, instead of surfacing three steps later with no breadcrumb. Sentinels (held/blank) and unknown grading types still pass — it only flags a genuinely-illegal value.

## Tests
5 for `validate_summary_scores`: flags incomplete-on-points, allows complete/incomplete on pass_fail, allows numeric on points, skips empty/absent scores, no-ops on unknown grading_type. Suite: 20 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)