### PR TITLE
feat(voicing skill): real convention + template derived from the actual profiles

### DIFF
--- a/.claude/skills/voicing/FEEDBACK_VOICE.template.md
+++ b/.claude/skills/voicing/FEEDBACK_VOICE.template.md
@@ -1,0 +1,58 @@
+# Student Feedback Voice — <COURSE>
+
+<!--
+The instructor's grading-comment voice. The `voicing` skill loads this before
+drafting ANY student-facing comment and writes in this voice. Keep it CONCRETE —
+rules + real examples, not abstractions. Zone-1: it's the instructor's voice, NOT
+student PII, so it's safe to commit — but keep student names OUT of the examples.
+Derived from the shared structure of the DS250 / ITM327 / DS460 voice files.
+Delete these comments as you fill it in.
+-->
+
+## Framing — where this voice comes from
+
+<!-- 1–3 lines: the source of the voice. The syllabus competency framing, the
+program's tone, "learned from <instructor>'s edits on <date>". -->
+
+## Core principles
+
+<!-- The 3–6 essentials of how feedback reads. Bullet list. e.g.: second person,
+specific over generic, name the one thing to fix, warm but not effusive, short. -->
+-
+
+## Banned jargon (hard rule)
+
+<!-- Words/phrases that read as "AI" or off-voice — NEVER use them. List concretely.
+e.g. "delve", "leverage", "robust", "it's worth noting", "furthermore". -->
+-
+
+## Template openers — keep them
+
+<!-- Intentional opener/closer conventions to preserve (near-)verbatim. Some courses
+have fixed frames the instructor wants kept; list them here so agents don't "improve"
+them away. -->
+
+## Comment structure (by assignment type)
+
+<!-- The shape of a comment for EACH kind of assignment: what to lead with, the
+order, length, and how to deliver criticism. One block per type. Add/remove types. -->
+
+### <Assignment type — e.g. KC / coding challenge>
+<!-- lead with … then … criticism as … close with … (target length) -->
+
+### <Assignment type — e.g. performance review / milestone>
+
+### <Assignment type — e.g. final-letter / end-of-term note>
+
+## Before / after — what "too AI" looks like
+
+<!-- 1–3 short pairs. The sharpest teaching signal. NO student names. -->
+
+**Too AI:** <a generic, jargon-y version>
+**In voice:** <the corrected version>
+
+## Hard rules / poka-yokes
+
+<!-- Non-negotiables. e.g. "never blame a student for the course's own
+inconsistency", "never invent a score", "no praise sandwich", course must-nots. -->
+-

--- a/.claude/skills/voicing/SKILL.md
+++ b/.claude/skills/voicing/SKILL.md
@@ -17,30 +17,39 @@ write in that voice. Never make up a new one when a profile exists.**
 
 ## Find the profile (check, in order)
 
-1. `VOICING.md` at the course root
-2. `grading/voicing.md` (or `grading/voicing_profile.md`)
-3. A location the course `AGENTS.md` points to (some courses name their own)
+1. **`grading/FEEDBACK_VOICE.md`** — the canonical location (what DS250 / ITM327 use)
+2. `grading/tasks/feedback_voice*.md` or `agents/knowledge/student_feedback_voice*.md`
+   — older/alt spots some courses used before the convention settled
+3. A location the course `AGENTS.md` names (some courses point to their own)
 
 The profile is course context (the instructor's voice — **not** student PII), so it's
 Zone-1: safe to read and to commit. Read it fully before you write.
 
-## Apply it
+## The standard structure
 
-A voicing profile typically pins: overall tone (warm / direct / formal), how to open
-and close, how to deliver criticism (sandwich? straight?), encouragement style,
-signature phrases to **use** and ones to **avoid**, length, and second-person vs
-third. Match all of it. When the profile and a rubric conflict on wording, the rubric
-governs *what* you say; the profile governs *how* you say it.
+Profiles follow a shared skeleton (see `FEEDBACK_VOICE.template.md` in this skill) —
+so once you know it, you can read any course's profile fast:
+
+- **Core principles** — how feedback should read (second person, specific, short, …)
+- **Banned jargon (hard rule)** — words/phrases that read as "AI"; NEVER use them
+- **Template openers — keep them** — intentional frames to preserve, not "improve"
+- **Comment structure (by assignment type)** — the shape per KC / milestone / review /
+  final-letter: what to lead with, order, length, how to deliver criticism
+- **Before / after** — "too AI" vs in-voice pairs (the sharpest signal)
+- **Hard rules / poka-yokes** — non-negotiables (e.g. never blame a student for the
+  course's own inconsistency)
+
+Apply **all** of it. When the profile and a rubric conflict, the rubric governs *what*
+you say; the profile governs *how* you say it.
 
 ## If there is no profile yet
 
 Do **not** silently invent one. Instead:
-1. Ask the instructor a few quick questions — tone, how they like to open/close,
-   phrases they love/hate, how blunt to be about problems.
-2. Draft a short profile from their answers **and their existing comments** if any
-   are available for reference.
-3. Save it to `VOICING.md` (or `grading/voicing.md`) so **every future comment reuses
-   it** — that's the whole point. Confirm the save with the instructor.
+1. Copy `FEEDBACK_VOICE.template.md` (in this skill) as the structure.
+2. Fill it from the instructor — ask about tone, openers/closers, jargon they hate,
+   how blunt to be — **and** from their existing edited comments if any are available.
+3. Save it to **`grading/FEEDBACK_VOICE.md`** so every future comment reuses it — that's
+   the whole point. Confirm the save with the instructor.
 
 ## Where this plugs in
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.8.13] — 2026-07-28
+
+**`voicing` skill: real convention + a template derived from the actual course profiles.**
+
+Read the voice files that already exist across the repos and found the real convention is **`grading/FEEDBACK_VOICE.md`** (not the `VOICING.md` the skill first guessed), with a shared structure — Core principles · Banned jargon · Template openers · Comment structure by assignment type · Before/after · Hard rules/poka-yokes. Captured that as **`FEEDBACK_VOICE.template.md`** in the skill (so a new profile has a known shape), and pointed the skill at the real location plus the alt spots some courses use (`agents/knowledge/student_feedback_voice*.md`) — which is exactly why one repo's agents kept missing its profile and inventing a new voice: the profile lived at a non-standard path.
+
+---
+
 ## [1.8.12] — 2026-07-28
 
 **Two fixes for the "reinvent instead of reuse" pattern: `cb_update` now installs the guardian hook, and a new `voicing` skill.**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.12"
+version = "1.8.13"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.11"
+version = "1.8.13"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Read the voice files that already exist across the repos. The real convention is **`grading/FEEDBACK_VOICE.md`** (DS250, ITM327), not the `VOICING.md` the skill first guessed — and they share a structure: Core principles / Banned jargon / Template openers / Comment structure by assignment type / Before-after / Hard rules-poka-yokes. Captured it as **`FEEDBACK_VOICE.template.md`** in the skill (a known shape for new profiles) and pointed the skill at the real location + the alt spots some courses use (`agents/knowledge/student_feedback_voice*.md`). That non-standard path is exactly why one repo's agents kept missing its profile and inventing a new voice. 12 cb_update tests pass; 8 skills validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)