### PR TITLE
fix(course_engagement_audit): Link-header pagination — stop everyone reading 'never participated'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.6] — 2026-07-28
+
+**Fix: the engagement audit's per-student submission fetch made every student look "never participated."**
+
+`course_engagement_audit`'s submission + discussion fetches (in the Python fallback and the main file) still incremented `page` blindly — the same `Link: rel="next"` bug fixed for the *enrollment* fetch in 1.7.37, but missed here. `/students/submissions?student_ids[]` answers a page past the last with **HTTP 400**, so on a single-page result (any student with <100 submissions — i.e. essentially all of them) page 1 succeeded, page 2 400'd, the fetch crashed, and the student was recorded with **no engagement** → the whole report showed everyone as "never participated" despite having grades. Found in the field (and correctly diagnosed as *not* an API-key problem — page 1 and enrollments worked; only the blind page 2 failed).
+
+All three fetches now follow the `Link` header (discussion-topic 404s still skip gracefully). The Rust engagement binary should be checked for the same pattern if it's in use.
+
+---
+
 ## [1.8.5] — 2026-07-28
 
 **Shift-left: catch an illegal grade at `.review.csv` creation, not at push (field-proposed).**

--- a/lib/tools/_course_engagement_audit_python.py
+++ b/lib/tools/_course_engagement_audit_python.py
@@ -18,6 +18,7 @@ See docs/proposals/rust-high-priority-roadmap.md for details.
 """
 from __future__ import annotations
 
+import re
 import sys
 from typing import Any
 
@@ -32,75 +33,56 @@ except ImportError:
 _TIMEOUT = 30
 
 
+def _paged_get(base: str, headers: dict, path: str, params: dict,
+               tolerate_errors: bool = False) -> list:
+    """GET a Canvas collection, following the `Link: rel="next"` header instead of
+    blindly incrementing `page`. Several endpoints — including
+    `/students/submissions?student_ids[]` — return HTTP 400 (NOT an empty page) when
+    asked for a page past the last. Blind `page += 1` therefore hit page 2 on a
+    single-page result, got a 400, and crashed the fetch — so EVERY student looked
+    'never participated' even with grades (issue #67). `tolerate_errors` lets a
+    first-request 4xx return [] (some discussion topics 404)."""
+    out: list = []
+    url: str | None = f"{base}{path}"
+    p: dict | None = {**params, "per_page": 100}
+    while url:
+        r = requests.get(url, headers=headers,
+                         params=p if "?" not in url else None, timeout=_TIMEOUT)
+        if tolerate_errors and r.status_code >= 400:
+            break
+        r.raise_for_status()
+        out += r.json() or []
+        m = re.search(r'<([^>]+)>;\s*rel="next"', r.headers.get("Link", ""))
+        url = m.group(1) if m else None
+        p = None
+    return out
+
+
 def fetch_student_submissions(
     base: str, cid: str, headers: dict, user_id: int | str,
 ) -> list[dict]:
-    """All assignment + quiz submissions for one student."""
-    out: list[dict] = []
-    page = 1
-    while True:
-        r = requests.get(
-            f"{base}/api/v1/courses/{cid}/students/submissions",
-            headers=headers,
-            params={
-                "student_ids[]": str(user_id),
-                "per_page": 100,
-                "page": page,
-            },
-            timeout=_TIMEOUT,
-        )
-        r.raise_for_status()
-        batch = r.json() or []
-        if not batch:
-            break
-        out += batch
-        page += 1
-    return out
+    """All assignment + quiz submissions for one student (Link-paginated, #67)."""
+    return _paged_get(base, headers, f"/api/v1/courses/{cid}/students/submissions",
+                      {"student_ids[]": str(user_id)})
 
 
 def fetch_discussion_entries(
     base: str, cid: str, headers: dict, user_id: int | str,
 ) -> list[str]:
-    """ISO timestamps of all discussion entries by one student."""
-    timestamps: list[str] = []
-    # Get topic IDs
-    page = 1
-    topic_ids: list[str] = []
-    while True:
-        r = requests.get(
-            f"{base}/api/v1/courses/{cid}/discussion_topics",
-            headers=headers,
-            params={"per_page": 100, "page": page},
-            timeout=_TIMEOUT,
-        )
-        r.raise_for_status()
-        batch = r.json() or []
-        if not batch:
-            break
-        topic_ids += [str(t.get("id")) for t in batch if t.get("id")]
-        page += 1
+    """ISO timestamps of all discussion entries by one student (Link-paginated)."""
+    topics = _paged_get(base, headers, f"/api/v1/courses/{cid}/discussion_topics", {})
     uid_str = str(user_id)
-    for tid in topic_ids:
-        entry_page = 1
-        while True:
-            r = requests.get(
-                f"{base}/api/v1/courses/{cid}/discussion_topics/{tid}/entries",
-                headers=headers,
-                params={"per_page": 100, "page": entry_page},
-                timeout=_TIMEOUT,
-            )
-            if r.status_code >= 400:
-                break  # some topics return 404; skip silently
-            batch = r.json() or []
-            if not batch:
-                break
-            for entry in batch:
-                if str(entry.get("user_id")) == uid_str:
-                    for k in ("updated_at", "created_at"):
-                        v = entry.get(k)
-                        if v:
-                            timestamps.append(v)
-            entry_page += 1
+    timestamps: list[str] = []
+    for tid in (str(t.get("id")) for t in topics if t.get("id")):
+        entries = _paged_get(
+            base, headers, f"/api/v1/courses/{cid}/discussion_topics/{tid}/entries",
+            {}, tolerate_errors=True)  # some topics 404 — skip
+        for entry in entries:
+            if str(entry.get("user_id")) == uid_str:
+                for k in ("updated_at", "created_at"):
+                    v = entry.get(k)
+                    if v:
+                        timestamps.append(v)
     return timestamps
 
 

--- a/lib/tools/course_engagement_audit.py
+++ b/lib/tools/course_engagement_audit.py
@@ -435,27 +435,21 @@ def fetch_student_submissions(
 ) -> list[dict]:
     """All assignment + quiz submissions for one student. Submissions
     include `submitted_at` (None for not-yet-submitted) which is the
-    Title IV engagement timestamp.
+    Title IV engagement timestamp. Follows `Link: rel="next"` — blind `page += 1`
+    hit page 2 on a single-page result, which `/students/submissions?student_ids[]`
+    answers with HTTP 400, so every student looked 'never participated' (issue #67).
     """
     out: list[dict] = []
-    page = 1
-    while True:
-        r = requests.get(
-            f"{base}/api/v1/courses/{cid}/students/submissions",
-            headers=headers,
-            params={
-                "student_ids[]": str(user_id),
-                "per_page": 100,
-                "page": page,
-            },
-            timeout=_TIMEOUT,
-        )
+    url: str | None = f"{base}/api/v1/courses/{cid}/students/submissions"
+    params: list | None = [("student_ids[]", str(user_id)), ("per_page", 100)]
+    while url:
+        r = requests.get(url, headers=headers,
+                         params=params if "?" not in url else None, timeout=_TIMEOUT)
         r.raise_for_status()
-        batch = r.json() or []
-        if not batch:
-            break
-        out += batch
-        page += 1
+        out += r.json() or []
+        m = re.search(r'<([^>]+)>;\s*rel="next"', r.headers.get("Link", ""))
+        url = m.group(1) if m else None
+        params = None
     return out
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.5"
+version = "1.8.6"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.4"
+version = "1.8.5"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## The bug (field-found, correctly diagnosed)

Every student showed **"never participated"** in the engagement audit even with grades. The submission + discussion fetches (Python fallback *and* the main file's `fetch_student_submissions`) still did blind `page += 1` — the same #67 issue fixed for the *enrollment* fetch in 1.7.37, but missed here.

`/students/submissions?student_ids[]` answers a page **past the last** with **HTTP 400** (not an empty page). So for any student with <100 submissions (essentially all): page 1 succeeds → page 2 → 400 → `raise_for_status` crashes the fetch → the student is recorded with **no engagement**. The instructor even asked the right question — *"is it my API key?"* — and the agent correctly ruled it out: page 1 and enrollments worked; only the blind page 2 failed.

## Fix

All three fetches (submissions, discussion topics, discussion entries) now follow the `Link: rel="next"` header via a shared `_paged_get` helper. Discussion-topic 404s still skip gracefully. The Rust engagement binary (`engagement_audit_rs`) should be checked for the same pattern if it's compiled/in use.

## Verified

Both files import clean; the audit helper suite (40 tests) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)