### PR TITLE
feat(course_engagement_audit): focused failing-only UW report (UW-never/UW-before/F-After)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.7] — 2026-07-28
+
+**`course_engagement_audit`: the report is now a focused, failing-students-only Title IV list with clear UW-never / UW-before / F-After classes.**
+
+Reworked to match how the report is actually used (guided by a real field example):
+
+- **Only flagged students appear.** A **passing**, engaged student is excluded; so is anyone **formally dropped** (deleted/rejected enrollment — the fetch already omits them). **Inactive/concluded** enrollments ARE included (they may be unofficial withdrawals not yet processed) and now carry an **Enrollment** column so the reviewer sees who isn't currently active — this replaces the separate INACTIVE_ENROLLMENT section from 1.7.37.
+- **Three clear classes** (`title_iv_class`), grouped into their own report sections: **UW-never** (never participated → return 100%), **UW-before** (failing, stopped before the cutoff → R2T4 by last date), **F-After** (failing, engaged past the cutoff → completer-F, no R2T4). Each section is a name/user-id/last-engagement/score/enrollment table.
+
+Note this reverses two earlier calls at the maintainer's direction: passing students are now excluded (they weren't before), and inactive students are classified inline rather than parked in a review-only bucket.
+
+---
+
 ## [1.8.6] — 2026-07-28
 
 **Fix: the engagement audit's per-student submission fetch made every student look "never participated."**

--- a/lib/tests/test_course_engagement_audit_helpers.py
+++ b/lib/tests/test_course_engagement_audit_helpers.py
@@ -25,9 +25,46 @@ from course_engagement_audit import (  # noqa: E402
     parse_iso_utc,
     compute_last_engagement,
     classify_student,
+    title_iv_class,
     downloads_dir,
     render_report_md,
 )
+from datetime import datetime as _dt, timezone as _tz  # noqa: E402
+
+
+def _eng(day):
+    """A UTC engagement datetime on 2026-04-<day> (for title_iv_class tests)."""
+    return _dt(2026, 4, day, tzinfo=_tz.utc)
+
+
+_CUTOFF = _dt(2026, 4, 15, tzinfo=_tz.utc)
+
+
+# ---------------------------------------------------------------------------
+# title_iv_class — the focused report classifier (failing/never; passing excluded)
+# ---------------------------------------------------------------------------
+
+def test_title_iv_never_participated():
+    assert title_iv_class(None, _CUTOFF, None, 60.0) == "UW-never"
+    assert title_iv_class(None, _CUTOFF, 95.0, 60.0) == "UW-never"  # never engaged wins
+
+
+def test_title_iv_passing_engaged_is_excluded():
+    assert title_iv_class(_eng(20), _CUTOFF, 85.0, 60.0) is None
+
+
+def test_title_iv_uw_before_when_failing_and_stopped_early():
+    assert title_iv_class(_eng(10), _CUTOFF, 40.0, 60.0) == "UW-before"
+
+
+def test_title_iv_f_after_when_failing_and_engaged_after_cutoff():
+    assert title_iv_class(_eng(20), _CUTOFF, 40.0, 60.0) == "F-After"
+
+
+def test_title_iv_no_grade_counts_as_failing():
+    # engaged, no recorded score → not passing → flagged by timing
+    assert title_iv_class(_eng(10), _CUTOFF, None, 60.0) == "UW-before"
+    assert title_iv_class(_eng(20), _CUTOFF, None, 60.0) == "F-After"
 
 
 # ---------------------------------------------------------------------------
