### PR TITLE
fix(course_engagement_audit): Rust engine had the same pagination bug — Python now default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.9] — 2026-07-28
+
+**Critical: the Rust engagement engine had the SAME pagination bug — every student read "never participated" on Rust-enabled repos. Python is now the trusted default.**
+
+1.8.6 fixed the pagination in the Python engine but not the compiled **Rust** binary, which is the *default when present* — so a repo with the Rust binary (e.g. DS460) produced a report flagging **all 35 students as UW-never** while Python-only repos classified correctly. The Rust `get_paginated` blind-incremented `page` and `bail!`ed on the page-2 `400`, zeroing every student's engagement.
+
+Two changes:
+- **Python is now the trusted default engine**; Rust is opt-in via `--rust`. A wrong Title IV report is worse than a slow one, and the field binaries are stale, so the tool no longer uses a compiled Rust binary unless explicitly asked. This makes every repo correct on the next pull — no recompile needed.
+- **The Rust source is fixed too** (Link-header pagination, matching the Python fix; compiles clean) — so `--rust` is correct *after rebuilding the binary from current source*. An older binary still mis-reports, hence the opt-in + the warning the flag prints.
+
+If you use `--rust`, rebuild first (`cd canvas-toolbox/lib/tools/engagement_audit_rs && cargo build --release`).
+
+---
+
 ## [1.8.8] — 2026-07-28
 
 **The engagement report filename now includes the course name — identifiable across sections.**

--- a/lib/tools/course_engagement_audit.py
+++ b/lib/tools/course_engagement_audit.py
@@ -561,6 +561,11 @@ def main() -> int:
                          "withdrawals whose last engagement must be documented.")
     ap.add_argument("--dry-run", action="store_true",
                     help="Print classification counts only; no file written.")
+    ap.add_argument("--rust", action="store_true",
+                    help="Use the fast concurrent Rust engine instead of the trusted "
+                         "Python default. ONLY after rebuilding the Rust binary from "
+                         "current source — an older binary mis-reports engagement "
+                         "(every student 'never participated').")
     args = ap.parse_args()
 
     tok, base, cid = _env_canvas(args.course_id)
@@ -657,17 +662,25 @@ def main() -> int:
           f"({len(keyed_rows) - n_inactive} active, {n_inactive} inactive). "
           "Fetching engagement events...")
 
-    # Step 2: Per-student engagement events (KEYED — operates on user_id)
-    # Dispatcher: Use Rust binary if available, otherwise Python fallback
+    # Step 2: Per-student engagement events (KEYED — operates on user_id).
+    # Engine: the PYTHON implementation is the trusted default. The Rust binary is
+    # opt-in (--rust) and, until rebuilt from current source, carries the SAME
+    # blind-pagination bug the Python path fixed in 1.8.6 — a compiled Rust binary in
+    # the field zeroed out engagement and reported every student as "never
+    # participated". A wrong Title IV report is worse than a slow one, so Rust is no
+    # longer used unless explicitly requested AND freshly rebuilt.
     script_dir = Path(__file__).parent
     rust_bin = script_dir / "engagement_audit_rs" / "target" / "release" / "engagement-audit"
+    if not args.rust:
+        rust_bin = None  # trusted Python default
 
     user_ids = [row["user_id"] for row in keyed_rows]
     engagement_data = {}  # user_id -> {submission_timestamps, discussion_timestamps}
 
