### PR TITLE
docs(grading skill): fresh-data-before-grading discipline

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -8,6 +8,26 @@ description: Use for ANY grading work in a Canvas course — fetching submission
 Grading with AI is **decision support, not autonomy.** A human decides every grade
 that reaches a student. This skill is the operating manual for that discipline.
 
+## Fresh data before any grading decision
+
+A grading decision is only as good as the data under it. A stale cache — a
+`_computed_grades.csv` from an earlier sync, a day-old export — has produced
+confidently-wrong conclusions ("KC3 blocker" when 19/31 had actually completed it).
+So: **pull fresh Canvas data before you reason about grades**, and never trust a
+cache without checking its age.
+
+The toolkit already builds this in — do NOT hand-roll a `verify_data_freshness.sh` or
+a timestamped CSV:
+- **`grader_fetch_gradebook.py`** mirrors the whole gradebook, stamps it with
+  `fetched_at`, and **skips the fetch only if the cache is younger than
+  `--max-age-hours` (default 6)** — `--force` always refreshes. Use it (or its cache)
+  as the source of truth for gradebook-wide reasoning.
+- **`grader_fetch.py`** re-fetches a challenge's submissions; when in doubt, re-run it
+  rather than reusing an old fetch.
+
+If a course keeps a *computed* file (final grades, standings), regenerate it from a
+fresh fetch each run — never read a cached custom CSV whose age you can't see.
+
 > The **constitution** (AGENTS.md) already binds you at all times: never read FERPA
 > Zone-2 files, and grades reach Canvas ONLY through a sanctioned `lib/tools/`
 > writer. This skill is the *how*; those are the *never*.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.11] — 2026-07-28
+
+**Grading skill: a "fresh data before any grading decision" discipline (field-driven).**
+
+A course session reasoned off a stale `_computed_grades.csv` and reached a confidently-wrong conclusion (a "KC3 blocker" when 19/31 students had actually completed it), then hand-rolled a `verify_data_freshness.sh` + a poka-yoke doc to prevent it. But the toolkit already builds freshness in — `grader_fetch_gradebook.py` stamps `fetched_at` and skips only if the cache is younger than `--max-age-hours` (default 6). The `grading` skill now states the rule — pull fresh Canvas data before reasoning about grades; use the tool's cache (with its visible age), never a custom CSV whose age you can't see — so agents reach for the built-in guarantee instead of re-inventing it locally.
+
+---
+
 ## [1.8.10] — 2026-07-28
 
 **Engagement report now excludes withdrawn students by default.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.10"
+version = "1.8.11"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
A course session reasoned off a stale `_computed_grades.csv` → a confidently-wrong 'KC3 blocker' conclusion (19/31 had actually completed it), then hand-rolled a `verify_data_freshness.sh` + poka-yoke doc. But the toolkit already builds this in: **`grader_fetch_gradebook.py`** stamps `fetched_at` and skips only if the cache is younger than `--max-age-hours` (default 6). The `grading` skill now states the rule — pull fresh data before reasoning about grades; use the tool's cache (visible age), never a custom CSV whose age you can't see — so agents reach for the built-in guarantee instead of re-inventing it. Same reuse-over-reinvention pattern as the grade-writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)