### PR TITLE
feat(grader_push): --roster-csv — comment on non-submitters by user_id (#269)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -84,6 +84,11 @@ cannot click either for them, and you cannot self-attest.
   `--comments-only`: it posts the comment, leaves the grade untouched, bypasses the
   regrade gate, and *supersedes* the prior grader comment so nothing stacks. Never clear
   grades to "get past" the gate — that's destructive and re-opens the sync-mismatch bugs.
+- **Comment on a NON-SUBMITTER (0 / no submission) → `--roster-csv`.** The file-keyed
+  push can't see a student with no submission file. `--roster-csv <user_id,comment>`
+  posts comment-only straight to `/submissions/<user_id>` — their empty submission
+  object still accepts it. Grade untouched, guardian pop-up still gates it. For an
+  instructor-written note there, pass `--disclosure script` (it's not AI-drafted).
 - **Disclosure is mandatory** (see the menu below), appended automatically.
 
 **The in-chat review is the gate, not a rubber-stamp.** The failure an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.13.0] — 2026-07-29
+
+**`grader_push --roster-csv`: comment on non-submitters (a 0 / no-submission student) by user_id (#269).**
+
+The file-keyed push builds its set from submission files, so a student who never submitted has no `.review.csv` row and is unreachable — but instructors still need to leave them feedback. In Canvas, a non-submitter's submission object exists (empty, `unsubmitted`) and *does* accept a comment; you just have to address them by user_id instead of a file.
+
+- **New `--roster-csv <path>`** — a CSV with a `user_id` column plus a `comment` (inline) or `comment_file` (path) column. Posts **comment-only** straight to `/submissions/<user_id>`, reaching non-submitters. Grade untouched; disclosure tag applied (pass `--disclosure script` for an instructor-written note); **still gated by the `grade_guardian` pop-up** (it's a comment push with `--push`). Idempotent — a user already in the push log is skipped unless `--force`, so re-runs don't stack a second comment.
+- Pure loader `load_roster_comments` (unit-tested); the `grading` skill documents the non-submitter path.
+
+---
+
 ## [1.12.0] — 2026-07-29
 
 **Route the grading path at the right tool: grader_push refuses No-Submission columns and points to grader_standing; the pointer block drops the stale terminal-confirmation wording (#268).**

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -277,6 +277,14 @@ def test_asks_on_comments_only_push():
     assert ask_reason("Bash", {"command": cmd}) is not None
 
 
+def test_asks_on_roster_csv_push():
+    """--roster-csv --push posts comments to students (incl. non-submitters) → it MUST
+    trip the guardian pop-up (it's a comment write on the AI-drafted path)."""
+    cmd = "uv run python canvas-toolbox/lib/tools/grader_push.py --challenge-dir grading/fpr --roster-csv ns.csv --assignment-id 5 --push"
+    assert _grader_push_checkpoint(cmd) == "push"
+    assert ask_reason("Bash", {"command": cmd}) is not None
+
+
 def test_no_ask_on_dry_run():
     """No --push / --mark-reviewed (dry-run) is not a checkpoint — no prompt. A
     --comments-only dry-run (no --push) likewise doesn't write, so no prompt."""

--- a/lib/tests/test_grader_push_helpers.py
+++ b/lib/tests/test_grader_push_helpers.py
@@ -1164,3 +1164,23 @@ def test_is_no_submission_assignment():
     assert _GP.is_no_submission_assignment(["online_text_entry", "online_upload"]) is False
     assert _GP.is_no_submission_assignment([]) is False
     assert _GP.is_no_submission_assignment(None) is False
+
+
+def test_load_roster_comments(tmp_path):
+    """--roster-csv reads (user_id, comment) pairs; supports inline `comment` and a
+    `comment_file` path; drops rows missing a user_id or any comment text."""
+    fb = tmp_path / "feedback"; fb.mkdir()
+    (fb / "note.md").write_text(
+        "# x\n\n## Comment to student\n\nSee you next term.\n", encoding="utf-8")
+    csvp = tmp_path / "roster.csv"
+    csvp.write_text(
+        "user_id,comment,comment_file\n"
+        "111,Great work,\n"
+        "222,,feedback/note.md\n"
+        "333,,\n"
+        ",orphan,\n",
+        encoding="utf-8")
+    pairs = _GP.load_roster_comments(csvp, tmp_path)
+    assert ("111", "Great work") in pairs
+    assert ("222", "See you next term.") in pairs
+    assert len(pairs) == 2                     # the no-comment and no-user_id rows dropped

--- a/lib/tools/grader_push.py
+++ b/lib/tools/grader_push.py
@@ -78,6 +78,9 @@ MULTI-OUTPUT SUPPORT
   or FIX feedback on ALREADY-GRADED work (grade now, comment later; or replace a
   wrong comment). It bypasses the regrade gate (no re-grade is happening) and
   supersedes a prior grader comment for the same key, so re-runs never stack.
+  --roster-csv <user_id,comment> posts comment-only BY user_id — the way to reach
+  a NON-SUBMITTER (0 / no submission), whose empty submission object still takes a
+  comment even though the file-keyed push can't see them.
   --default-comment <text> posts a fixed comment when a feedback file lacks a
   `## Comment to student` block (e.g. "See Mid Review for detailed feedback").
 
@@ -1016,6 +1019,95 @@ def resolve_user_id(filename: str, subs: list[dict]) -> int | None:
     return cand2[0]["user_id"] if len(cand2) == 1 else None
 
 
+def load_roster_comments(path: Path, challenge: Path) -> list[tuple[str, str]]:
+    """Read (user_id, comment) pairs from a --roster-csv. Columns: `user_id` (or `id`)
+    plus either `comment` (inline text) or `comment_file` (a challenge-relative path to
+    a .md with a `## Comment to student` block). Rows missing a user_id or any comment
+    text are dropped. Pure — no network — so it's unit-testable."""
+    import csv as _csv
+    out: list[tuple[str, str]] = []
+    with path.open(encoding="utf-8") as fh:
+        for row in _csv.DictReader(fh):
+            uid = (row.get("user_id") or row.get("id") or "").strip()
+            comment = (row.get("comment") or "").strip()
+            cfile = (row.get("comment_file") or "").strip()
+            if cfile and not comment:
+                comment = comment_for(resolve_feedback_file(challenge, cfile)).strip()
+            if uid and comment:
+                out.append((uid, comment))
+    return out
+
+
+def push_roster_comments(args, base, cid, headers, challenge, disclosure_kind) -> int:
+    """--roster-csv: post comment-only to students BY user_id — reaches non-submitters
+    (a 0 / no-submission student whose empty submission object still accepts a comment).
+    The file-keyed push can't see them (no submission file → no .review.csv row). Grade
+    untouched; disclosure tag applied; the grade_guardian pop-up gates the write (it's a
+    comment push with --push). Idempotent: a user already in the log is skipped unless
+    --force, so re-runs don't stack a second comment."""
+    path = Path(args.roster_csv)
+    if not path.is_file():
+        print(f"⛔ --roster-csv not found: {path}", file=sys.stderr)
+        return 1
+    pairs = load_roster_comments(path, challenge)
+    if not pairs:
+        print(f"⛔ no (user_id, comment) rows in {path} — need a `user_id` column and a "
+              "`comment` or `comment_file` column.", file=sys.stderr)
+        return 1
+    log = challenge / ".push_log.md"
+    already: set[str] = set()
+    if log.is_file() and not args.force:
+        for ln in log.read_text(encoding="utf-8").splitlines():
+            m = re.match(r"- roster-(\S+): comment ", ln)
+            if m:
+                already.add(m.group(1))
+    todo = [(u, c) for u, c in pairs if u not in already]
+    skipped = len(pairs) - len(todo)
+    tail = f", {skipped} already logged (--force to re-post)" if skipped else ""
+    print(f"Roster comment-only push → assignment {args.assignment_id}: "
+          f"{len(todo)} to post{tail}.")
+    for uid, comment in todo:
+        print(f"  [OK] user_id={uid}  comment=\"{truncate_comment_preview(comment)}\"")
+    if not todo:
+        print("Nothing to post.")
+        return 0
+    print(f"Disclosure tag on comments: {DISCLOSURE_TAGS[disclosure_kind]!r} "
+          f"(--disclosure {disclosure_kind}). For an instructor-written note to a "
+          "non-submitter, pass --disclosure script.")
+    if not args.push:
+        print("\nDry run — nothing written. Add --push to post.")
+        return 0
+    if not args.yes and not require_typed_confirmation(
+            f"\nType 'push' to post {len(todo)} comment(s) to LIVE course {cid}: ", "push"):
+        print("Aborted.")
+        return 1
+    posted, failed = 0, []
+    with log.open("a", encoding="utf-8") as lg:
+        for uid, comment in todo:
+            body = {"comment[text_comment]": append_disclosure_tag(comment, disclosure_kind)}
+            resp = requests.put(
+                f"{base}/api/v1/courses/{cid}/assignments/{args.assignment_id}/submissions/{uid}",
+                headers=headers, data=body, timeout=_TIMEOUT)
+            if resp.status_code < 400:
+                try:
+                    sc = (resp.json() or {}).get("submission_comments") or []
+                    new_id = (sc[-1] if sc else {}).get("id")
+                except (ValueError, TypeError):
+                    new_id = None
+                print(f"  commented user_id={uid} (grade untouched)")
+                lg.write(f"- roster-{uid}: comment {new_id} pushed to assignment "
+                         f"{args.assignment_id} (grade untouched)\n")
+                posted += 1
+            else:
+                print(f"  ERROR user_id={uid}: {resp.status_code} {resp.text[:120]}")
+                failed.append(uid)
+                if 400 <= resp.status_code < 500:
+                    print("\n⛔ 4xx — STOP (P-003). Investigate before re-running.")
+                    break
+    print(f"\nPosted {posted}/{len(todo)} roster comment(s). Logged to {log}.")
+    return 0 if not failed else 1
+
+
 # Issue #63 part 2: retract previously-pushed comments. Comment ids are
 # captured in .push_log.md on every comment push (one line per push:
 # `- <KEY>: comment <ID> pushed to assignment <AID>`). --retract reads
@@ -1230,6 +1322,12 @@ def main() -> int:
                          "re-grading) and SUPERSEDES a prior grader comment for the same key (deletes "
                          "the old, posts fresh) so re-runs never stack. Still requires the grade_guardian "
                          "pop-up. Mutually exclusive with --grade-only.")
+    ap.add_argument("--roster-csv",
+                    help="Post comment-only to students BY user_id — a CSV with a `user_id` column "
+                         "plus a `comment` (inline) or `comment_file` (path) column. Reaches "
+                         "NON-SUBMITTERS (a 0 / no-submission student the file-keyed push can't see, "
+                         "since they have no submission file). Grade untouched; still gated by the "
+                         "guardian pop-up; idempotent (a logged user is skipped unless --force).")
     ap.add_argument("--disclosure", default=None, choices=sorted(DISCLOSURE_TAGS),
                     help="Which provenance tag to append to drafted comments: "
                          "'ai' (AI drafted the grade + comment), 'hybrid' (a script "
@@ -1440,6 +1538,12 @@ def main() -> int:
     # canvas_course_guard: refuse enrolled-course writes unless --allow-enrolled
     if guard_enforce and (args.push or args.test_user is not None):
         guard_enforce(base, headers, cid, mode="write", allow_override=args.allow_enrolled)
+
+    # --- roster-keyed comments (#269): reach students BY user_id, incl. non-submitters ---
+    # The file-keyed .review.csv path can't see a student with no submission; this posts
+    # comment-only straight to /submissions/<user_id>. Grade untouched; guardian pop-up gates it.
+    if args.roster_csv:
+        return push_roster_comments(args, base, cid, headers, challenge, disclosure_kind)
 
     # --- one-shot Test Student validation ---
     if args.test_user:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.12.0"
+version = "1.13.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Why

You need to leave feedback on a **non-submitter** — a student with a 0 / no submission. But `grader_push` builds its set from submission **files**, so a student who never submitted has no `.review.csv` row and is simply unreachable. In Canvas, though, their submission object exists (empty, `unsubmitted`) and **does** accept a comment — you just have to address them by **user_id** instead of a file. ("Can't comment on a submission that doesn't exist" is a misconception: it exists, it's just empty.)

## What

New **`--roster-csv <path>`** — a CSV with a `user_id` column plus a `comment` (inline) or `comment_file` (challenge-relative path) column:

- Posts **comment-only** straight to `/submissions/<user_id>` → reaches non-submitters (and anyone else by id).
- **Grade untouched.** Disclosure tag applied — pass `--disclosure script` for an instructor-written note (it's not AI-drafted).
- **Still gated** by the `grade_guardian` pop-up (it's a comment push with `--push`) — new guardian test confirms `--roster-csv --push` trips the ask.
- **Idempotent**: a user already in the push log is skipped unless `--force`, so re-runs don't stack a second comment.
- Pure loader `load_roster_comments` (unit-tested for inline text, `comment_file`, and dropping rows missing a user_id or comment).

The `grading` skill documents the non-submitter path alongside `--comments-only`.

## Verification

- 148 targeted tests pass (push helpers + guardian); full suite running.
- Contained: `--roster-csv` short-circuits to its own comment-only loop after env/guard setup — it does not perturb the file-keyed `.review.csv` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
