### PR TITLE
fix(cb_update): ignore toolkit skills by name, not the whole directory (#271, #272)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.14.1] — 2026-07-30
+
+**`cb_update` no longer gitignores the course's OWN skills (#271, #272).**
+
+`ensure_gitignore()` appended a blanket `.claude/skills/` — right for the toolkit's symlinks, wrong for a skill the course authored in that same folder. `cb_update` already models the distinction (`install_skill_symlinks()` returns `skip-course-owns` for a real directory it must not clobber) and then ignored those directories anyway.
+
+It failed *quietly*: `.gitignore` doesn't affect already-tracked files, so nothing broke at apply time. It bit the **next** course-owned skill added — untracked and ignored, so `git add -A` skipped it, `git status` never listed it, and it was simply never committed. Reported by a non-Canvas consumer (Brightspace) using the toolkit for its knowledge library and skills architecture, with six course-owned skills of its own.
+
+- **Ignore the toolkit's skills by name** (`.claude/skills/grading/`, …) instead of the directory. The ignore set now matches exactly what the tool creates, so anything classified `skip-course-owns` is protected **by construction** rather than by a negation list the consumer has to remember to extend. Fails safe in the right direction too: a newly shipped toolkit skill shows up as a tracked symlink (visible, trivially fixed) instead of a course-owned skill vanishing without a trace.
+- **Existing repos are migrated, not just new ones.** The old code returned `present` the moment it saw the blanket line, so a changed emit alone would have fixed only fresh repos and left every already-updated consumer — including the reporter's — broken. `--apply` now replaces a legacy blanket line in place (`migrated`), preserving surrounding entries and any consumer-added negations.
+- Consumers who added negations or a `pre-commit` guard as a workaround can keep them; they're harmless once the blanket line is gone.
+
+---
+
 ## [1.14.0] — 2026-07-29
 
 **Close the shell FERPA hole (`cat .keymap.json`) and codify "letters are read, not parsed" (#270).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -5,6 +5,7 @@ stale pointer in 6/9. These pin the two fixes: install skills at the course root
 (non-clobbering) and refresh the pointer in place.
 """
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -135,10 +136,61 @@ def test_install_never_clobbers_a_course_owned_skill(tmp_path):
     assert (owned / "SKILL.md").read_text(encoding="utf-8") == "course's own\n"  # intact
 
 
-def test_ensure_gitignore_adds_skills_line_once(tmp_path):
-    assert ensure_gitignore(tmp_path, apply=True) == "added"
-    assert ".claude/skills/" in (tmp_path / ".gitignore").read_text(encoding="utf-8")
-    assert ensure_gitignore(tmp_path, apply=True) == "present"  # idempotent
+def _gi_lines(tmp_path):
+    return (tmp_path / ".gitignore").read_text(encoding="utf-8").splitlines()
+
+
+def test_ensure_gitignore_ignores_toolkit_skills_by_name_not_the_directory(tmp_path):
+    """The blanket `.claude/skills/` also swallowed course-OWNED skills (#271).
+    Ignore only the names this tool installs."""
+    assert ensure_gitignore(tmp_path, ["grading", "audit"], apply=True) == "added"
+    lines = _gi_lines(tmp_path)
+    assert ".claude/skills/grading/" in lines and ".claude/skills/audit/" in lines
+    assert ".claude/skills/" not in lines                   # never the whole directory
+    assert ensure_gitignore(tmp_path, ["grading", "audit"], apply=True) == "present"
+
+
+def test_ensure_gitignore_migrates_the_legacy_blanket_line(tmp_path):
+    """Every repo an older cb_update already touched has the blanket line, and the
+    old code returned 'present' on sight of it — so a changed emit alone would fix
+    only fresh repos. Replace it in place."""
+    (tmp_path / ".gitignore").write_text(
+        "*.pyc\n.claude/skills/\n.env\n", encoding="utf-8")
+    assert ensure_gitignore(tmp_path, ["grading"], apply=False) == "would-migrate"
+    assert ".claude/skills/" in _gi_lines(tmp_path)          # dry-run wrote nothing
+    assert ensure_gitignore(tmp_path, ["grading"], apply=True) == "migrated"
+    lines = _gi_lines(tmp_path)
+    assert lines == ["*.pyc", ".claude/skills/grading/", ".env"]  # in place, nothing lost
+    assert ensure_gitignore(tmp_path, ["grading"], apply=True) == "present"  # idempotent
+
+
+def test_ensure_gitignore_adds_only_newly_shipped_skills(tmp_path):
+    ensure_gitignore(tmp_path, ["grading"], apply=True)
+    assert ensure_gitignore(tmp_path, ["grading", "improve"], apply=True) == "added"
+    assert _gi_lines(tmp_path).count(".claude/skills/grading/") == 1   # no duplicate
+
+
+def test_course_owned_skill_stays_visible_to_git(tmp_path):
+    """The bug as the consumer felt it: a course-authored skill added AFTER
+    cb_update ran was untracked AND ignored, so `git add -A` silently skipped it."""
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    owned = tmp_path / ".claude" / "skills" / "my-course-skill"
+    owned.mkdir(parents=True)
+    (owned / "SKILL.md").write_text("course's own\n", encoding="utf-8")
+    (tmp_path / ".gitignore").write_text(".claude/skills/\n", encoding="utf-8")  # legacy
+
+    def ignored(rel):
+        return subprocess.run(["git", "-C", str(tmp_path), "check-ignore", "-q", rel]
+                              ).returncode == 0
+
+    assert ignored(".claude/skills/my-course-skill/SKILL.md")      # the bug
+    ensure_gitignore(tmp_path, ["grading"], apply=True)
+    assert not ignored(".claude/skills/my-course-skill/SKILL.md")  # fixed
+    assert ignored(".claude/skills/grading/")                      # toolkit's own still ignored
+    status = subprocess.run(["git", "-C", str(tmp_path), "status", "--short", "-uall"],
+                            capture_output=True, text=True).stdout
+    assert "my-course-skill/SKILL.md" in status   # the consumer can finally commit it
+    assert "skills/grading" not in status         # toolkit symlinks still stay out
 
 
 def test_refresh_pointer_injects_into_course_agents(tmp_path):

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -118,20 +118,55 @@ def install_skill_symlinks(plan: list[tuple[Path, str]], apply: bool) -> list[tu
     return results
 
 
-def ensure_gitignore(course_root: Path, apply: bool) -> str:
-    """Make sure `.claude/skills/` is gitignored (the symlinks/copies point at the
-    gitignored vendored toolkit; re-created by this tool, not committed)."""
+_BLANKET = ".claude/skills/"   # what we used to write — too broad (see below)
+_GI_HEADER = "# canvas-toolbox skills (symlinks into the vendored toolkit)"
+
+
+def ensure_gitignore(course_root: Path, skills: list[str], apply: bool) -> str:
+    """Gitignore the toolkit's OWN skills by name — never the whole directory.
+
+    The symlinks/copies point at the gitignored vendored toolkit and are re-created
+    by this tool, so they shouldn't be committed. But `install_skill_symlinks()`
+    already knows a course can own a skill of its own in that same folder
+    (`skip-course-owns`), and the old blanket `.claude/skills/` line gitignored those
+    too. Quietly: .gitignore doesn't affect tracked files, so nothing broke at apply
+    time — it bit the NEXT course-owned skill added, which `git add -A` and
+    `git status` then silently skipped (#271, #272).
+
+    Ignoring `SKILLS` by name makes the ignore set exactly what this tool creates, so
+    a course-owned skill is protected by construction. It also fails safe in the
+    right direction: a newly shipped toolkit skill shows up as a tracked symlink
+    (visible, trivially fixed) instead of a course-owned skill vanishing untracked.
+
+    Returns present/would-add/added/would-migrate/migrated ("migrate" = a legacy
+    blanket line was replaced in place; without that, every repo already updated by
+    an older cb_update would keep the blanket line forever)."""
     gi = course_root / ".gitignore"
-    line = ".claude/skills/"
     existing = gi.read_text(encoding="utf-8") if gi.is_file() else ""
-    if line in existing.splitlines():
+    lines = existing.splitlines()
+    wanted = [f".claude/skills/{s}/" for s in skills]
+
+    if _BLANKET in lines:
+        if not apply:
+            return "would-migrate"
+        out = []
+        for ln in lines:
+            if ln == _BLANKET:
+                out.extend(w for w in wanted if w not in lines)  # replace in place
+            else:
+                out.append(ln)
+        gi.write_text("\n".join(out) + "\n", encoding="utf-8")
+        return "migrated"
+
+    missing = [w for w in wanted if w not in lines]
+    if not missing:
         return "present"
     if not apply:
         return "would-add"
     with gi.open("a", encoding="utf-8") as fh:
         if existing and not existing.endswith("\n"):
             fh.write("\n")
-        fh.write(f"# canvas-toolbox skills (symlinks into the vendored toolkit)\n{line}\n")
+        fh.write(_GI_HEADER + "\n" + "".join(f"{w}\n" for w in missing))
     return "added"
 
 
@@ -222,7 +257,11 @@ def main() -> int:
     print("Skills → .claude/skills/ (so Claude Code activates them here):")
     for name, status in install_skill_symlinks(plan, args.apply):
         print(f"  {status:16} {name}")
-    print(f"  gitignore .claude/skills/: {ensure_gitignore(course_root, args.apply)}")
+    gi_status = ensure_gitignore(course_root, SKILLS, args.apply)
+    print(f"  gitignore (toolkit skills, by name): {gi_status}")
+    if gi_status in ("migrated", "would-migrate"):
+        print("  ↳ replaced a blanket `.claude/skills/` ignore, which also hid the "
+              "course's OWN skills from git (#271). Course-owned skills are now visible.")
 
     fname, status = refresh_pointer(course_root, args.apply)
     print(f"\nConstitution+skills pointer in {fname}: {status}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.14.0"
+version = "1.14.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.8.13"
+version = "1.14.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #271. Closes #272.

`ensure_gitignore()` appended a blanket `.claude/skills/` to the course `.gitignore`. Correct for the toolkit's symlinks — they point into the gitignored vendored toolkit and are re-created by this tool — but it also swallowed any skill the **course** authored in that same folder.

As #272 sharpened it: `cb_update` already models the distinction. `install_skill_symlinks()` returns a first-class `skip-course-owns` for a real directory it must not clobber, and then `ensure_gitignore()` ~30 lines later gitignores those same directories.

### Why it was quiet

`.gitignore` has no effect on already-tracked files, so nothing broke at apply time. It bit the *next* course-owned skill added: untracked, so the blanket line hid it. `git add -A` skipped it, `git status` never listed it, and it was simply never committed. No error, no warning.

### The fix

**Ignore the toolkit's own skill names** (`.claude/skills/grading/`, …) rather than the directory. The ignore set now matches exactly what the tool creates, so anything classified `skip-course-owns` is protected **by construction** rather than by a negation list the consumer has to remember to extend. It also fails safe in the right direction: a newly shipped toolkit skill shows up as a tracked symlink (visible, trivially fixed) instead of a course-owned skill vanishing without a trace.

**Plus a migration, which neither issue called for but the fix is incomplete without.** The old code returned `present` the moment it saw the blanket line, so changing only the emit would have fixed fresh repos and left every already-updated consumer — including the reporter's — permanently broken. `--apply` now replaces a legacy blanket line **in place** (new status `migrated` / `would-migrate`), preserving surrounding entries and any consumer-added negations.

### Tests

The existing assert was `".claude/skills/" in text` — a substring of the per-skill lines, so it passed either way and was blind to this bug. Replaced with four that pin behavior:

- per-skill emit, and that the bare directory line is **never** written
- migration replaces a legacy blanket line in place, dry-run writes nothing, idempotent on re-run
- a newly shipped toolkit skill is appended without duplicating existing lines
- **the consumer-visible symptom, end-to-end in a real git repo** — `git check-ignore` shows a course-owned skill ignored before and visible after, the toolkit's own still ignored, and `git status -uall` lists the course skill as committable

`1103 passed` on the full suite; `ruff` clean.

### Notes

- Consumers who added `.gitignore` negations or a `pre-commit` guard as a workaround can keep them — harmless once the blanket line is gone.
- #272's secondary ask (`cb_report_bug --issue N` to comment on an existing issue, so an agent doesn't have to file a second issue to add context) is **not** in this PR — the `POST /comment` route lives in the edge-infra sister repo. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)