### PR TITLE
feat(course_engagement_audit): course name in the report filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.8] — 2026-07-28
+
+**The engagement report filename now includes the course name — identifiable across sections.**
+
+Reports were named `engagement-audit-<course-id>-<date>.md`; with 5 sections across 4 courses the opaque course-id made them hard to tell apart in `~/Downloads/`. Now: `engagement-<course-name>-<course-id>-<date>.md` (e.g. `engagement-big-data-programming-407908-2026-07-28.md`). The course *name* is a title, not student PII (Zone-1), so it's safe in the filename; the course-id stays for disambiguation.
+
+---
+
 ## [1.8.7] — 2026-07-28
 
 **`course_engagement_audit`: the report is now a focused, failing-students-only Title IV list with clear UW-never / UW-before / F-After classes.**

--- a/lib/tests/test_course_engagement_audit_helpers.py
+++ b/lib/tests/test_course_engagement_audit_helpers.py
@@ -26,9 +26,31 @@ from course_engagement_audit import (  # noqa: E402
     compute_last_engagement,
     classify_student,
     title_iv_class,
+    slugify_course,
     downloads_dir,
     render_report_md,
 )
+
+
+# ---------------------------------------------------------------------------
+# slugify_course — course name in the report filename (identify across sections)
+# ---------------------------------------------------------------------------
+
+def test_slugify_course_basic():
+    assert slugify_course("Big Data Programming") == "big-data-programming"
+
+
+def test_slugify_course_strips_punctuation_and_edges():
+    assert slugify_course("ITM 327: Web Apps (S2)!") == "itm-327-web-apps-s2"
+
+
+def test_slugify_course_empty_falls_back():
+    assert slugify_course("") == "course"
+    assert slugify_course(None) == "course"
+
+
+def test_slugify_course_truncates_long_names():
+    assert len(slugify_course("word " * 40)) <= 40
 from datetime import datetime as _dt, timezone as _tz  # noqa: E402
 
 

--- a/lib/tools/course_engagement_audit.py
+++ b/lib/tools/course_engagement_audit.py
@@ -269,6 +269,14 @@ def downloads_dir() -> Path:
     return home
 
 
+def slugify_course(name: str, maxlen: int = 40) -> str:
+    """A filename-safe slug of a COURSE name (a title, not student PII) so a report
+    is identifiable across sections: 'Big Data Programming' -> 'big-data-programming'.
+    Empty/odd input -> 'course'."""
+    s = re.sub(r"[^a-z0-9]+", "-", (name or "").lower()).strip("-")
+    return s[:maxlen].strip("-") or "course"
+
+
 _CLASS_ORDER = ["UW-never", "UW-before", "F-After"]
 _CLASS_MEANING = {
     "UW-never": "never participated — no engagement on record (Title IV: return 100%; there is no last date of academically related activity)",
@@ -545,7 +553,7 @@ def main() -> int:
                          "60%% passing bar).")
     ap.add_argument("--out", default=None,
                     help="Override output path. Default: "
-                         "~/Downloads/engagement-audit-<course-id>-<YYYY-MM-DD>.md")
+                         "~/Downloads/engagement-<course-name>-<course-id>-<YYYY-MM-DD>.md")
     ap.add_argument("--active-only", action="store_true",
                     help="Audit only active enrollments. Default includes inactive/"
                          "completed students (surfaced separately) — for Title IV "
@@ -770,7 +778,7 @@ def main() -> int:
     else:
         dl = downloads_dir()
         today = datetime.now().strftime("%Y-%m-%d")
-        out_path = dl / f"engagement-audit-{cid}-{today}.md"
+        out_path = dl / f"engagement-{slugify_course(course_title)}-{cid}-{today}.md"
 
     # Defense in depth: refuse to write inside the canvas-toolbox repo dir.
     # The repo lives at whatever the cwd is when this runs; we check by

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.7"
+version = "1.8.8"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.6"
+version = "1.8.7"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Reports were `engagement-audit-<course-id>-<date>.md` — opaque across 5 sections in 4 courses. Now **`engagement-<course-name>-<course-id>-<date>.md`**, e.g. `engagement-big-data-programming-407908-2026-07-28.md`. The course *name* is a title (Zone-1, not student PII), so it's safe in the filename; the course-id stays for disambiguation. `slugify_course()` lowercases/dashes/strips-punctuation, truncates to 40, falls back to `course`. 4 new slug tests; suite 50 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)