### PR TITLE
feat: voicing skill + cb_update ensures the grade_guardian hook

### DIFF
--- a/.claude/skills/voicing/SKILL.md
+++ b/.claude/skills/voicing/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: voicing
+description: Use whenever you draft ANY student-facing text — grading comments, feedback, the "your grade" note, an announcement, an email. Load and apply the instructor's established VOICING PROFILE (their feedback tone/voice) so every comment sounds like them, not like a fresh AI voice each time. Never invent a new voice when a profile exists. Load this together with the `grading` skill before writing feedback.
+---
+
+# Voicing
+
+Student-facing text should sound like the **instructor**, consistently — the same
+warmth, directness, and phrasing across every assignment. The failure this prevents:
+an agent invents a *new* voice each session (or per assignment), so a student gets
+feedback that reads differently every time and doesn't match the instructor's.
+
+## The one rule
+
+**Before drafting any student-facing comment, load the course's voicing profile and
+write in that voice. Never make up a new one when a profile exists.**
+
+## Find the profile (check, in order)
+
+1. `VOICING.md` at the course root
+2. `grading/voicing.md` (or `grading/voicing_profile.md`)
+3. A location the course `AGENTS.md` points to (some courses name their own)
+
+The profile is course context (the instructor's voice — **not** student PII), so it's
+Zone-1: safe to read and to commit. Read it fully before you write.
+
+## Apply it
+
+A voicing profile typically pins: overall tone (warm / direct / formal), how to open
+and close, how to deliver criticism (sandwich? straight?), encouragement style,
+signature phrases to **use** and ones to **avoid**, length, and second-person vs
+third. Match all of it. When the profile and a rubric conflict on wording, the rubric
+governs *what* you say; the profile governs *how* you say it.
+
+## If there is no profile yet
+
+Do **not** silently invent one. Instead:
+1. Ask the instructor a few quick questions — tone, how they like to open/close,
+   phrases they love/hate, how blunt to be about problems.
+2. Draft a short profile from their answers **and their existing comments** if any
+   are available for reference.
+3. Save it to `VOICING.md` (or `grading/voicing.md`) so **every future comment reuses
+   it** — that's the whole point. Confirm the save with the instructor.
+
+## Where this plugs in
+
+- **Grading feedback** (`grader_push` comments, `grader_letter_comments` End-Letter
+  notes): draft in the profile's voice, then the usual HG-5 review/push.
+- The profile shapes *voice only* — it never changes a grade, a rubric score, or the
+  HG-5 gate. Load the `grading` skill for those.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,6 +48,7 @@ playbook (tools, gates, order of operations) so you don't operate from half-memo
 | **`accommodations`** | Per-student interventions | time extensions, late grace, SAS letters, overrides, exemptions, submit-on-behalf |
 | **`ferpa-deid`** | De-id/re-id machinery | `build_deid_master`, de-identify artifacts, re-identify by key, name-leak check |
 | **`title-iv`** | Federal engagement / withdrawal compliance | `course_engagement_audit` (UW/UF/R2T4), Title IV snapshot |
+| **`voicing`** | Writing student-facing text in the instructor's voice | load the course's voicing profile for grading comments / notes — never invent a voice |
 
 Meta/lifecycle tools (`cb_init` setup, `cb_report_bug`, `vote_feature`) are governed
 here in the constitution, not a skill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.12] — 2026-07-28