@@ -286,16 +323,15 @@ def test_downloads_dir_xdg_override(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 
 def _named_rows():
-    """Test fixture: a small set of named rows post-reidentification."""
+    """Named, FLAGGED rows post-reidentification (only what the focused report shows —
+    passing-and-engaged students are excluded upstream)."""
     return [
         {"user_id": 1, "name": "Smith, A", "last_engagement_str": "2026-03-15",
-         "current_score": 50.0, "classification": "UF"},
-        {"user_id": 2, "name": "Jones, B", "last_engagement_str": "2026-03-20",
-         "current_score": 70.0, "classification": "UW"},
+         "current_score": 50.0, "title_iv_class": "UW-before", "enrollment_state": "active"},
         {"user_id": 3, "name": "Lee, C", "last_engagement_str": "(never)",
-         "current_score": None, "classification": "NEVER_PARTICIPATED"},
-        {"user_id": 4, "name": "Park, D", "last_engagement_str": "2026-05-01",
-         "current_score": 85.0, "classification": "ACTIVE"},
+         "current_score": None, "title_iv_class": "UW-never", "enrollment_state": "active"},
+        {"user_id": 5, "name": "Kim, E", "last_engagement_str": "2026-05-01",
+         "current_score": 40.0, "title_iv_class": "F-After", "enrollment_state": "inactive"},
     ]
 
 
@@ -307,26 +343,32 @@ def test_render_report_md_includes_title_iv_verification_date():
     assert "2026-06-26" in md  # the verification date stamp
 
 
-def test_render_report_md_has_all_four_sections():
-    """Every classification bucket gets its own section in the report,
-    even when empty (so faculty can see the audit completed)."""
+def test_render_report_md_has_the_three_class_sections():
+    """The focused report has a section per flag class (UW-never/UW-before/F-After)."""
     md = render_report_md(_named_rows(), "Test Course", "12345",
                           "2026-04-15", "2026-06-26 12:00 UTC", 60.0)
-    assert "## UF" in md
-    assert "## UW" in md
-    assert "## NEVER PARTICIPATED" in md
-    assert "## ACTIVE" in md
+    assert "## UW-never" in md
+    assert "## UW-before" in md
+    assert "## F-After" in md
 
 
 def test_render_report_md_counts_match_input():
-    """The summary counts at the top must match the named rows."""
+    """The summary counts must match the flagged rows (1 each, 3 total)."""
     md = render_report_md(_named_rows(), "Test Course", "12345",
                           "2026-04-15", "2026-06-26 12:00 UTC", 60.0)
-    assert "**4** total enrolled students" in md
-    assert "**1** classified as **UF**" in md
-    assert "**1** classified as **UW**" in md
-    assert "**1** **NEVER PARTICIPATED**" in md
-    assert "**1** **ACTIVE**" in md
+    assert "**1** UW-never" in md
+    assert "**1** UW-before" in md
+    assert "**1** F-After" in md
+    assert "**3** flagged total" in md
+
+
+def test_render_report_md_excludes_passing_students():
+    """A passing-engaged row would never be in `rows` (filtered upstream) — the
+    report shows only flagged students. Sanity: 'passing' never appears as a class."""
+    md = render_report_md(_named_rows(), "Test Course", "12345",
+                          "2026-04-15", "2026-06-26 12:00 UTC", 60.0)
+    assert "Park, D" not in md  # the old passing student isn't in the fixture anymore
+    assert "enrollment" in md.lower()  # the Enrollment column is present
 
 
 def test_render_report_md_warning_about_PII():
@@ -348,31 +390,26 @@ def test_render_report_md_cites_title_iv_regulation():
 
 
 def test_render_report_md_empty_rows_renders_cleanly():
-    """No enrolled students → still produces a valid report (with all
-    sections showing _(none)_). The audit completes; counts are zero."""
+    """No flagged students → still a valid report: each class section shows _(none)_,
+    0 flagged total. (Every student passing-and-engaged is the good case.)"""
     md = render_report_md([], "Empty Course", "99999",
                           "2026-04-15", "2026-06-26 12:00 UTC", 60.0)
-    assert "## UF" in md
+    assert "## UW-never" in md
     assert "_(none)_" in md
-    assert "**0** total enrolled students" in md
+    assert "**0** flagged total" in md
 
 
-def test_render_report_md_sorts_within_bucket():
-    """Within each classification bucket, students are sorted by name
-    so the report is deterministic + scan-friendly."""
+def test_render_report_md_sorts_within_section():
+    """Within a class section, students are sorted by name (deterministic report)."""
     rows = [
         {"user_id": 1, "name": "Zoo, Z", "last_engagement_str": "2026-03-15",
-         "current_score": 50.0, "classification": "UF"},
+         "current_score": 50.0, "title_iv_class": "UW-before", "enrollment_state": "active"},
         {"user_id": 2, "name": "Aaa, A", "last_engagement_str": "2026-03-16",
-         "current_score": 40.0, "classification": "UF"},
+         "current_score": 40.0, "title_iv_class": "UW-before", "enrollment_state": "active"},
     ]
     md = render_report_md(rows, "Test", "1", "2026-04-15",
                           "2026-06-26 12:00 UTC", 60.0)
