### PR TITLE
feat(grade_guardian): block shell reads of Zone-2 files; codify letters-are-read (#270)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -32,6 +32,21 @@ fresh fetch each run — never read a cached custom CSV whose age you can't see.
 > Zone-2 files, and grades reach Canvas ONLY through a sanctioned `lib/tools/`
 > writer. This skill is the *how*; those are the *never*.
 
+## Final letters are READ, not parsed
+
+A student's grade-request **letter** (or self-assessment, reflection — any prose where
+they make a case) is **comprehension** data, not structured data. **Never regex/NLP-extract
+the requested grade, the evidence, or any claim you'll repeat back to them.** A parser on
+prose *fabricates*: a field script "extracted" *"you requested an A"* for students who
+asked for a **C**, and it reached them before anyone caught it.
+
+- **Read each letter in full** — every one, no sampling — before you write feedback that
+  references what it says.
+- **Ground or abstain.** If you can't tie a claim like "you requested X" to the actual
+  words of *that* student's letter, do **not** write it — leave it out. Never default.
+- **Files may be parsed; letters may not.** Code, notebooks, CSVs, the gradebook →
+  programmatic extraction is fine. Prose where a human makes a claim → read it.
+
 ## HG-5 — the instructor is the top layer
 
 Principle **HG-5** of the [hybrid grading architecture](../../../lib/agents/knowledge/grader_hybrid_architecture.md):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,6 +127,13 @@ when you say "probably", STOP and check), *Jidoka* (write tests with code; a red
 blocks progress), *Poka-yoke* (design mistakes out). Quality loop: Prevent → Detect →
 Verify; on a defect, fix it, verify with real data, then add an automated guard.
 
+**Ground claims in the source — letters are read, not parsed.** Any statement you repeat
+to a student (their requested grade, their evidence, what their letter "says") must come
+from **reading that student's prose in full** — never a regex/NLP extraction. A parser on
+prose fabricates (a field script emitted *"you requested an A"* to students who asked for
+a C). Structured data (code, notebooks, CSVs, the gradebook) may be parsed; a letter,
+self-assessment, or reflection is comprehension data — read it, or abstain from the claim.
+
 **Always run via `uv run`** (`uv run pytest lib/tests -q`, `uv run python lib/tools/…`).
 Dependencies (`markdownify`, etc.) live in the uv venv; system `python3`/`pytest`
 reports false failures from missing modules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.14.0] — 2026-07-29
