### PR TITLE
feat(grader_push): No-Submission boundary → grader_standing; fix stale pointer text (#268)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -125,6 +125,13 @@ tag prints in the pre-push banner. It won't stack if you switch graders mid-stre
 
 ## grader_standing — the "your grade" column
 
+**Which push tool? Ask: does the assignment take a student submission?**
+**Yes** (online upload / text / quiz) → `grader_push` (keyed on submission files).
+**No** (a No-Submission "Your Grade" / standing column) → **`grader_standing`** (roster-keyed
+by user_id, overwrites freely, no regrade gate). Using grader_push on a No-Submission
+column hits the regrade gate and dead-ends — grader_push now detects this and refuses
+with a pointer here, but pick the right tool up front.
+
 For a No-Submission column (often weighted 100%) that you compute from a syllabus
 table and refresh weekly — instructor-computed, value-only, roster-keyed. It
 sidesteps Canvas's auto-zero and the regrade gate. It **computes nothing** — your

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.12.0] — 2026-07-29
+
+**Route the grading path at the right tool: grader_push refuses No-Submission columns and points to grader_standing; the pointer block drops the stale terminal-confirmation wording (#268).**
+
+Two "wrong guidance sends the agent off a cliff" fixes from the field.
+
+- **Submission-type boundary in `grader_push`.** A field agent ran `grader_push --grade-only` on a No-Submission "Your Grade" column, hit the regrade gate, and thrashed toward `--force` and the raw API. grader_push already fetches the assignment; it now reads `submission_types` and, on a No-Submission / on-paper / not-graded column, **refuses up front and points at `grader_standing`** (roster-keyed, no regrade gate) — the right tool for value grades on a standing column. `--comments-only` is still allowed there (comments attach to any submission object). The `grading` skill gains a front-loaded "which push tool?" discriminator so agents route correctly *before* hitting the wall.
+- **Pointer-block grading text updated to the chat-approval model.** The sentinel block injected into course `AGENTS.md` still described the pre-1.9.0 flow — *"`--mark-reviewed` (type `reviewed`) → `--push` (type `push`); `--yes` does not bypass review."* That's wrong since 1.9.0/1.9.1. It now says: `--yes` is honored (no terminal), and `grade_guardian` fires an in-chat pop-up at **both** the review and the push (#264/#265). Existing course repos self-heal the wording on the next `cb_update --apply`.
+
+---
+
 ## [1.11.0] — 2026-07-29
 
 **New `improve` skill: a local continuous-improvement kanban (`IMPROVEMENTS.md`) so course findings are tracked to done, not lost in one-off letters.**

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -1152,3 +1152,15 @@ def test_comments_only_and_grade_only_are_mutually_exclusive():
         capture_output=True, text=True)
     assert r.returncode == 1
     assert "opposites" in r.stderr
+
+
+def test_is_no_submission_assignment():
+    """No-Submission / on-paper columns → True (value grades belong in grader_standing);
+    online-submission types → False; unknown/empty → False (never block on missing data)."""
+    assert _GP.is_no_submission_assignment(["none"]) is True
+    assert _GP.is_no_submission_assignment(["on_paper"]) is True
+    assert _GP.is_no_submission_assignment(["none", "not_graded"]) is True
+    assert _GP.is_no_submission_assignment(["online_upload"]) is False
+    assert _GP.is_no_submission_assignment(["online_text_entry", "online_upload"]) is False
+    assert _GP.is_no_submission_assignment([]) is False
+    assert _GP.is_no_submission_assignment(None) is False

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -948,7 +948,21 @@ def fetch_assignment_lock_state(
             # before the PUT (Canvas otherwise silently coerces invalid
             # strings to wrong grades — e.g. "(held)" → incomplete on
             # pass_fail).
-            "grading_type": a.get("grading_type") or ""}
+            "grading_type": a.get("grading_type") or "",
+            # Issue #268: submission_types drives the No-Submission boundary —
+            # value grades on a No-Submission column belong in grader_standing.
+            "submission_types": a.get("submission_types") or []}
+
+
+def is_no_submission_assignment(submission_types) -> bool:
+    """True if the assignment takes NO online student submission — a No-Submission /
+    on-paper / not-graded column (e.g. a 'Your Grade' standing column). grader_push is
+    keyed on submission FILES; value grades on these belong in grader_standing. Unknown
+    / unfetched (empty) → False, so a failed metadata fetch never blocks a real push."""
+    types = {str(t).strip() for t in (submission_types or []) if str(t).strip()}
+    if not types:
+        return False
+    return types.issubset({"none", "on_paper", "not_graded"})
 
 
 def comment_has_resubmit_language(text: str) -> bool:
@@ -1650,8 +1664,25 @@ def main() -> int:
         print(f"WARN: assignment metadata fetch failed "
               f"({type(e).__name__}: {e}); lock-state + grading-type checks disabled.",
               file=sys.stderr)