-    # Aaa, A should appear before Zoo, Z
-    aaa_pos = md.find("Aaa, A")
-    zoo_pos = md.find("Zoo, Z")
-    assert aaa_pos > 0 and zoo_pos > 0
-    assert aaa_pos < zoo_pos
+    assert 0 < md.find("Aaa, A") < md.find("Zoo, Z")
 
 
 # ---------------------------------------------------------------------------
@@ -438,16 +475,15 @@ def test_fetch_enrollments_include_inactive_requests_inactive_states(monkeypatch
     assert "inactive" not in states and "active" in states
 
 
-def test_render_report_surfaces_inactive_bucket_without_labeling_uw():
-    """An inactive-enrollment student appears in its own review section and is NOT
-    counted as UW/UF — asserting that would claim a withdrawal determination this
-    tool can't make."""
+def test_render_report_shows_inactive_students_with_their_enrollment_state():
+    """Inactive/completed enrollments ARE included (potential unofficial withdrawals),
+    classified like anyone else, with their enrollment state shown in the Enrollment
+    column so the reviewer knows they're not currently active."""
     rows = [
         {"user_id": 9, "name": "Gone, G", "last_engagement_str": "2026-02-01",
-         "current_score": 30.0, "classification": "INACTIVE_ENROLLMENT"},
+         "current_score": 30.0, "title_iv_class": "UW-before", "enrollment_state": "inactive"},
     ]
     md = render_report_md(rows, "Test", "1", "2026-04-15", "2026-06-26 12:00 UTC", 60.0)
-    assert "INACTIVE ENROLLMENT" in md
-    assert "review" in md.lower()
-    assert "**0** classified as **UW**" in md
     assert "Gone, G" in md
+    assert "inactive" in md          # enrollment state surfaced in the row
+    assert "## UW-before" in md      # classified, not shunted to a separate bucket

--- a/lib/tools/course_engagement_audit.py
+++ b/lib/tools/course_engagement_audit.py
@@ -269,6 +269,37 @@ def downloads_dir() -> Path:
     return home
 
 