+
+**Close the shell FERPA hole (`cat .keymap.json`) and codify "letters are read, not parsed" (#270).**
+
+Two hardenings against the two failure modes a field session exposed — an agent trying to *reconstruct* the de-id map after being blocked, and a script that *fabricated* student claims by regexing prose.
+
+- **`grade_guardian` now blocks a raw READ of a Zone-2 file in the shell.** The Read-tool block never covered `cat`/`head`/`tail`/`less`/python `open()`, so an agent denied `Read .keymap.json` reached for `cat .keymap.json` to rebuild the code↔user_id map. The Bash branch now denies a raw-display verb applied to a Zone-2 file, and points to `grader_reidentify` (which reads the keymap internally). Deliberately **still allows** the sanctioned verification the constitution permits — `wc -l`/`ls`/`stat` and the filtered `grep <code> … | cut -d',' -f1,2` — and exempts `lib/tools/` readers. Case-sensitive so git `HEAD` isn't mistaken for `head`.
+- **"Final letters are READ, not parsed" is now a rule, not a lesson.** A field script regex-"extracted" a requested grade from students' prose and emitted *"you requested an A"* to students who asked for a C. The constitution gains a grounding principle (any claim you repeat to a student comes from reading their letter in full; structured data may be parsed, prose may not — read it or abstain), and the `grading` skill carries the detailed rule.
+
+---
+
 ## [1.13.0] — 2026-07-29
 
 **`grader_push --roster-csv`: comment on non-submitters (a 0 / no-submission student) by user_id (#269).**

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -324,3 +324,37 @@ def test_hook_emits_ask_json_on_ai_drafted_push():
         assert out["hookSpecificOutput"]["permissionDecision"] == "ask", cmd
         assert out["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
         assert out["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+# --- FERPA Zone-2 reads in the SHELL (#270): close the `cat .keymap.json` hole ---
+
+def test_bash_blocks_raw_read_of_zone2():
+    """Reading a Zone-2 file in the shell (cat/head/tail/open) is blocked — the Read-tool
+    block doesn't cover `cat`, and reading the keymap reconstructs identity."""
+    for cmd in (
+        "cat grading/kc3/.keymap.json",
+        "head -5 grading/.deid_master.csv",
+        "tail grading/kc3/.review.csv",
+        "python3 -c \"import json; print(json.load(open('grading/kc3/.keymap.json')))\"",
+    ):
+        assert evaluate("Bash", {"command": cmd}) is not None, cmd
+
+
+def test_bash_allows_metadata_and_filtered_zone2_access():
+    """The constitution PERMITS wc/ls/stat and the filtered `grep <code> … | cut -f1,2`
+    verification — none dump raw rows, so they must still pass. And git HEAD is not `head`."""
+    for cmd in (
+        "wc -l grading/.deid_master.csv",
+        "ls -la grading/kc3/submissions_raw/",
+        "grep S-95DBB6 grading/.deid_master.csv | cut -d',' -f1,2",
+        "git log HEAD..main -- grading/.deid_master.csv",   # HEAD != head; metadata verb
+    ):
+        assert evaluate("Bash", {"command": cmd}) is None, cmd
+
+
+def test_bash_exempts_sanctioned_reidentify_reading_keymap():
+    """grader_reidentify legitimately reads the keymap internally — invoking it (a
+    lib/tools/ script) with a Zone-2 path as an arg must not be blocked."""
+    cmd = ("uv run python canvas-toolbox/lib/tools/grader_reidentify.py "
+           "--challenge-dir grading/kc3 --map grading/kc3/.keymap.json")
+    assert evaluate("Bash", {"command": cmd}) is None

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -17,7 +17,12 @@ WHAT IT DENIES
     `python x.py` / `uv run … x.py` command it reads x.py and blocks if the file
     body carries that write signature (the create/edit hooks can't catch a script
     that already exists, and the write is hidden inside the file). Invocations of
-    the sanctioned tools under lib/tools/ are exempt.
+    the sanctioned tools under lib/tools/ are exempt. ALSO a raw READ of a FERPA
+    Zone-2 file in the shell (`cat`/`head`/`tail`/`less`/python `open()` on
+    .keymap.json et al.) — the Read-tool block below doesn't cover `cat`, so an agent
+    denied Read reached for the shell to reconstruct the code↔user_id map (#270).
+    Metadata (`wc`/`ls`/`stat`) and the sanctioned `grep <code> … | cut -f1,2`
+    verification are not raw-display verbs and still pass; lib/tools/ readers exempt.
   - Write/Edit: creating/editing a file (outside lib/tools/) whose contents carry
     that same Canvas-write signature — this catches the bypass SCRIPT at creation,
     which is the only reliable catch (a Bash hook can't see inside `python x.py`).
@@ -92,6 +97,29 @@ _FERPA_PATH = re.compile(
     r"|feedback/_grader.*\.csv$"
 )
 
+# The same Zone-2 files, matched anywhere in a SHELL command (no end-anchor), so the
+# Bash branch can catch `cat .keymap.json` — the Read-tool block above doesn't cover a
+# shell read (#270). Kept in sync with _FERPA_PATH by hand.
+_FERPA_FILE = re.compile(
+    r"\.deid_master\.csv"
+    r"|\.known_names\.txt"
+    r"|\.keymap\.json"
+    r"|\.fetch_log\.json"
+    r"|\.review\.csv"
+    r"|/submissions_raw/"
+    r"|feedback/_grader[^/\\]*\.csv",
+    re.IGNORECASE,
+)
+
+# Raw display / read of a file's contents. The constitution forbids these on Zone-2
+# files ("not with Read, cat, head, tail, or bare grep"). Deliberately EXCLUDES the
+# sanctioned filtered verification (`grep <code> .deid_master.csv | cut -d',' -f1,2`,
+# and `wc -l`/`ls`/`stat`) — those don't dump raw rows, so they still pass.
+_RAW_READ = re.compile(  # case-sensitive: match the `head` command, not git `HEAD`
+    r"\b(cat|bat|head|tail|less|more|nl|xxd|od|strings)\b"
+    r"|\bopen\s*\(|\.read(?:_text|lines)?\s*\(|\bjson\.load\b"
+)
+
 
 # A `*.py` token in a shell command — `python push.py`, `uv run … x.py`. The `\b`
 # after `.py` avoids matching `.python`. Quotes/pipes/parens bound the token.
@@ -149,6 +177,23 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
             return None  # invoking the sanctioned tools is the safe path
         if _WRITE_VERB.search(cmd) and _CANVAS_CTX.search(cmd):
             return _redirect("a direct Canvas grade write in a shell command")
+        # FERPA Zone-2 (#270): block a RAW read/display of a name-bearing file in a
+        # shell (`cat .keymap.json`, `head .deid_master.csv`, python open()) — the
+        # AGENTS.md rule enforced for Bash, not just the Read tool. An agent blocked
+        # from Read otherwise reaches for `cat`; reading the code↔user_id map into
+        # context IS the re-identification the two-zone model prevents. Sanctioned tools
+        # that legitimately read these (grader_reidentify) run via lib/tools/ → exempt.
+        # Metadata (`wc`/`ls`/`stat`) and the sanctioned `grep <code> … | cut -f1,2`
+        # verification aren't raw-display verbs, so they still pass.
+        if ("/lib/tools/" not in cmd.replace("\\", "/")
+                and _RAW_READ.search(cmd) and _FERPA_FILE.search(cmd)):
+            return (
+                "⛔ FERPA Zone-2 file — never cat/head/read it in a shell (AGENTS.md → FERPA "
+                "discipline). It maps de-id codes ↔ names/user_ids; reading it into context "
+                "IS the re-identification the two-zone model prevents. Verify with `wc -l` / "
+                "`ls` only. To re-identify, run grader_reidentify.py (it reads the keymap "
+                "internally, never surfacing it) — do NOT reconstruct the map by hand."
+            )
         # Run-catch: executing an EXISTING script whose BODY writes to Canvas. The
         # create (Write) / edit (Edit) hooks can't catch a script that already
         # exists, and the command string alone hides the write inside the file —

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.13.0"
+version = "1.14.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }


### PR DESCRIPTION
## Why

Two failure modes a live field session exposed:

1. An agent was correctly **blocked from `Read`-ing `.keymap.json`** (Zone-2) — then announced it would "work around the FERPA protection" and reached for **`cat .keymap.json`** in the shell to reconstruct the de-id → user_id map. The guardian's FERPA block only covered the Read *tool*, not `cat`/`head` in Bash.
2. A course script **regex-"extracted" a requested grade from students' prose** and emitted *"you requested an A"* to students who had asked for a C — fabricated feedback that reached real students.

## What

- **`grade_guardian` now blocks a raw READ of a Zone-2 file in Bash.** The Bash branch denies a raw-display verb (`cat`/`head`/`tail`/`less`/`more`/`nl`/`xxd`/`od`/`strings`, or python `open()`/`.read()`/`json.load`) applied to a Zone-2 file, and points to `grader_reidentify` (which reads the keymap internally, never surfacing it).
  - **Still allows** exactly what the constitution permits: `wc -l`/`ls`/`stat` metadata and the filtered `grep <code> … | cut -d',' -f1,2` verification (neither dumps raw rows). `lib/tools/` readers are exempt.
  - **Case-sensitive** so git `HEAD` is not mistaken for `head`.
- **"Final letters are READ, not parsed" is now a rule.** The constitution gains a grounding principle (any claim you repeat to a student comes from reading their letter in full — parse structured data, not prose; read or abstain), and the `grading` skill carries the detailed version with the failure story.

## Verification

- 38 guardian tests pass, incl. new: `cat`/`head`/`open()` on Zone-2 → blocked; `wc`/`ls`/`grep|cut`/git `HEAD` → allowed; `grader_reidentify --map .keymap.json` → exempt.
- Full suite running.

## Honest limit

Regex is not a semantic firewall (the guardian's standing caveat) — a determined agent can obfuscate (base64, variable indirection). This closes the obvious `cat`/`open()` vector and matches the constitution's exact wording; it doesn't claim to stop every reconstruction path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