-    if rust_bin.exists():
-        # Rust path - concurrent fetching
-        print("  Using Rust implementation (concurrent, fast)...", file=sys.stderr)
+    if rust_bin and rust_bin.exists():
+        # Rust path - concurrent fetching (opt-in; must be rebuilt from current source)
+        print("  Using Rust implementation (--rust). Ensure it was rebuilt from "
+              "current source (older binaries mis-report engagement).", file=sys.stderr)
         try:
             user_ids_csv = ",".join(str(uid) for uid in user_ids)
             result = subprocess.run(
@@ -699,17 +712,12 @@ def main() -> int:
             rust_bin = None  # Force Python fallback
 
     if not rust_bin or not rust_bin.exists():
-        # Python fallback - sequential fetching
-        print("  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", file=sys.stderr)
-        print("  ⚠ Rust binary not found — using Python fallback (SLOW)", file=sys.stderr)
-        print("  ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━", file=sys.stderr)
-        print(file=sys.stderr)
-        print("  Python fallback is slow for large courses (5-10 min for 100+ students).", file=sys.stderr)
-        print("  For 10-20x speedup, install Rust:", file=sys.stderr)
-        print("    cb-init --with-rust", file=sys.stderr)
-        print(file=sys.stderr)
-        print("  Proceeding with Python fallback...", file=sys.stderr)
-        print(file=sys.stderr)
+        # Python — the trusted default engine (correct pagination; #67).
+        print("  Fetching engagement (Python engine — the trusted default).",
+              file=sys.stderr)
+        print("  Sequential, so slow for large courses (~5-10 min for 100+ students). "
+              "For speed, rebuild the Rust binary from current source and pass --rust.",
+              file=sys.stderr)
 
         try:
             from _course_engagement_audit_python import run_python_fallback

--- a/lib/tools/engagement_audit_rs/src/main.rs
+++ b/lib/tools/engagement_audit_rs/src/main.rs
@@ -6,6 +6,22 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 use std::time::Duration;
 
+/// Extract the `rel="next"` URL from a Canvas `Link` header, if present.
+/// Format: `<https://…?page=2>; rel="next", <https://…?page=5>; rel="last"`.
+fn parse_next_link(link: &str) -> Option<String> {
+    for part in link.split(',') {
+        let seg = part.trim();
+        if seg.contains("rel=\"next\"") {
+            if let (Some(a), Some(b)) = (seg.find('<'), seg.find('>')) {
+                if a < b {
+                    return Some(seg[a + 1..b].to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
 #[derive(Parser, Debug)]
 #[command(name = "engagement-audit")]
 #[command(about = "Fetch Canvas engagement data for Title IV audit (Rust impl)")]
@@ -80,21 +96,25 @@ impl CanvasClient {
         endpoint: &str,
         params: &[(&str, String)],
     ) -> Result<Vec<T>> {
+        // Follow the `Link: rel="next"` header instead of blindly incrementing `page`.
+        // `/students/submissions?student_ids[]` returns HTTP 400 (not an empty page)
+        // for a page past the last, so blind `page += 1` bailed on page 2 of a
+        // single-page result — the whole fetch errored and every student was recorded
+        // with NO engagement ("never participated"). Issue #67 (matches the Python fix).
         let mut all_items = Vec::new();
-        let mut page = 1;
+        let mut url = format!("{}/api/v1/{}", self.base_url, endpoint);
+        let mut first = true;
 
         loop {
-            let url = format!("{}/api/v1/{}", self.base_url, endpoint);
+            let mut req = self.client.get(&url).bearer_auth(&self.token);
+            if first {
+                let mut query_params: Vec<(&str, String)> = params.to_vec();
+                query_params.push(("per_page", "100".to_string()));
+                req = req.query(&query_params);
+                first = false;
+            }
 
-            let mut query_params: Vec<(&str, String)> = params.to_vec();
-            query_params.push(("per_page", "100".to_string()));
-            query_params.push(("page", page.to_string()));
-
-            let response = self
-                .client
-                .get(&url)
-                .bearer_auth(&self.token)
-                .query(&query_params)
+            let response = req
                 .send()
                 .await
                 .context(format!("Failed to GET {}", endpoint))?;
@@ -103,17 +123,23 @@ impl CanvasClient {
                 anyhow::bail!("HTTP {} for {}", response.status(), endpoint);
             }
 
+            // Read the next-page link BEFORE consuming the body with `.json()`.
+            let next = response
+                .headers()
+                .get(reqwest::header::LINK)
+                .and_then(|v| v.to_str().ok())
+                .and_then(parse_next_link);
+
             let items: Vec<T> = response
                 .json()
                 .await
                 .context(format!("Failed to parse JSON from {}", endpoint))?;
-
-            if items.is_empty() {
-                break;
-            }
-
             all_items.extend(items);
-            page += 1;
+
+            match next {
+                Some(n) => url = n,
+                None => break,
+            }
         }
 
         Ok(all_items)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.8"
+version = "1.8.9"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.7"
+version = "1.8.8"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Root cause of "every student shows no participation"

1.8.6 fixed the pagination in the **Python** engine but not the compiled **Rust** binary — which is the *default when present*. So:

| Repo | Engine | Result |
|---|---|---|
| DS460 (407908) | **Rust** (binary compiled) | 🔴 **35/35 UW-never** — all wrong |
| DS250, M119 | Python (no binary) | ✅ correct mixed classifications |

The Rust `get_paginated` blind-incremented `page` and `bail!`ed on the page-2 `400`, zeroing every student's engagement.

## Fix

- **Python is now the trusted default engine**; Rust is opt-in via `--rust`. A wrong Title IV report is worse than a slow one, and the field binaries are stale — so the tool no longer runs a compiled Rust binary unless asked. **Every repo is correct on the next pull, no recompile needed.**
- **Rust source fixed too** — `get_paginated` follows `Link: rel="next"` (new `parse_next_link` helper), matching the Python fix. **Compiles clean** (`cargo build --release`). `--rust` is correct only *after* rebuilding from current source; the flag prints a warning.

## Verified

`cargo build --release` succeeds; Python-engine tests (50) pass; `--rust` shows in `--help`.

Pairs with #256 (Python pagination) — together they close the "never participated" bug on both engines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
