### PR TITLE
fix(course_engagement_audit): exclude withdrawn students by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.10] — 2026-07-28
+
+**Engagement report now excludes withdrawn students by default.**
+
+The report was dominated by `inactive` (withdrawn/deactivated) students — in one section, 20 of 26 flagged were inactive. Those are **formally-handled** withdrawals, not the *unofficial* withdrawals the report targets, so they were noise. The default now audits **actively-enrolled students only** (inactive / completed / deleted / rejected excluded); the flag flips from `--active-only` to **`--include-inactive`** for the rare case where you want to review a withdrawal you suspect wasn't processed.
+
+Reverses the 1.7.37 default at the maintainer's direction (that release *added* inactive students on the reasoning they might be unofficial withdrawals; in practice they swamped the report with already-processed drops).
+
+---
+
 ## [1.8.9] — 2026-07-28
 
 **Critical: the Rust engagement engine had the SAME pagination bug — every student read "never participated" on Rust-enabled repos. Python is now the trusted default.**

--- a/lib/tools/course_engagement_audit.py
+++ b/lib/tools/course_engagement_audit.py
@@ -344,7 +344,7 @@ def render_report_md(
         "",
         "> ⚠️ **Contains student names — generated OUTSIDE the repo for FERPA. Do NOT copy it into a repo folder, cloud-sync it, or email it unencrypted.**",
         "",
-        "> Only **flagged** students appear (failing or never-participated). **Passing** students are excluded, as is anyone **formally dropped** (deleted/rejected enrollment). **Inactive/concluded** enrollments ARE included — they may be unofficial withdrawals not yet processed (see the Enrollment column).",
+        "> Only **flagged** students appear (failing or never-participated), and only **actively-enrolled** ones. **Passing** students are excluded, and so are **withdrawn** students — anyone dropped/deactivated/concluded (inactive, completed, deleted, rejected) is a formally-handled withdrawal, not an *unofficial* one. Pass `--include-inactive` to review borderline cases (e.g. a withdrawal you suspect wasn't processed).",
         "",
         "## Summary",
         "",
@@ -554,11 +554,12 @@ def main() -> int:
     ap.add_argument("--out", default=None,
                     help="Override output path. Default: "
                          "~/Downloads/engagement-<course-name>-<course-id>-<YYYY-MM-DD>.md")
-    ap.add_argument("--active-only", action="store_true",
-                    help="Audit only active enrollments. Default includes inactive/"
-                         "completed students (surfaced separately) — for Title IV "
-                         "you generally want them, as they may be unofficial "
-                         "withdrawals whose last engagement must be documented.")
+    ap.add_argument("--include-inactive", action="store_true",
+                    help="Also include withdrawn students — inactive/completed/deleted/"
+                         "rejected enrollments. By DEFAULT they're EXCLUDED: an inactive "
+                         "enrollment is a formally-dropped/withdrawn student (already "
+                         "handled), not the unofficial withdrawal this report targets. "
+                         "Include them only to review borderline cases.")
     ap.add_argument("--dry-run", action="store_true",
                     help="Print classification counts only; no file written.")
     ap.add_argument("--rust", action="store_true",
@@ -617,7 +618,7 @@ def main() -> int:
     # we'll use ONLY at the re-id step before writing the named report.
     try:
         enrollments = fetch_enrollments(base, cid, headers,
-                                        include_inactive=not args.active_only)
+                                        include_inactive=args.include_inactive)
     except (requests.HTTPError, requests.RequestException) as e:
         print(f"ERROR: enrollment fetch failed ({type(e).__name__}: {e}).",
               file=sys.stderr)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.9"
+version = "1.8.10"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.8"
+version = "1.8.9"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
The report was dominated by `inactive` (withdrawn) students — **20 of 26 flagged** in one section. Those are formally-handled withdrawals, not the *unofficial* withdrawals the report targets. The default now audits **actively-enrolled students only** (inactive/completed/deleted/rejected excluded); the flag flips `--active-only` → **`--include-inactive`** for the rare borderline-review case. Reverses the 1.7.37 include-inactive default at your direction. 50 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)