### PR TITLE
feat(grader_push): chat-approval push — honor --yes, guardian forces in-chat ask (#264)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -37,40 +37,52 @@ fresh fetch each run — never read a cached custom CSV whose age you can't see.
 Principle **HG-5** of the [hybrid grading architecture](../../../lib/agents/knowledge/grader_hybrid_architecture.md):
 the agent drafts; the instructor reviews and confirms; only then does anything post.
 
-### The push protocol — never skip a step
+### The push protocol — you run all of it; the human approves in chat
+
+**You are not blocked from pushing.** Run the whole flow yourself — never send the
+instructor to a terminal (that dead-ended non-technical faculty). The human gate is an
+in-chat permission prompt, not a shell keystroke.
 
 1. **Grade** — `grader_fetch.py --challenge-dir grading/<name>` → 3-pass consensus
    (`grader_grade.py --bulk` → `grader_consensus.py`). Single-pass LLM grading
    drifts; consensus is the default.
-2. **Review** — a **human** reads `feedback/_all_comments.md` + each per-student
-   `<KEY>.md`. This is the gate, not a formality.
-3. **Attest** — `grader_push.py --challenge-dir grading/<name> --mark-reviewed`.
-   The human types `reviewed`. The marker auto-invalidates if any feedback file
-   changes afterward.
-4. **Push** — `grader_push.py --challenge-dir grading/<name> --push`. The human
-   types `push` at the confirmation.
+2. **Show the review surface in the conversation** — present `feedback/_all_comments.md`
+   + the per-student `<KEY>.md` and the **old→new grade preview** (dry-run) right here in
+   chat. This IS the review. Wait for the instructor to approve in a reply.
+3. **Attest** — after they approve, run
+   `grader_push.py --challenge-dir grading/<name> --mark-reviewed --yes`. The `.reviewed`
+   marker records the attested state (auto-invalidates if a feedback file changes after).
+4. **Push** — run `grader_push.py --challenge-dir grading/<name> --push --yes`. The
+   `grade_guardian` hook forces a permission **prompt** in the chat; the instructor
+   **clicks allow** — that click is the human gate (#264). No terminal, ever.
 
 ## What the code enforces (so the protocol isn't docs-only)
 
-- **`--yes` cannot bypass human review on the AI-drafted path.** With per-student
-  comment files, `--yes` is refused at *both* `--mark-reviewed` (#97) and the final
-  `--push` (#207, HG-5). The value-only / human-graded path (no comment files) keeps
-  `--yes` — there the human *is* the grader.
-- **Confirmation requires a real terminal (#241).** The `reviewed`/`push` prompts
-  refuse piped/redirected stdin — `echo push | grader_push …` no longer satisfies
-  the gate. If you are an assistant and hit this prompt, **hand the command to the
-  instructor to run in their terminal**; do not pipe an answer and do not stack
-  `--yes`/`--regrade`/`--grade-only`/`--allow-enrolled` to force it.
+- **`--yes` is honored on every path — including AI-drafted comments (#264).** You run
+  `--mark-reviewed --yes` then `--push --yes`. Do not tell the instructor to open a
+  terminal or type `reviewed`/`push` at a shell; do not pipe answers on stdin.
+- **The human gate is the in-chat permission prompt.** On the AI-drafted `--push`,
+  `grade_guardian` returns an `ask` decision, so Claude Code prompts the instructor to
+  approve the write; their click is the attestation that replaced the terminal keystroke.
+  (Value-only / `grader_standing` pushes don't prompt — the human is the grader there.)
 - **Duplicate-comment Andon.** Canvas *appends* comments, so re-runs stack them.
   Default mode refuses an already-graded submission; `--regrade` admits ONLY
   genuine resubmissions and *supersedes* (deletes old grader comments) rather than
   appending.
+- **When rows are SKIPPED, read why — never reach for the API.** grader_push skips
+  already-pushed rows (re-push with `--regrade`), rows that would LOWER an existing
+  grade (`--allow-lower`), and inactive/Test students (#61 — `--include-inactive`). The
+  fix is always a flag *on the tool*; a hand-written `requests`/`python -c` write skips
+  every safeguard and the guardian blocks it anyway.
 - **Disclosure is mandatory** (see the menu below), appended automatically.
 
-**Do not** run `grader_push.py --yes --push` to "just get the grades in." That is
-the exact HG-5 breach an [RCA](https://github.com/chaz-clark/canvas-toolbox/issues/207)
-was written about — students received AI-drafted grades with no review. If a gate
-blocks you, the fix is to *do the review*, not to reach for an override.
+**The in-chat review is the gate, not a rubber-stamp.** The failure an
+[RCA](https://github.com/chaz-clark/canvas-toolbox/issues/207) was written about was
+students getting AI-drafted grades with *no* review. `--yes --push` is the sanctioned
+path now — but only because the review moved into the conversation and the guardian
+prompt makes the instructor consciously approve the write. So actually show the comments
+and the old→new grades and get a real "yes" before you push; never stack overrides to
+skip a gate you hit.
 
 ## Never hand-write a Canvas write (the field failure mode)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.9.0] — 2026-07-28
+
+**Grade push moves off the terminal: `--yes` is honored on the AI-drafted path, and the human gate becomes an in-chat permission prompt (#264).**
+
+Field use kept hitting the same wall: on the AI-drafted-comment path `grader_push` refused `--yes` (#97/#207) and demanded a keystroke at a real terminal (#241), so agents dead-ended non-technical faculty with "run this in your terminal and type 'reviewed'/'push'" — or thrashed and reached for a direct Canvas API write. That terminal gate was aimed at the wrong threat (a headless `echo push | …` bypass), not the interactive instructor sitting in the Claude Code chat.
+
+- **`grader_push` honors `--yes` on every path.** The `is_yes_refused_on_review` refusal is removed; `--mark-reviewed --yes` and `--push --yes` now work for AI-drafted comments too. The agent runs the whole flow — no terminal keystroke, ever. The `.reviewed` marker reverts to its staleness-guard role (#46), not a human attestation.
+- **`grade_guardian` forces an in-chat `ask` on the AI-drafted push.** The human gate moved UP to the PreToolUse hook: on a `grader_push … --push` that writes per-student comments (not `--grade-only`/`--test-user`/`--retract`), the guardian returns `permissionDecision: "ask"`, so Claude Code prompts the instructor to approve the write. Their click is the attestation that replaced the keystroke — un-fakeable by the agent, never a separate terminal. (In full bypass-permissions mode nothing prompts — an explicit opt-out.)
+- **`grading` skill rewritten to the chat-approval flow.** "You are not blocked from pushing": show the comments + old→new preview in chat, get the instructor's reply, `--mark-reviewed --yes`, `--push --yes` → the guardian prompt is the gate. Adds a "when rows are skipped, read why (`--regrade`/`--allow-lower`/`--include-inactive`) — never reach for the API" note, straight from a field session that thrashed through override flags after a push skipped most rows.
+
+Value-only / `grader_standing` pushes are unchanged (the human is the grader there; `--yes` was always allowed).
+
+---
+
 ## [1.8.13] — 2026-07-28
 
 **`voicing` skill: real convention + a template derived from the actual course profiles.**

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -15,7 +15,7 @@ if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
 from grade_guardian import (evaluate, ensure_hook, hook_command,  # noqa: E402
-                            _extract_script_paths)
+                            _extract_script_paths, ask_reason, _is_ai_drafted_push)
 
 _BYPASS_BODY = ('import requests\n'
                 'requests.put("https://x.instructure.com/api/v1/courses/1/assignments/2/'
@@ -249,3 +249,44 @@ def test_hook_fails_open_on_garbage_stdin():
     r = subprocess.run([sys.executable, str(HOOK)], input="not json",
                        capture_output=True, text=True)
     assert r.returncode == 0
+
+
+# --- ASK layer (#264): force an in-chat prompt on the AI-drafted grade push ---
+
+def test_asks_on_ai_drafted_push():
+    """grader_push --push writing AI-drafted comments → the guardian asks (the human
+    review gate moved here now that --yes is honored, so no terminal keystroke)."""
+    cmd = "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --push"
+    assert _is_ai_drafted_push(cmd) is True
+    assert ask_reason("Bash", {"command": cmd}) is not None
+
+
+def test_no_ask_on_dry_run():
+    """No --push (dry-run) is not a write — no prompt."""
+    cmd = "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --assignment-id 5"
+    assert ask_reason("Bash", {"command": cmd}) is None
+
+
+def test_no_ask_on_value_only_and_test_and_retract():
+    """Value-only (--grade-only), test-student (--test-user), and retract (--retract)
+    are not AI-drafted-comment writes — they keep the frictionless --yes path."""
+    base = "python lib/tools/grader_push.py --challenge-dir grading/kc3 --push"
+    for extra in ("--grade-only", "--test-user 1234", "--retract"):
+        assert ask_reason("Bash", {"command": f"{base} {extra}"}) is None, extra
+
+
+def test_no_ask_on_non_grader_push_or_other_tools():
+    assert ask_reason("Bash", {"command": "git push origin main"}) is None  # --push, not grader
+    assert ask_reason("Write", {"file_path": "x.py", "content": "grader_push --push"}) is None
+
+
+def test_hook_emits_ask_json_on_ai_drafted_push():
+    """End-to-end: the real hook prints permissionDecision 'ask' (exit 0) so Claude
+    Code prompts the instructor — the in-chat attestation that replaced the terminal."""
+    r = _run_hook({"tool_name": "Bash", "tool_input": {"command":
+        "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --push"}})
+    assert r.returncode == 0
+    out = json.loads(r.stdout)
+    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert out["hookSpecificOutput"]["permissionDecisionReason"]

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -20,7 +20,6 @@ from grader_push import (  # noqa: E402
     consensus_gate_status,
     normalize_grade,
     regression_check,
-    is_yes_refused_on_review,
     truncate_comment_preview,
     validate_grade_for_grading_type,
     is_group_mirror_row,
@@ -458,38 +457,11 @@ def test_regression_check_new_empty_is_mismatch_not_silent():
 
 
 # ---------------------------------------------------------------------------
-# is_yes_refused_on_review — issue #97 (review-gate attestation)
+# Chat-approval model (#264): --yes is now HONORED on the AI-drafted path — the old
+# is_yes_refused_on_review refusal was removed. The human gate moved to the
+# grade_guardian 'ask' permission prompt on the push; that behavior is covered in
+# test_grade_guardian.py (test_asks_on_ai_drafted_push et al.), not here.
 # ---------------------------------------------------------------------------
-
-def test_yes_refused_when_comment_files_exist():
-    """LLM-comment review path + --yes → refused. The agent flow that
-    motivated #97: write _all_comments.md + per-student .md files,
-    then immediately --mark-reviewed --yes to self-attest. Now blocked."""
-    fake_files = [Path("/tmp/KC1-A1B2C3.md")]
-    assert is_yes_refused_on_review(fake_files, yes_flag=True) is True
-
-
-def test_yes_allowed_when_no_comment_files():
-    """Value-only / human-graded path (no LLM comment .md files) keeps
-    --yes — the human IS the grader; --yes is a script convenience there."""
-    assert is_yes_refused_on_review([], yes_flag=True) is False
-
-
-def test_no_yes_allowed_regardless_of_path():
-    """Without --yes, the interactive 'Type reviewed' prompt runs regardless
-    of which sub-path; the helper returns False both times."""
-    assert is_yes_refused_on_review([Path("/tmp/x.md")], yes_flag=False) is False
-    assert is_yes_refused_on_review([], yes_flag=False) is False
-
-
-def test_yes_refused_does_not_depend_on_file_count():
-    """One comment file is enough to count as the LLM-comment path; the
-    refusal isn't gated by N >= some-threshold (a single missed review
-    is still a missed review)."""
-    one_file = [Path("/tmp/KC1-A1B2C3.md")]
-    assert is_yes_refused_on_review(one_file, yes_flag=True) is True
-    many_files = [Path(f"/tmp/KC1-XXX{i}.md") for i in range(10)]
-    assert is_yes_refused_on_review(many_files, yes_flag=True) is True
 
 
 # ---------------------------------------------------------------------------

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -24,6 +24,14 @@ WHAT IT DENIES
   - Read: FERPA Zone-2 files (.deid_master.csv et al.) — the AGENTS.md discipline,
     enforced deterministically instead of by instruction (#212).
 
+WHAT IT ASKS (does not deny — forces a human prompt) (#264)
+  - Bash: a grader_push.py --push that writes AI-drafted comments (not --grade-only /
+    --test-user / --retract). grader_push now honors --yes on that path (no terminal
+    keystroke — that dead-ended non-technical faculty at a shell), so the human review
+    gate lives HERE: the hook returns permissionDecision "ask", forcing Claude Code to
+    prompt the instructor. Their in-chat click is the attestation. (In full
+    bypass-permissions mode nothing prompts — an explicit opt-out, honestly out of scope.)
+
 WHAT IT DOES NOT DO (honest limits)
   Regex on a command / file body is not a semantic firewall. A determined agent
   can obfuscate (eval, base64, variable indirection) past it. This decisively
@@ -186,6 +194,38 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# ASK layer (#264): force a human permission prompt on the AI-drafted grade push.
+# grader_push now honors --yes there (no terminal keystroke), so the human review
+# gate is this hook forcing Claude Code to ask — the instructor's click attests.
+# ---------------------------------------------------------------------------
+
+def _is_ai_drafted_push(cmd: str) -> bool:
+    """True for a grader_push invocation that writes AI-drafted comments to a live
+    course — the write the instructor must approve in-chat. Excludes the value-only
+    (--grade-only), test-student (--test-user), and retract (--retract) paths."""
+    if "grader_push" not in cmd or not re.search(r"--push\b", cmd):
+        return False
+    return not any(re.search(re.escape(f) + r"\b", cmd)
+                   for f in ("--grade-only", "--test-user", "--retract"))
+
+
+def ask_reason(tool_name: str, tool_input: dict) -> str | None:
+    """Return a permission-prompt reason if this call is an AI-drafted grade push the
+    instructor should confirm, else None. Pure function — unit-testable without Claude
+    Code. main() turns a non-None reason into a permissionDecision 'ask'."""
+    tool_input = tool_input or {}
+    if tool_name != "Bash":
+        return None
+    if not _is_ai_drafted_push(tool_input.get("command", "") or ""):
+        return None
+    return (
+        "Human review gate (HG-5, #264): this pushes AI-drafted feedback + grades to "
+        "students on a LIVE course. Approve only after reviewing the comments and the "
+        "old→new grade preview the agent showed you. Allow = send; Deny = hold."
+    )
+
+
+# ---------------------------------------------------------------------------
 # Installer helpers — cb_init wires this hook into a course repo's settings.json.
 # Single-sourced here so the matcher/command never drift from the hook itself.
 # ---------------------------------------------------------------------------
@@ -229,19 +269,35 @@ def ensure_hook(settings: dict) -> tuple:
     return settings, True
 
 
+def _emit_ask(reason: str) -> None:
+    """Print the PreToolUse JSON that forces Claude Code to prompt the instructor
+    (permissionDecision 'ask'). Exit 0 accompanies it — stdout JSON drives the
+    decision; exit 2 would instead hard-block (deny)."""
+    print(json.dumps({"hookSpecificOutput": {
+        "hookEventName": "PreToolUse",
+        "permissionDecision": "ask",
+        "permissionDecisionReason": reason,
+    }}))
+
+
 def main() -> int:
     if "--help" in sys.argv[1:]:
-        print("PreToolUse hook (issue #213). Reads a tool call as JSON on stdin; "
-              "exits 2 to block a direct Canvas grade write. Not an operator CLI.")
+        print("PreToolUse hook (issue #213/#264). Reads a tool call as JSON on stdin; "
+              "exits 2 to block a direct Canvas grade write, or emits an 'ask' JSON to "
+              "prompt the instructor before an AI-drafted grade push. Not an operator CLI.")
         return 0
     try:
         data = json.load(sys.stdin)
     except (json.JSONDecodeError, ValueError, OSError):
         return 0  # fail open — never break the session on bad/empty input
-    reason = evaluate(data.get("tool_name", ""), data.get("tool_input", {}))
+    tool_name, tool_input = data.get("tool_name", ""), data.get("tool_input", {})
+    reason = evaluate(tool_name, tool_input)
     if reason:
         print(reason, file=sys.stderr)
         return 2
+    ask = ask_reason(tool_name, tool_input)
+    if ask:
+        _emit_ask(ask)
     return 0
 
 

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -22,11 +22,12 @@ WHAT IT DOES
 GUARDRAILS (no override on the first three)
   1. --mark-reviewed REQUIRED before --push. Marker auto-invalidates if any
      comment file mtime > marker mtime (you can't approve a state and then
-     mutate it). **Issue #207 (HG-5)** — on the AI-drafted (LLM-comment)
-     push path, --yes does NOT bypass the final "type 'push'" confirmation:
-     an agent can pass --yes, but the instructor is the top layer and must
-     decide the write. A deprecated disclosure tag in any comment file
-     refuses the push (override: --allow-bad-disclosure-tags).
+     mutate it). **HG-5 chat-approval (#264)** — on the AI-drafted (LLM-comment)
+     path, --yes IS honored (no terminal keystroke — that dead-ended non-technical
+     faculty at a shell). The human gate moved UP to the grade_guardian PreToolUse
+     hook, which forces an 'ask' permission prompt on the --push write: the
+     instructor's in-chat click is the attestation. A deprecated disclosure tag in
+     any comment file refuses the push (override: --allow-bad-disclosure-tags).
   2. canvas_course_guard refuses live-course writes unless --allow-enrolled
      is passed. The toolkit's standing safety bar.
   3. Per-assignment idempotency. Keys already in the .push_log.md scoped to
@@ -651,32 +652,6 @@ def truncate_comment_preview(text: str | None, limit: int = 240) -> str:
     return snippet
 
 
-def is_yes_refused_on_review(comment_files: list, yes_flag: bool) -> bool:
-    """Issue #97: --yes is refused on the LLM-comment review path.
-
-    The `.reviewed` marker attests that a HUMAN reviewed
-    `feedback/_all_comments.md` (+ each per-student `<KEY>.md`
-    justification). A grading agent under the keyless protocol can pass
-    `--yes` and self-attest review — that collapses the
-    human-in-the-middle gate. The fix is to refuse the combination on
-    the path where comment files exist (LLM-comment grading).
-
-    The value-only / human-graded path keeps `--yes` (the human IS the
-    grader; `--yes` there is a script convenience, not an attestation
-    bypass).
-
-    Issue #207 (HG-5): the same helper also gates the FINAL push
-    confirmation. #97 closed the bypass on `--mark-reviewed`, but `--yes`
-    still skipped the "type 'push'" prompt afterward — so an agent that
-    re-marks reviewed could chain `--push --yes` and post AI-drafted
-    feedback with no human keystroke. On the LLM-comment path, the
-    instructor (the top layer) must physically confirm the write.
-
-    Returns True if the caller should refuse the command and exit.
-    """
-    return bool(comment_files) and bool(yes_flag)
-
-
 def is_group_mirror_row(row: dict) -> bool:
     """Issue #100: a .review.csv row is a 'group mirror' if its
     `group_mirror_of` column is non-empty — it's not the representative
@@ -1208,11 +1183,12 @@ def main() -> int:
                          "uses a MANUAL posting policy — otherwise grades are entered but hidden "
                          "from students and read as 'needs grading' (issue #199).")
     ap.add_argument("--yes", action="store_true",
-                    help="Skip the confirmation prompt. NOTE: REFUSED on the "
-                         "LLM-comment --mark-reviewed path (issue #97) — a human "
-                         "must physically type 'reviewed' there to attest review "
-                         "of _all_comments.md. Works on the value-only / "
-                         "human-graded review path + on the main --push prompt.")
+                    help="Skip the terminal confirmation prompt — honored on ALL paths, "
+                         "including the AI-drafted (LLM-comment) --mark-reviewed / --push "
+                         "path (#264). The human gate is no longer a terminal keystroke "
+                         "but the grade_guardian 'ask' permission prompt on the push; the "
+                         "agent shows the review surface in-chat and the instructor "
+                         "approves in a reply, then clicks the prompt.")
     ap.add_argument("--allow-enrolled", action="store_true",
                     help="Bypass canvas_course_guard for enrolled-course writes (instructor's own course).")
     ap.add_argument("--test-user", type=int,
@@ -1409,25 +1385,13 @@ def main() -> int:
                   "a review surface.", file=sys.stderr)
             return 1
 
-        # Issue #97: refuse --yes on the LLM-comment review path. The risk:
-        # an agent grading on the keyless protocol can self-attest review by
-        # running `grader_push --mark-reviewed --yes` immediately after
-        # writing _all_comments.md, then chain into --push. That collapses
-        # "grade" and "push" — the human-in-the-middle review of
-        # _all_comments.md never happens. The value-only / human-graded
-        # path keeps the --yes shortcut (the human IS the grader; --yes is
-        # a script convenience).
-        if is_yes_refused_on_review(comment_files, args.yes):
-            print(f"\n⛔ --yes is refused on the LLM-comment review path (issue #97).",
-                  file=sys.stderr)
-            print(f"   The .reviewed marker attests human review of "
-                  f"{fbdir.relative_to(challenge)}/_all_comments.md", file=sys.stderr)
-            print(f"   + each per-student {prefix}-*.md justification. An agent can "
-                  f"pass --yes; a human must physically type 'reviewed'.",
-                  file=sys.stderr)
-            print(f"   Fix: re-run WITHOUT --yes; eyeball the comments; type "
-                  f"'reviewed' at the prompt.", file=sys.stderr)
-            return 1
+        # Chat-approval model (#264): --yes is HONORED on the AI-drafted path.
+        # The human-in-the-loop no longer happens as a terminal keystroke here
+        # (that dead-ended non-technical faculty at a shell). Instead the agent
+        # shows the review surface in the conversation, the instructor approves in
+        # a reply, and the agent runs --mark-reviewed --yes. The .reviewed marker
+        # is a staleness guard (#46), not the attestation; the hard human gate is
+        # the grade_guardian 'ask' permission prompt on the --push write.
         if not args.yes and not require_typed_confirmation("\nType 'reviewed' to confirm: ", "reviewed"):
             print("Not marked.")
             return 1
@@ -1798,23 +1762,15 @@ def main() -> int:
             print(b)
         return 1
 
-    # --- HG-5 GATE: instructor is the top layer on the AI-drafted push path ---
-    # Issue #207: the presence of per-student comment files marks the LLM-comment
-    # (AI-drafted) path. On that path --yes must not bypass the final push
-    # confirmation — an agent can pass --yes, but a human must decide to write
-    # AI-drafted feedback to a live course (HG-5: decision support, not autonomy).
-    # The value-only / human-graded path (no comment files) keeps --yes.
+    # --- HG-5, chat-approval model (#264) ---
+    # Per-student comment files mark the AI-drafted (LLM-comment) path. --yes is now
+    # HONORED here: the agent shows the comments + old→new grades IN THE CONVERSATION,
+    # the instructor approves in a reply, and the write goes out. The hard human gate
+    # moved UP to the grade_guardian PreToolUse hook, which forces an 'ask' permission
+    # prompt on this --push — the instructor's in-chat click is the attestation.
+    # #207's terminal keystroke dead-ended non-technical faculty at a shell; the
+    # guardian prompt replaces it without ever sending them to a terminal.
     ai_comment_files = list(fbdir.glob(f"{prefix}-*.md"))
-    if is_yes_refused_on_review(ai_comment_files, args.yes):
-        print("\n⛔ --yes is refused on the AI-drafted push path (issue #207, HG-5).",
-              file=sys.stderr)
-        print("   Pushing AI-drafted feedback to a live course requires the instructor",
-              file=sys.stderr)
-        print("   to confirm the write — the instructor is the top layer and decides.",
-              file=sys.stderr)
-        print("   Fix: re-run WITHOUT --yes; type 'push' at the confirmation prompt.",
-              file=sys.stderr)
-        return 1
 
     # Issue #207: refuse deprecated disclosure-tag formats before writing. A stale
     # tag would get the canonical DISCLOSURE_TAG stacked on top of it at send-time.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.8.13"
+version = "1.9.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Why

Field use (a DS460 grading session, live-transcribed) kept hitting the same wall: on the **AI-drafted-comment** path `grader_push` refused `--yes` (#97/#207) and demanded a keystroke at a real terminal (#241). So the agent either dead-ended non-technical faculty ("run this in your terminal and type `reviewed`/`push`") or, worse, thrashed for minutes and reached for a **direct Canvas API write** to get around it. That terminal gate was aimed at the wrong threat — a headless `echo push | …` bypass — not the interactive instructor sitting in the Claude Code chat, whose replies the agent can't fabricate.

## What

Move the human gate **off the terminal and into the chat**, per the instructor's directive ("no terminal copy-paste"; hardened = force an in-chat prompt):

- **`grader_push` honors `--yes` on every path.** `is_yes_refused_on_review` removed; `--mark-reviewed --yes` and `--push --yes` now work for AI-drafted comments. The `.reviewed` marker reverts to its staleness-guard role (#46), not a human attestation.
- **`grade_guardian` forces an in-chat `ask`.** On a `grader_push … --push` that writes per-student comments (not `--grade-only`/`--test-user`/`--retract`), the PreToolUse hook returns `permissionDecision: "ask"`, so Claude Code prompts the instructor to approve the write. Their **click** is the attestation — un-fakeable by the agent, never a separate terminal. (Full bypass-permissions mode won't prompt — explicit opt-out.)
- **`grading` skill rewritten** to the chat-approval flow ("you are not blocked from pushing"): show comments + old→new preview in chat → instructor replies → `--mark-reviewed --yes` → `--push --yes` → guardian prompt is the gate. Adds a "when rows are skipped, read why (`--regrade`/`--allow-lower`/`--include-inactive`) — never reach for the API" note, straight from the field thrash.

Value-only / `grader_standing` pushes are unchanged (the human is the grader there).

## Verification

- `1091 passed` (full suite); new guardian ask tests (unit + end-to-end JSON) and the removed-refusal tests updated.
- Live: guardian emits `permissionDecision:"ask"` (exit 0) on an AI-drafted `--push`; silent on `--grade-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