-        lock_state = {"locked_now": False, "grading_type": ""}
+        lock_state = {"locked_now": False, "grading_type": "", "submission_types": []}
     grading_type = (lock_state.get("grading_type") or "").strip()
+
+    # Submission-type boundary (#268): grader_push is keyed on submission FILES. A
+    # No-Submission column (e.g. "Your Grade") has none — its value grades belong in
+    # grader_standing (roster-keyed, no regrade gate). This is the wrong-tool wall an
+    # agent otherwise hits as the regrade gate, then thrashes toward --force / the API.
+    # Comments CAN attach to any submission object, so --comments-only is still allowed.
+    if not args.comments_only and is_no_submission_assignment(lock_state.get("submission_types")):
+        st = lock_state.get("submission_types")
+        print(f"\n⛔ Assignment {args.assignment_id} is a No-Submission column "
+              f"(submission_types={st}). grader_push is for submission-based work; value "
+              "grades on a No-Submission / 'Your Grade' column belong in grader_standing "
+              "(roster-keyed, no regrade gate).", file=sys.stderr)
+        print("   Use:  grader_standing.py --csv <user_id,grade> --assignment-id "
+              f"{args.assignment_id} --push --allow-enrolled", file=sys.stderr)
+        print("   (To post COMMENTS to this column instead, re-run with --comments-only.)",
+              file=sys.stderr)
+        return 1
     # The resubmit-language check is still gated by the flags; only the
     # underlying fetch was lifted.
     if not args.no_lock_check and not args.grade_only and lock_state.get("locked_now"):

--- a/lib/tools/sync_grading_protocol.py
+++ b/lib/tools/sync_grading_protocol.py
@@ -50,11 +50,13 @@ procedure lives in **operating-mode skills** under `.claude/skills/`: `grading`,
 `improve`. Load the skill that matches your task.
 
 **Grading is HG-5 — the instructor decides.** AI grading is decision support, not
-autonomy: grade → review the feedback → `grader_push.py --mark-reviewed` (type
-`reviewed`) → `--push` (type `push`). `--yes` does **not** bypass review on the
-AI-drafted path — enforced in code (#207). When a gate blocks you, do the review —
-never stack `--force`/`--regrade`/`--yes` to route around it, and never hand-write a
-Canvas write (the `grade_guardian` hook blocks that at create/edit/run).
+autonomy: grade → **show the feedback in chat** → `grader_push.py --mark-reviewed --yes`
+→ `--push --yes`. `--yes` is honored (no terminal — never send faculty to a shell), but
+the `grade_guardian` hook fires an in-chat **permission pop-up** at BOTH the review and
+the push (#264/#265): the instructor clicks to approve — an agent cannot skip it or
+self-attest. When a gate blocks you, get the human — never stack `--force`/`--regrade`
+to route around it, and never hand-write a Canvas write (the `grade_guardian` hook
+blocks that at create/edit/run).
 
 **Updating the toolkit — run ONE command, don't improvise git.** When the instructor
 says any of these (all mean the same thing):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.11.0"
+version = "1.12.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Why

Two "wrong guidance sends the agent off a cliff" fixes, both straight from a live field session.

1. An agent ran `grader_push --grade-only` on a **No-Submission "Your Grade" column**, hit the regrade gate ("already graded, no new submission"), and thrashed toward `--force` and the raw Canvas API. The right tool for value grades on a standing column is `grader_standing` — but nothing told it that at the point of failure.
2. The sentinel **pointer block** injected into every course `AGENTS.md` still described the pre-1.9.0 flow — *"`--mark-reviewed` (type `reviewed`) → `--push` (type `push`); `--yes` does not bypass review"* — which has been wrong since 1.9.0/1.9.1 and actively misleads agents.

## What

- **Submission-type boundary in `grader_push`.** It already GETs the assignment (for lock-state + grading_type); now it also reads `submission_types`. On a No-Submission / on-paper / not-graded column it **refuses up front and points at `grader_standing`** (roster-keyed, overwrites freely, no regrade gate). `--comments-only` is still allowed there (comments attach to any submission object). Unknown/unfetched types → no gate (fail open). New pure helper `is_no_submission_assignment` + test.
- **`grading` skill** gains a front-loaded *"which push tool?"* discriminator (submission → grader_push; No-Submission → grader_standing) so agents route correctly *before* hitting the wall — locality, not just a refusal.
- **Pointer block updated** to the chat-approval model: `--yes` honored (no terminal), `grade_guardian` fires an in-chat pop-up at **both** review and push (#264/#265). Existing course repos self-heal the wording on the next `cb_update --apply`.

## Verification

- 155 targeted tests pass (push helpers + sync-protocol + guardian); full suite running.
- `is_no_submission_assignment`: `["none"]`/`["on_paper"]` → True; `["online_upload"]`/`[]`/`None` → False.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