+
+**Two fixes for the "reinvent instead of reuse" pattern: `cb_update` now installs the guardian hook, and a new `voicing` skill.**
+
+Diagnosing why one course repo "always did things differently" surfaced two gaps of the same shape — an agent reinventing what already exists because nothing pointed it at the real thing:
+
+- **`cb_update` now ensures the `grade_guardian` hook.** An audit found one repo (init'd before the hook feature, later `cb_update`d only for skills) was the *only* one without the guardian — so its agents could hand-write Canvas writes and route around gates freely. `cb_update` installed skills + pointer but never the hook. It now does (idempotent, non-clobbering, guarded on the vendored script), so any repo brought current gets the enforcement. Run `cb_update --apply` to backfill it.
+- **New `voicing` skill.** Agents kept inventing a fresh feedback voice per session instead of using the instructor's established one. The skill carries the discipline — load the course's voicing profile (`VOICING.md` / `grading/voicing.md`, Zone-1) and write in that voice for *every* comment; never invent one; if none exists, elicit it and save it for reuse. Loads alongside `grading`. Seventh operating-mode skill.
+
+---
+
 ## [1.8.11] — 2026-07-28
 
 **Grading skill: a "fresh data before any grading decision" discipline (field-driven).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -12,6 +12,41 @@ _TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
 if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
+import json  # noqa: E402
+from cb_update import ensure_guardian_hook  # noqa: E402
+
+
+def _fake_toolkit(tmp_path):
+    """A course root with a vendored canvas-toolbox/lib/tools/grade_guardian.py."""
+    g = tmp_path / "canvas-toolbox" / "lib" / "tools"
+    g.mkdir(parents=True)
+    (g / "grade_guardian.py").write_text("# guardian\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_ensure_guardian_hook_installs_when_missing(tmp_path):
+    """The CSE450 gap: a repo cb_update'd for skills but never given the guardian.
+    cb_update now installs it (non-clobbering, idempotent)."""
+    course = _fake_toolkit(tmp_path)
+    assert ensure_guardian_hook(course, "canvas-toolbox", apply=False) == "would-install"
+    assert not (course / ".claude" / "settings.json").exists()   # dry-run wrote nothing
+    assert ensure_guardian_hook(course, "canvas-toolbox", apply=True) == "installed"
+    settings = json.loads((course / ".claude" / "settings.json").read_text(encoding="utf-8"))
+    assert "grade_guardian" in json.dumps(settings)               # hook wired
+    assert ensure_guardian_hook(course, "canvas-toolbox", apply=True) == "present"  # idempotent
+
+
+def test_ensure_guardian_hook_skips_without_vendored_script(tmp_path):
+    assert ensure_guardian_hook(tmp_path, "canvas-toolbox", apply=True) == "skipped-no-script"
+
+
+def test_ensure_guardian_hook_refuses_unparseable_settings(tmp_path):
+    course = _fake_toolkit(tmp_path)
+    (course / ".claude").mkdir()
+    (course / ".claude" / "settings.json").write_text("{not json", encoding="utf-8")
+    assert ensure_guardian_hook(course, "canvas-toolbox", apply=True) == "bad-json"
+
+
 from cb_update import (  # noqa: E402
     plan_skill_symlinks,
     install_skill_symlinks,

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -28,6 +28,7 @@ hand-typing `cd` + `git pull` into the wrong repo.
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import shutil
 import subprocess
@@ -48,7 +49,13 @@ except ImportError:
 from cb_init import detect_course_context, REPO_ROOT
 from sync_grading_protocol import inject_grading_pointer
 
-SKILLS = ["grading", "course-build", "audit", "accommodations", "ferpa-deid", "title-iv"]
+try:
+    from grade_guardian import ensure_hook as _ensure_guardian_hook
+except ImportError:
+    _ensure_guardian_hook = None
+
+SKILLS = ["grading", "course-build", "audit", "accommodations", "ferpa-deid",
+          "title-iv", "voicing"]
 
 
 def plan_skill_symlinks(course_root: Path, toolkit_subdir: str,
@@ -147,6 +154,35 @@ def refresh_pointer(course_root: Path, apply: bool) -> tuple[str, str]:
     return (path.name, "refreshed")
 
 
+def ensure_guardian_hook(course_root: Path, toolkit_subdir: str, apply: bool) -> str:
+    """Install the grade_guardian PreToolUse hook into the course's
+    `.claude/settings.json` if missing — THE most important safety piece. A repo
+    init'd before the hook feature (and only ever `cb_update`d for skills) has none,
+    so its agents can hand-write Canvas writes and route around gates freely — the
+    'one repo without the hook does everything differently' situation. Idempotent,
+    non-clobbering, guarded on the vendored guardian script existing. Returns
+    present/would-install/installed/skipped-no-script/bad-json."""
+    if _ensure_guardian_hook is None:
+        return "skipped-no-script"
+    guardian = course_root / toolkit_subdir / "lib" / "tools" / "grade_guardian.py"
+    if not guardian.is_file():
+        return "skipped-no-script"
+    settings_path = course_root / ".claude" / "settings.json"
+    try:
+        existing = (json.loads(settings_path.read_text(encoding="utf-8"))
+                    if settings_path.exists() else {})
+    except (OSError, ValueError):
+        return "bad-json"                     # never clobber an unparseable settings file
+    new_settings, changed = _ensure_guardian_hook(existing)
+    if not changed:
+        return "present"
+    if not apply:
+        return "would-install"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(new_settings, indent=2) + "\n", encoding="utf-8")
+    return "installed"
+
+
 def main() -> int:
     force_utf8_console()
     ap = argparse.ArgumentParser(
@@ -190,6 +226,12 @@ def main() -> int:
 
     fname, status = refresh_pointer(course_root, args.apply)
     print(f"\nConstitution+skills pointer in {fname}: {status}")
+
+    hook_status = ensure_guardian_hook(course_root, toolkit_subdir, args.apply)
+    print(f"grade_guardian hook (.claude/settings.json): {hook_status}")
+    if hook_status in ("installed", "would-install"):
+        print("  ↳ this repo was missing the guardian — agents could hand-write "
+              "Canvas writes / bypass gates. Now enforced at create/edit/run.")
 
     print("\nReminder: `cd " + toolkit_subdir + " && git pull` keeps the toolkit "
           "(and the symlinked skills) current.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.11"
+version = "1.8.12"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.9"
+version = "1.8.11"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Diagnosing why one repo *always did things differently* surfaced two **reinvent-instead-of-reuse** gaps of the same shape:

## 1. cb_update now ensures the guardian hook
An audit found one repo — init'd before the hook feature, later `cb_update`d only for skills — was the **only one without the `grade_guardian` hook**. Its agents could hand-write Canvas writes and route around gates freely, because nothing stopped them. `cb_update` installed skills + pointer but **never the hook**. Now it does (reusing `grade_guardian.ensure_hook`; idempotent, non-clobbering, guarded on the vendored script) — so any repo brought current gets the enforcement. `cb_update --apply` backfills it.

## 2. New `voicing` skill (7th operating mode)
Agents kept inventing a fresh feedback voice per session instead of the instructor's established one. The skill carries the discipline: **load the course's voicing profile** (`VOICING.md` / `grading/voicing.md`, Zone-1) and write **every** student-facing comment in that voice; never invent one; if none exists, elicit it and **save it for reuse**. Loads alongside `grading`.

## Tests
3 new for `ensure_guardian_hook` (would-install / installed+idempotent / skips-no-script / refuses-bad-json); all 7 skills validate; cb_update suite 12 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)