+_CLASS_ORDER = ["UW-never", "UW-before", "F-After"]
+_CLASS_MEANING = {
+    "UW-never": "never participated — no engagement on record (Title IV: return 100%; there is no last date of academically related activity)",
+    "UW-before": "stopped engaging BEFORE the cutoff — an unofficial withdrawal (document the last-engagement date and run R2T4)",
+    "F-After": "engaged ON/AFTER the cutoff but FAILING — attended through, a completer-F, not a withdrawal (no R2T4)",
+}
+
+
+def title_iv_class(last_engagement, uf_date, current_score: float | None,
+                   passing_score: float) -> str | None:
+    """The Title IV flag for a student, or None if they need no flag. The report is
+    failing-students-only: a **passing** student (current_score >= passing_score) is
+    excluded regardless of engagement. Flagged students are grouped by engagement:
+
+      'UW-never'  — no engagement on record (never participated)
+      'UW-before' — failing AND last engagement BEFORE the cutoff (stopped early)
+      'F-After'   — failing AND engaged ON/AFTER the cutoff (attended through, failing)
+      None        — passing-and-engaged → excluded
+
+    A 'no grade' student counts as failing (they have no earned score); a
+    never-participated student is UW-never regardless of grade.
+    """
+    if last_engagement is None:
+        return "UW-never"
+    if current_score is not None and current_score >= passing_score:
+        return None                                # passing + engaged → excluded
+    if uf_date is not None and last_engagement < uf_date:
+        return "UW-before"                         # failing, stopped before cutoff
+    return "F-After"                               # failing, engaged on/after cutoff
+
+
 def render_report_md(
     rows: list[dict],
     course_title: str,
@@ -277,30 +308,25 @@ def render_report_md(
     generated_at: str,
     passing_score: float,
 ) -> str:
-    """Issue #(course-engagement-audit): render the named, FERPA-out-of-
-    scope report as Markdown. Input rows must already be re-identified
-    (contain 'name' field). Caller writes the output to ~/Downloads/
-    — NEVER to a file inside the repo.
-
-    Pure function for testability: takes pre-built row data + course
-    metadata, returns the full Markdown string.
+    """Render the FOCUSED Title IV report — ONLY flagged students (UW-never /
+    UW-before / F-After). Passing-and-engaged students, and anyone formally dropped
+    (deleted/rejected enrollment), are excluded upstream. Input rows are re-identified
+    (contain 'name' + 'title_iv_class'). Caller writes to ~/Downloads/ — NEVER the repo.
     """
-    by_class: dict[str, list[dict]] = {
-        "UF": [], "UW": [], "NEVER_PARTICIPATED": [], "ACTIVE": [],
-        "INACTIVE_ENROLLMENT": [],
-    }
+    by_class: dict[str, list[dict]] = {k: [] for k in _CLASS_ORDER}
     for r in rows:
-        by_class.setdefault(r["classification"], []).append(r)
+        by_class.setdefault(r.get("title_iv_class"), []).append(r)
+    counts = {k: len(by_class.get(k, [])) for k in _CLASS_ORDER}
+    total = sum(counts.values())
 
-    n = len(rows)
-    n_uf = len(by_class["UF"])
-    n_uw = len(by_class["UW"])
-    n_never = len(by_class["NEVER_PARTICIPATED"])
-    n_active = len(by_class["ACTIVE"])
-    n_inactive = len(by_class["INACTIVE_ENROLLMENT"])
+    _SECTION_NAME = {
+        "UW-never": "Never Participated",
+        "UW-before": f"Failing, Last Engagement Before {uf_date_str}",
+        "F-After": f"Failing, Last Engagement After {uf_date_str}",
+    }
 
     out: list[str] = [
-        f"# Course Engagement Audit — {course_title}",
+        f"# Title IV Engagement Report — {course_title}",
         "",
         f"**Course ID:** {course_id}  ",
         f"**UF cutoff date:** {uf_date_str}  ",
@@ -308,61 +334,34 @@ def render_report_md(
         f"**Report generated:** {generated_at}  ",
         f"**Title IV definitions verified against:** {_TITLE_IV_VERIFIED_DATE}",
         "",
-        "> ⚠️ **This report contains student names. It was generated outside the canvas-toolbox repo for FERPA reasons (see below). Do NOT copy it into a repo folder, share it via cloud sync, or email it unencrypted.**",
+        "> ⚠️ **Contains student names — generated OUTSIDE the repo for FERPA. Do NOT copy it into a repo folder, cloud-sync it, or email it unencrypted.**",
+        "",
+        "> Only **flagged** students appear (failing or never-participated). **Passing** students are excluded, as is anyone **formally dropped** (deleted/rejected enrollment). **Inactive/concluded** enrollments ARE included — they may be unofficial withdrawals not yet processed (see the Enrollment column).",
         "",
         "## Summary",
         "",
-        f"- **{n}** total enrolled students",
-        f"- **{n_uf}** classified as **UF** (Unofficial Fail — last engagement < UF date AND failing grade; R2T4 candidate)",
-        f"- **{n_uw}** classified as **UW** (Unofficial Withdrawal — last engagement < UF date)",
-        f"- **{n_never}** **NEVER PARTICIPATED** (no engagement on record)",
-        f"- **{n_active}** **ACTIVE** (engagement on or after UF date)",
-        f"- **{n_inactive}** **INACTIVE ENROLLMENT** (dropped/concluded in Canvas — review each for official vs unofficial withdrawal)",
+        f"- **{counts['UW-never']}** UW-never · **{counts['UW-before']}** UW-before · "
+        f"**{counts['F-After']}** F-After · **{total}** flagged total",
         "",
-        "Federal Title IV reference: 34 CFR 668.22 + 2025-2026 FSA Handbook, Vol 5 Ch 1. Distance-education R2T4 final rules went into effect 2026-07-01. Re-verify this tool's classification rules against the then-current FSA Handbook if reading after ~2027.",
-        "",
-        "---",
+        "Federal reference: 34 CFR 668.22 + 2025-2026 FSA Handbook, Vol 5 Ch 1. Re-verify against the then-current FSA Handbook if reading after ~2027.",
         "",
     ]
-
-    section_titles = [
-        ("UF", "## UF — Unofficial Fail (R2T4 candidates)",
-         "These students stopped engaging before the UF date AND have a failing current grade. The institution's financial aid office must run R2T4 if they received Title IV aid. The professor of record documents the **last date of academically related activity** (the `last_engagement` column below)."),
-        ("UW", "## UW — Unofficial Withdrawal",
-         "These students stopped engaging before the UF date but have a passing-or-unknown grade. Per 34 CFR 668.22, if they do not earn a passing grade by term end, the institution must treat them as unofficial withdrawals — re-classify and R2T4 then."),
-        ("NEVER_PARTICIPATED", "## NEVER PARTICIPATED",
-         "These students are enrolled but have no submissions, quiz attempts, or discussion entries on record. Per Title IV, logging in is not sufficient to demonstrate engagement; these students never had a date of academically related activity. If they received Title IV aid, the institution must return 100% per the no-show / no-attendance rules."),
-        ("ACTIVE", "## ACTIVE",
-         "These students have engagement on or after the UF date. No Title IV concern."),
-        ("INACTIVE_ENROLLMENT", "## INACTIVE ENROLLMENT — review required",
-         "These students are inactive/concluded in Canvas (dropped, deactivated, or "
-         "the enrollment concluded). Some are **official** withdrawals already "
-         "processed; others may be **unofficial** withdrawals not yet caught. This "
-         "tool does NOT auto-classify them — the last-engagement column is their "
-         "last date of academically related activity; the registrar/financial-aid "
-         "office reconciles each against the official withdrawal record and runs "
-         "R2T4 where required. Pass --active-only to exclude this section."),
-    ]
-
-    for key, header, blurb in section_titles:
-        bucket = by_class.get(key, [])
-        out.append(header)
-        out.append("")
-        out.append(blurb)
-        out.append("")
+    for cls in _CLASS_ORDER:
+        bucket = by_class[cls]
+        out += [f"## {cls} — {_SECTION_NAME[cls]} ({len(bucket)})", "",
+                _CLASS_MEANING[cls], ""]
         if not bucket:
-            out.append("_(none)_")
-            out.append("")
+            out += ["_(none)_", ""]
             continue
-        out.append("| Student | User ID | Last engagement | Current score |")
-        out.append("|---|---|---|---|")
+        out += ["| Student | User ID | Last engagement | Current score | Enrollment |",
+                "|---|---|---|---|---|"]
         for r in sorted(bucket, key=lambda x: x.get("name", "")):
-            name = r.get("name", "(unknown)")
-            uid = r.get("user_id", "")
-            last = r.get("last_engagement_str", "(none)")
             score = r.get("current_score")
-            score_s = f"{score}" if score is not None else "(no grade)"
-            out.append(f"| {name} | {uid} | {last} | {score_s} |")
+            out.append(
+                f"| {r.get('name', '(unknown)')} | {r.get('user_id', '')} | "
+                f"{r.get('last_engagement_str', '(none)')} | "
+                f"{score if score is not None else '(no grade)'} | "
+                f"{r.get('enrollment_state', '')} |")
         out.append("")
 
     out.extend([
@@ -728,41 +727,36 @@ def main() -> int:
         last = compute_last_engagement(sub_timestamps, disc_timestamps, [])
         row["last_engagement"] = last
         row["last_engagement_str"] = last.strftime("%Y-%m-%d") if last else "(never)"
-        # An inactive/completed enrollment is surfaced in its OWN bucket — it may be
-        # an unofficial withdrawal OR an already-processed official one; the FA
-        # office decides. We still compute last_engagement (the date they need), but
-        # never auto-label it UW/UF, which would assert a determination we can't make.
-        if row["enrollment_state"] not in ("active", "invited"):
-            row["classification"] = "INACTIVE_ENROLLMENT"
-        else:
-            row["classification"] = classify_student(
-                last, uf_date, row["current_score"], args.passing_score,
-            )
+        # Flag failing/never-participated students, grouped by engagement timing.
+        # Passing-and-engaged → None (excluded). Inactive/completed enrollments ARE
+        # classified (they may be unofficial withdrawals); the fetch already excludes
+        # formally-dropped (deleted/rejected).
+        row["title_iv_class"] = title_iv_class(
+            last, uf_date, row["current_score"], args.passing_score)
     print()
 
-    # Step 3: classification summary (KEYED — no names in console)
+    # Report only FLAGGED students — passing-and-engaged are excluded.
+    flagged = [r for r in keyed_rows if r.get("title_iv_class")]
     counts: dict[str, int] = {}
-    for r in keyed_rows:
-        counts[r["classification"]] = counts.get(r["classification"], 0) + 1
-    print("Classification:")
-    for k in ("UF", "UW", "NEVER_PARTICIPATED", "ACTIVE", "INACTIVE_ENROLLMENT"):
-        print(f"  {k:20} {counts.get(k, 0):3d}")
+    for r in flagged:
+        counts[r["title_iv_class"]] = counts.get(r["title_iv_class"], 0) + 1
+    print(f"Flagged {len(flagged)} of {len(keyed_rows)} students "
+          "(passing-and-engaged excluded):")
+    for k in ("UW-never", "UW-before", "F-After"):
+        print(f"  {k:12} {counts.get(k, 0):3d}")
     print()
 
     if args.dry_run:
         print("Dry run — no file written.")
         return 0
 
-    # Step 4: RE-IDENTIFICATION — swap user_id → name for the named report
-    # This is the FIRST place names enter the named-output flow. Before
-    # this point, console output was keyed-only. The re-id'd report lives
-    # ONLY in ~/Downloads/, never in the repo.
-    named_rows: list[dict] = []
-    for r in keyed_rows:
-        named_rows.append({
-            **r,
-            "name": keymap.get(r["user_id"], f"(user_id={r['user_id']})"),
-        })
+    # Step 4: RE-IDENTIFICATION — swap user_id → name for the named report, for the
+    # FLAGGED rows only. This is the FIRST place names enter the named-output flow;
+    # the re-id'd report lives ONLY in ~/Downloads/, never in the repo.
+    named_rows: list[dict] = [
+        {**r, "name": keymap.get(r["user_id"], f"(user_id={r['user_id']})")}
+        for r in flagged
+    ]
 
     # Step 5: Render report
     generated_at = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.6"
+version = "1.8.7"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.5"
+version = "1.8.6"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## What

Reworked the Title IV report to match how it's actually used (you shared a real DS460 example as the guide):

- **Only flagged students appear.** **Passing** + engaged students are excluded; **formally dropped** (deleted/rejected) already omitted by the fetch; **inactive/concluded** students ARE included (potential unofficial withdrawals) with a new **Enrollment** column so the reviewer sees who isn't active.
- **Three clear classes** in their own sections:
  - **UW-never** — never participated (return 100%; no last date)
  - **UW-before** — failing, stopped before the cutoff (unofficial withdrawal; R2T4 by last date)
  - **F-After** — failing, engaged past the cutoff (completer-F, no R2T4)

Each section is a `Student | User ID | Last engagement | Current score | Enrollment` table.

## Policy calls (yours)

This reverses two earlier decisions **at your direction**: passing students are now **excluded** (they weren't), and inactive students are **classified inline** instead of parked in a review-only bucket (1.7.37 added that bucket; you asked to fold them in).

## Tests

46 pass — 5 new `title_iv_class` tests (never / passing-excluded / UW-before / F-After / no-grade-as-failing) + the render tests rewritten for the focused sections + the Enrollment column. `classify_student` retained for back-compat.

Pairs with the 1.8.6 pagination fix so the engagement data is actually correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
