### PR TITLE
fix(grade_guardian): force the ask pop-up at the review checkpoint too (#265)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -37,33 +37,38 @@ fresh fetch each run — never read a cached custom CSV whose age you can't see.
 Principle **HG-5** of the [hybrid grading architecture](../../../lib/agents/knowledge/grader_hybrid_architecture.md):
 the agent drafts; the instructor reviews and confirms; only then does anything post.
 
-### The push protocol — you run all of it; the human approves in chat
+### The push protocol — you run all of it; the human clicks to approve, twice
 
-**You are not blocked from pushing.** Run the whole flow yourself — never send the
-instructor to a terminal (that dead-ended non-technical faculty). The human gate is an
-in-chat permission prompt, not a shell keystroke.
+**You are not blocked from pushing** — but you may **not** skip the review. Run the whole
+flow yourself (never send the instructor to a terminal), and the instructor clicks an
+in-chat pop-up at TWO points: to attest the review, and to authorize the push. You
+cannot click either for them, and you cannot self-attest.
 
 1. **Grade** — `grader_fetch.py --challenge-dir grading/<name>` → 3-pass consensus
    (`grader_grade.py --bulk` → `grader_consensus.py`). Single-pass LLM grading
    drifts; consensus is the default.
-2. **Show the review surface in the conversation** — present `feedback/_all_comments.md`
-   + the per-student `<KEY>.md` and the **old→new grade preview** (dry-run) right here in
-   chat. This IS the review. Wait for the instructor to approve in a reply.
-3. **Attest** — after they approve, run
-   `grader_push.py --challenge-dir grading/<name> --mark-reviewed --yes`. The `.reviewed`
-   marker records the attested state (auto-invalidates if a feedback file changes after).
+2. **Show the review surface in the conversation — mandatory, never skip it.** Present
+   `feedback/_all_comments.md` + the per-student `<KEY>.md` and the **old→new grade
+   preview** (dry-run) right here in chat. This IS the review. Do not run
+   `--mark-reviewed` until you have actually shown the comments.
+3. **Attest** — run `grader_push.py --challenge-dir grading/<name> --mark-reviewed --yes`.
+   The `grade_guardian` hook fires a permission **pop-up** — the instructor clicks Allow
+   to attest they reviewed `_all_comments.md` (Deny if you skipped showing it, #265). The
+   `.reviewed` marker records the attested state (auto-invalidates if a file changes).
 4. **Push** — run `grader_push.py --challenge-dir grading/<name> --push --yes`. The
-   `grade_guardian` hook forces a permission **prompt** in the chat; the instructor
-   **clicks allow** — that click is the human gate (#264). No terminal, ever.
+   `grade_guardian` hook fires a **second** pop-up; the instructor **clicks Allow** — that
+   click authorizes the write (#264). No terminal, ever.
 
 ## What the code enforces (so the protocol isn't docs-only)
 
 - **`--yes` is honored on every path — including AI-drafted comments (#264).** You run
   `--mark-reviewed --yes` then `--push --yes`. Do not tell the instructor to open a
   terminal or type `reviewed`/`push` at a shell; do not pipe answers on stdin.
-- **The human gate is the in-chat permission prompt.** On the AI-drafted `--push`,
-  `grade_guardian` returns an `ask` decision, so Claude Code prompts the instructor to
-  approve the write; their click is the attestation that replaced the terminal keystroke.
+- **The human gate is TWO in-chat pop-ups you cannot skip (#264, #265).** On the
+  AI-drafted path, `grade_guardian` returns an `ask` at BOTH `--mark-reviewed` and
+  `--push`, so Claude Code prompts the instructor to click at each. `--yes` does not
+  bypass these — the hook fires above the tool. This is what stops an agent from running
+  `--mark-reviewed --yes` and self-attesting a review the human never saw.
   (Value-only / `grader_standing` pushes don't prompt — the human is the grader there.)
 - **Duplicate-comment Andon.** Canvas *appends* comments, so re-runs stack them.
   Default mode refuses an already-graded submission; `--regrade` admits ONLY

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.9.1] — 2026-07-28
+
+**Fix: the chat-approval loosening let an agent skip the review — force the pop-up at the review checkpoint too (#265).**
+
+1.9.0 honored `--yes` on the AI-drafted path and put the human gate on the guardian's `--push` prompt. But it left a hole: the agent could run `grader_push --mark-reviewed --yes` and **self-attest review** — marking the comments reviewed without ever showing the instructor `_all_comments.md` — then push. A field session did exactly that.
+
+- **`grade_guardian` now fires the `ask` prompt at BOTH checkpoints** — `--mark-reviewed` *and* `--push` — on the AI-drafted path (still silent on `--grade-only`/`--test-user`/`--retract`). `--yes` cannot bypass it: the hook runs above the tool. So the instructor clicks an in-chat pop-up to **attest the review** (Deny if the agent skipped showing the comments) and again to **authorize the push** — two clicks the agent can neither skip nor forge.
+- **`grading` skill tightened.** The push protocol now says the review is mandatory and never skippable, and documents the two pop-ups (attest, then push). Removed the "just run the flow" phrasing that read as license to skip step 2.
+
+Still no terminal, ever. Value-only / `grader_standing` pushes are unchanged.
+
+---
+
 ## [1.9.0] — 2026-07-28
 
 **Grade push moves off the terminal: `--yes` is honored on the AI-drafted path, and the human gate becomes an in-chat permission prompt (#264).**

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -15,7 +15,7 @@ if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
 from grade_guardian import (evaluate, ensure_hook, hook_command,  # noqa: E402
-                            _extract_script_paths, ask_reason, _is_ai_drafted_push)
+                            _extract_script_paths, ask_reason, _grader_push_checkpoint)
 
 _BYPASS_BODY = ('import requests\n'
                 'requests.put("https://x.instructure.com/api/v1/courses/1/assignments/2/'
@@ -251,28 +251,39 @@ def test_hook_fails_open_on_garbage_stdin():
     assert r.returncode == 0
 
 
-# --- ASK layer (#264): force an in-chat prompt on the AI-drafted grade push ---
+# --- ASK layer (#264, #265): force an in-chat prompt at BOTH AI-drafted checkpoints ---
 
 def test_asks_on_ai_drafted_push():
     """grader_push --push writing AI-drafted comments → the guardian asks (the human
     review gate moved here now that --yes is honored, so no terminal keystroke)."""
     cmd = "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --push"
-    assert _is_ai_drafted_push(cmd) is True
+    assert _grader_push_checkpoint(cmd) == "push"
+    assert ask_reason("Bash", {"command": cmd}) is not None
+
+
+def test_asks_on_mark_reviewed():
+    """#265: --mark-reviewed must ALSO prompt — else an agent runs `--mark-reviewed
+    --yes` and self-attests review without ever showing the human _all_comments.md."""
+    cmd = "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --mark-reviewed --yes"
+    assert _grader_push_checkpoint(cmd) == "review"
     assert ask_reason("Bash", {"command": cmd}) is not None
 
 
 def test_no_ask_on_dry_run():
-    """No --push (dry-run) is not a write — no prompt."""
+    """No --push / --mark-reviewed (dry-run) is not a checkpoint — no prompt."""
     cmd = "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --assignment-id 5"
+    assert _grader_push_checkpoint(cmd) is None
     assert ask_reason("Bash", {"command": cmd}) is None
 
 
 def test_no_ask_on_value_only_and_test_and_retract():
     """Value-only (--grade-only), test-student (--test-user), and retract (--retract)
-    are not AI-drafted-comment writes — they keep the frictionless --yes path."""
-    base = "python lib/tools/grader_push.py --challenge-dir grading/kc3 --push"
-    for extra in ("--grade-only", "--test-user 1234", "--retract"):
-        assert ask_reason("Bash", {"command": f"{base} {extra}"}) is None, extra
+    are not AI-drafted-comment checkpoints — they keep the frictionless --yes path,
+    at both --push and --mark-reviewed."""
+    for verb in ("--push", "--mark-reviewed"):
+        base = f"python lib/tools/grader_push.py --challenge-dir grading/kc3 {verb}"
+        for extra in ("--grade-only", "--test-user 1234", "--retract"):
+            assert ask_reason("Bash", {"command": f"{base} {extra}"}) is None, f"{verb} {extra}"
 
 
 def test_no_ask_on_non_grader_push_or_other_tools():
@@ -283,10 +294,13 @@ def test_no_ask_on_non_grader_push_or_other_tools():
 def test_hook_emits_ask_json_on_ai_drafted_push():
     """End-to-end: the real hook prints permissionDecision 'ask' (exit 0) so Claude
     Code prompts the instructor — the in-chat attestation that replaced the terminal."""
-    r = _run_hook({"tool_name": "Bash", "tool_input": {"command":
-        "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --push"}})
-    assert r.returncode == 0
-    out = json.loads(r.stdout)
-    assert out["hookSpecificOutput"]["permissionDecision"] == "ask"
-    assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
-    assert out["hookSpecificOutput"]["permissionDecisionReason"]
+    for cmd in (
+        "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --push",
+        "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/kc3 --mark-reviewed --yes",
+    ):
+        r = _run_hook({"tool_name": "Bash", "tool_input": {"command": cmd}})
+        assert r.returncode == 0, cmd
+        out = json.loads(r.stdout)
+        assert out["hookSpecificOutput"]["permissionDecision"] == "ask", cmd
+        assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+        assert out["hookSpecificOutput"]["permissionDecisionReason"]

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -24,13 +24,16 @@ WHAT IT DENIES
   - Read: FERPA Zone-2 files (.deid_master.csv et al.) — the AGENTS.md discipline,
     enforced deterministically instead of by instruction (#212).
 
-WHAT IT ASKS (does not deny — forces a human prompt) (#264)
-  - Bash: a grader_push.py --push that writes AI-drafted comments (not --grade-only /
-    --test-user / --retract). grader_push now honors --yes on that path (no terminal
-    keystroke — that dead-ended non-technical faculty at a shell), so the human review
-    gate lives HERE: the hook returns permissionDecision "ask", forcing Claude Code to
-    prompt the instructor. Their in-chat click is the attestation. (In full
-    bypass-permissions mode nothing prompts — an explicit opt-out, honestly out of scope.)
+WHAT IT ASKS (does not deny — forces a human prompt) (#264, #265)
+  - Bash: a grader_push.py AI-drafted checkpoint (not --grade-only / --test-user /
+    --retract) — at BOTH --mark-reviewed (the review attestation) and --push (the
+    write). grader_push honors --yes on that path (no terminal keystroke — that
+    dead-ended non-technical faculty at a shell), so an agent could `--mark-reviewed
+    --yes` and self-attest review without ever showing the human _all_comments.md,
+    then push (#265). The hook returns permissionDecision "ask" at each checkpoint,
+    forcing Claude Code to prompt the instructor; their in-chat click is the
+    attestation the agent cannot skip or forge. (In full bypass-permissions mode
+    nothing prompts — an explicit opt-out, honestly out of scope.)
 
 WHAT IT DOES NOT DO (honest limits)
   Regex on a command / file body is not a semantic firewall. A determined agent
@@ -194,35 +197,57 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
 
 
 # ---------------------------------------------------------------------------
-# ASK layer (#264): force a human permission prompt on the AI-drafted grade push.
-# grader_push now honors --yes there (no terminal keystroke), so the human review
-# gate is this hook forcing Claude Code to ask — the instructor's click attests.
+# ASK layer (#264, #265): force a human permission prompt at BOTH AI-drafted
+# checkpoints — the review attestation (--mark-reviewed) AND the push (--push).
+# grader_push honors --yes there (no terminal keystroke), so an agent could run
+# `--mark-reviewed --yes` and self-attest review without ever showing the human
+# _all_comments.md, then push (#265). Firing the prompt at --mark-reviewed too
+# means the instructor must click to attest review — the agent cannot skip it.
 # ---------------------------------------------------------------------------
 
-def _is_ai_drafted_push(cmd: str) -> bool:
-    """True for a grader_push invocation that writes AI-drafted comments to a live
-    course — the write the instructor must approve in-chat. Excludes the value-only
-    (--grade-only), test-student (--test-user), and retract (--retract) paths."""
-    if "grader_push" not in cmd or not re.search(r"--push\b", cmd):
-        return False
-    return not any(re.search(re.escape(f) + r"\b", cmd)
-                   for f in ("--grade-only", "--test-user", "--retract"))
+# What kind of AI-drafted checkpoint a grader_push command is — the moments a human
+# must consciously click. The value-only (--grade-only), test (--test-user), and
+# retract (--retract) paths are NOT AI-drafted-comment checkpoints.
+_CHECKPOINT_REASONS = {
+    "review": (
+        "Review gate (HG-5, #265): the agent is attesting it reviewed the AI-drafted "
+        "comments. Approve ONLY if it has shown you the actual comments "
+        "(feedback/_all_comments.md) in this chat. If it hasn't, Deny and make it show "
+        "you first — do not attest a review you didn't do."
+    ),
+    "push": (
+        "Push gate (HG-5, #264): this sends AI-drafted feedback + grades to students on "
+        "a LIVE course. Approve only after reviewing the comments and the old→new grade "
+        "preview the agent showed you. Allow = send; Deny = hold."
+    ),
+}
+
+
+def _grader_push_checkpoint(cmd: str) -> str | None:
+    """Return 'push' or 'review' if this grader_push command is an AI-drafted
+    human-checkpoint moment, else None. --push wins if both flags are present."""
+    if "grader_push" not in cmd:
+        return None
+    if any(re.search(re.escape(f) + r"\b", cmd)
+           for f in ("--grade-only", "--test-user", "--retract")):
+        return None                                   # not the AI-drafted-comment path
+    if re.search(r"--push\b", cmd):
+        return "push"
+    if re.search(r"--mark-reviewed\b", cmd):
+        return "review"
+    return None
 
 
 def ask_reason(tool_name: str, tool_input: dict) -> str | None:
-    """Return a permission-prompt reason if this call is an AI-drafted grade push the
-    instructor should confirm, else None. Pure function — unit-testable without Claude
-    Code. main() turns a non-None reason into a permissionDecision 'ask'."""
+    """Return a permission-prompt reason if this call is an AI-drafted grade checkpoint
+    (review attestation or push) the instructor must click, else None. Pure function —
+    unit-testable without Claude Code. main() turns a non-None reason into a
+    permissionDecision 'ask'."""
     tool_input = tool_input or {}
     if tool_name != "Bash":
         return None
-    if not _is_ai_drafted_push(tool_input.get("command", "") or ""):
-        return None
-    return (
-        "Human review gate (HG-5, #264): this pushes AI-drafted feedback + grades to "
-        "students on a LIVE course. Approve only after reviewing the comments and the "
-        "old→new grade preview the agent showed you. Allow = send; Deny = hold."
-    )
+    kind = _grader_push_checkpoint(tool_input.get("command", "") or "")
+    return _CHECKPOINT_REASONS.get(kind)
 
 
 # ---------------------------------------------------------------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.9.0"
+version = "1.9.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## The regression

1.9.0 moved the human gate off the terminal: `--yes` is honored, and the guardian forces an in-chat `ask` pop-up on `--push`. But the pop-up fired **only on the push**. An agent could run `grader_push --mark-reviewed --yes` — **self-attesting review without ever showing the instructor `_all_comments.md`** — then push. A live DS460 session did exactly that: it skipped the review surface entirely.

## The fix

`grade_guardian` now forces the `ask` pop-up at **both** AI-drafted checkpoints:

- **`--mark-reviewed`** → *"Approve only if the agent showed you `_all_comments.md`. Deny if it skipped it."*
- **`--push`** → *"Send AI-drafted feedback to N students? Allow = send."*

`--yes` cannot bypass either — the PreToolUse hook runs **above** the tool, so the flag only skips the tool's own (removed) prompt, never the guardian's. Two clicks the agent can neither skip nor forge. Still silent on `--grade-only`/`--test-user`/`--retract` (not AI-drafted-comment writes), and still **no terminal, ever**.

The `grading` skill's push protocol is tightened to match: the review step is mandatory and never skippable, and the two pop-ups are documented. Dropped the "just run the flow" phrasing from 1.9.0 that read as license to skip step 2.

## Honest limit

A PreToolUse hook can force the native **Allow/Deny** prompt, not a custom multi-option menu, and nothing prompts in full `bypassPermissions` mode (explicit opt-out).

## Verification

- `33 passed` in the guardian suite; new `test_asks_on_mark_reviewed` + end-to-end JSON for both checkpoints.
- Live: `--mark-reviewed --yes` now emits `permissionDecision:"ask"`; `--mark-reviewed --grade-only` stays silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
