### PR TITLE
feat(improve): course continuous-improvement kanban (IMPROVEMENTS.md) skill (#267)

### DIFF
--- a/.claude/skills/audit/SKILL.md
+++ b/.claude/skills/audit/SKILL.md
@@ -11,6 +11,11 @@ These tools mostly **read**; they surface problems, they don't apply fixes.
 > The **constitution** (AGENTS.md) binds you: FERPA Zone-2 files are never read, and
 > reports containing student names are written OUTSIDE the repo (see Title IV below).
 
+**Findings go on the board, not into the void.** When an audit surfaces something worth
+fixing, log it as a card in the course's `IMPROVEMENTS.md` (the `improve` skill) with
+`src: audit <date>` — so it's tracked to *done*, not filed in a one-off report and
+forgotten. An audit's real output is a prioritized set of cards.
+
 ## Structural + quality audits
 
 | Task | Tool |

--- a/.claude/skills/improve/IMPROVEMENTS.template.md
+++ b/.claude/skills/improve/IMPROVEMENTS.template.md
@@ -1,0 +1,30 @@
+# Improvement Board — <COURSE>
+
+<!--
+Continuous-improvement kanban for this course (the `improve` skill manages it).
+Pull from the TOP of Ready. WIP limit: keep In Progress ≈2. Card id = C-### (stable,
+never reused). Card line:
+  - **[C-###] Short title** — src: <audit YYYY-MM-DD | user | handoff> · size S/M/L · risk low/med/high · <PR/commit link when it moves>
+Zone-1 (course context, no student PII) — safe to commit. Delete these comments once seeded.
+-->
+
+## 🟡 In Progress (max ≈2)
+
+<!-- pulled from the top of Ready; finish before starting more -->
+
+## 🔵 In Review
+
+<!-- done but unverified — awaiting the instructor. Nothing self-marks Done. -->
+
+## 🔴 Ready (ordered — top = next)
+
+<!-- prioritized; the top card is the next thing to pull -->
+- **[C-001] <first improvement>** — src: user 2026-01-01 · size S · risk low
+
+## 🗄 Backlog (unordered)
+
+<!-- raw ideas + audit findings not yet prioritized -->
+
+## ✅ Done
+
+<!-- verified + linked. Keep as the record; prune only when long. -->

--- a/.claude/skills/improve/SKILL.md
+++ b/.claude/skills/improve/SKILL.md
@@ -1,0 +1,69 @@
+---
+name: improve
+description: Use to log, prioritize, move, or review COURSE IMPROVEMENTS — the local kanban backlog in the course's `IMPROVEMENTS.md`. Load whenever an audit surfaces findings, the user notes something to fix / try / revisit, a handoff lands action items, or you're asked "what's on the board / what's next / show the backlog / log this". Each improvement is a card that moves Backlog → Ready → In Progress → In Review → Done. This is CONTINUOUS IMPROVEMENT (kaizen) for the course — NOT continuous integration / CI pipelines / GitHub Actions.
+---
+
+# Improve — the course continuous-improvement board
+
+Every course accumulates "should fix / should try" items — from audits, from teaching
+a term, from the instructor noticing something. Left in chat or one-off letters, they're
+lost by the next session. This skill keeps them in **one local, git-tracked kanban
+board** so improvements are tracked to *done*, not rediscovered every term.
+
+## The board
+
+**`IMPROVEMENTS.md` at the course root.** Git-tracked (travels with the repo), plain
+markdown (the instructor can edit it directly), no external service. If it doesn't
+exist yet, copy `IMPROVEMENTS.template.md` from this skill to create it — confirm with
+the instructor the first time.
+
+## The one rule
+
+**When an improvement is found — by an audit, by the instructor, by a handoff — it
+becomes a card on the board. When it's worked, it moves through the columns. Nothing
+that matters gets left only in chat.**
+
+## Columns (the lifecycle)
+
+`🗄 Backlog` (unordered ideas) → `🔴 Ready` (prioritized; top = next) →
+`🟡 In Progress` (being worked) → `🔵 In Review` (done but unverified — awaiting the
+instructor) → `✅ Done` (verified, linked to the PR/commit that closed it).
+
+## Card schema
+
+One line per card, compact:
+
+```
+- **[C-###] Short title** — src: <audit YYYY-MM-DD | user | handoff | session> · size <S/M/L> · risk <low/med/high> · <link when it moves>
+```
+
+- **id** `C-###` — stable, monotonic; never reused. Assign the next free number.
+- **src** — where it came from + date, so provenance survives.
+- **size / risk** — rough, for ordering. No story points.
+- **link** — the PR/commit/handoff, added as the card moves to In Review / Done.
+
+## How to work it (lightweight agile — solo-instructor scale)
+
+- **Log**: new find → a `Backlog` card (or straight to `Ready` if it's clearly next).
+  Audits write their findings here **as cards**, not as a separate lost letter.
+- **Prioritize**: order `Ready` so the **top is the next thing** to pull. Tag size/risk.
+- **Pull, don't push**: start work by pulling the top of `Ready` into `In Progress`.
+  **WIP limit: keep `In Progress` small (≈2).** Finish before starting.
+- **Review gate**: work lands in `In Review`, not `Done`, until the instructor has
+  seen/verified it. Nothing self-marks Done.
+- **Close**: move to `Done` with the PR/commit link and the date. Keep Done as the
+  record (prune only when it's long).
+- **Age**: flag a card that's sat in `In Progress`/`In Review` too long — surface it.
+
+## Phrases that load this
+
+"log this / add to the board", "what's on the board / show the backlog", "what's next /
+what should I work on", "move C-012 to in progress / done", "prioritize the board",
+"turn the audit into cards".
+
+## Where it plugs in
+
+- **`audit`** — an audit's output is a set of `IMPROVEMENTS.md` cards (with `src: audit
+  <date>`), so findings are tracked to closure instead of filed and forgotten.
+- **Handoffs** — a received handoff's action items become cards.
+- The board is course context (no student PII) — **Zone-1**, safe to read and commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,6 +49,7 @@ playbook (tools, gates, order of operations) so you don't operate from half-memo
 | **`ferpa-deid`** | De-id/re-id machinery | `build_deid_master`, de-identify artifacts, re-identify by key, name-leak check |
 | **`title-iv`** | Federal engagement / withdrawal compliance | `course_engagement_audit` (UW/UF/R2T4), Title IV snapshot |
 | **`voicing`** | Writing student-facing text in the instructor's voice | load the course's voicing profile for grading comments / notes — never invent a voice |
+| **`improve`** | Logging & tracking course improvements | the `IMPROVEMENTS.md` kanban — audit findings + user notes as cards, Backlog → Ready → In Progress → In Review → Done |
 
 Meta/lifecycle tools (`cb_init` setup, `cb_report_bug`, `vote_feature`) are governed
 here in the constitution, not a skill.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.11.0] — 2026-07-29
+
+**New `improve` skill: a local continuous-improvement kanban (`IMPROVEMENTS.md`) so course findings are tracked to done, not lost in one-off letters.**
+
+Audits and field sessions kept surfacing "should fix / should try" items that landed in chat or a handoff letter and were gone by the next session. The `improve` skill gives each course a single git-tracked kanban board.
+
+- **`IMPROVEMENTS.md` at the course root** — plain markdown, instructor-editable, Zone-1 (no student PII). Columns are the lifecycle: `Backlog → Ready → In Progress → In Review → Done`. Cards carry an id (`C-###`), source+date, size/risk, and a PR/commit link as they move. Lightweight agile — WIP limit on In Progress, ordered Ready (top = next), an In-Review gate so nothing self-marks Done. Template ships in the skill.
+- **Audits feed the board.** The `audit` skill now says its real output is a prioritized set of `IMPROVEMENTS.md` cards (`src: audit <date>`), not a report that gets filed and forgotten.
+- **Named for clarity, not collision.** File `IMPROVEMENTS.md`, skill `improve` — a repo-facing "CI" slug would read as continuous *integration*; this is continuous *improvement*.
+- Wired into distribution: added to the `cb_update` skill set, the constitution's skills index, and the pointer block, so every `cb_update --apply` course activates it. (Also backfilled `voicing` into the pointer-block skill list, which had been omitted.)
+
+---
+
 ## [1.10.0] — 2026-07-28
 
 **`grader_push --comments-only`: add or fix feedback on already-graded work without touching the grade (#266).**

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -55,7 +55,7 @@ except ImportError:
     _ensure_guardian_hook = None
 
 SKILLS = ["grading", "course-build", "audit", "accommodations", "ferpa-deid",
-          "title-iv", "voicing"]
+          "title-iv", "voicing", "improve"]
 
 
 def plan_skill_symlinks(course_root: Path, toolkit_subdir: str,

--- a/lib/tools/sync_grading_protocol.py
+++ b/lib/tools/sync_grading_protocol.py
@@ -46,8 +46,8 @@ This course uses **canvas-toolbox**. Its always-on rules — FERPA discipline, t
 Canvas-write safety doctrine + the `grade_guardian` hook, and behavioral principles —
 live in **`canvas-toolbox/AGENTS.md`** (the constitution). Read it. Mode-specific
 procedure lives in **operating-mode skills** under `.claude/skills/`: `grading`,
-`course-build`, `audit`, `accommodations`, `ferpa-deid`, `title-iv`. Load the skill
-that matches your task.
+`course-build`, `audit`, `accommodations`, `ferpa-deid`, `title-iv`, `voicing`,
+`improve`. Load the skill that matches your task.
 
 **Grading is HG-5 — the instructor decides.** AI grading is decision support, not
 autonomy: grade → review the feedback → `grader_push.py --mark-reviewed` (type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.10.0"
+version = "1.11.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Why

Every audit and field session this week surfaced "should fix / should try" items — and each one landed in chat or a one-off handoff letter, then vanished by the next session. There was no persistent, prioritized place for course-level continuous improvement (closest existing things: handoffs, which get buried, and `cb_report_bug.py`, which is for *toolkit* bugs).

## What

New **`improve`** skill + a local kanban convention:

- **`IMPROVEMENTS.md`** at the course root — git-tracked, plain markdown, instructor-editable, **Zone-1** (no student PII). Columns are the lifecycle: `🗄 Backlog → 🔴 Ready → 🟡 In Progress → 🔵 In Review → ✅ Done`. Cards carry a stable id (`C-###`), `src:` + date, size/risk, and a PR/commit link as they move. Template ships in the skill.
- **Lightweight agile** — WIP limit on In Progress, ordered Ready (top = next, pull-based), an In-Review gate so nothing self-marks Done. No story points; solo-instructor scale.
- **Audits feed it** — the `audit` skill now states its real output is a set of `IMPROVEMENTS.md` cards (`src: audit <date>`), so findings are tracked to *done* instead of filed and forgotten.
- **Named to avoid the CI collision** — file `IMPROVEMENTS.md`, skill `improve`; a repo-facing "CI" slug reads as continuous *integration*, and this is continuous *improvement*. The skill description says so explicitly.

## Distribution

Added to the `cb_update` skill set, the constitution's skills index (`AGENTS.md`), and the sync pointer block — so any `cb_update --apply` course activates it. Also backfilled `voicing` into the pointer-block skill list, which had been omitted.

## Verification

- `cb_update`, `sync_grading_protocol`, and active-context tests pass; full suite green.
- Skill loads (frontmatter description registered).

## Next

The pending DS460 audit becomes the board's first real use — its findings seed DS460's `IMPROVEMENTS.md` instead of another letter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
