### PR TITLE
docs(ferpa): output discipline + Zone 2-Adjacent file class (#254 Phases 1–2)

### DIFF
--- a/.claude/skills/grading/SKILL.md
+++ b/.claude/skills/grading/SKILL.md
@@ -190,6 +190,10 @@ grader_standing.py --csv standing.csv --assignment-id <id> --push --yes --allow-
 - Zone-2 files (`.deid_master.csv`, `.keymap.json`, `.known_names.txt`,
   `.review.csv`, `submissions_raw/`, `feedback/_grader*.csv`) are **never** read or
   displayed. Verify with `wc -l` / `ls`, never `cat`/`head`/`grep`.
+- The working files you *do* read here (`_computed_grades.csv`,
+  `_gradebook_canvas.csv`, `_actual_grades.csv`) carry names. Reading them is fine;
+  **echoing a name out of them is not** — report every student as `user_id` or
+  `deid_code`. See the constitution's FERPA section (Zone 2-Adjacent).
 
 ## Final-letter grading — split the write, two sanctioned tools
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,14 +75,29 @@ surface:
 user_id, never the `sortable_name` column). Redirect to `/dev/null` or `cut` to
 columns 1,2 — never display raw rows.
 
-**Use codes, not names.** Tools accept `--deid-code`/`--user-id`; the *human* looks
-up the identifier locally and hands you the opaque code. You never re-identify.
-✅ "Reopened for user_id 280379" · ❌ "Reopened for Sam Bradshaw (280379)". If asked
-"who is user_id 280379?" → "I don't have the name mapping (FERPA Zone 2); check
-`grading/.deid_master.csv` locally."
+**These files are Zone 2-ADJACENT: read them freely, but NEVER echo a name out
+of them.** They're working files you legitimately need, and they carry names:
 
-*Two real incidents (2026-07-01, 2026-07-02) came from an agent reading/`head`-ing
-`.deid_master.csv` and surfacing a name. That is the failure this rule prevents.*
+- `grading/*/_computed_grades.csv` — computed grades, named
+- `grading/*/_gradebook_canvas.csv` — gradebook export, named
+- `grading/*/_actual_grades.csv` — pushed grades, named
+- `grading/*/FINAL_REVIEW_COMMENTS_*.md` — review comments, may name students
+
+**Use codes, not names — no matter which file the name came from.** Tools accept
+`--deid-code`/`--user-id`; the *human* looks up the identifier locally and hands you
+the opaque code. You never re-identify, and **being allowed to read a name never
+makes you allowed to print one** — refer to students only by `user_id` or
+`deid_code` in every response, summary, table, and commit message.
+✅ "Reopened for user_id 280379" · ❌ "Reopened for Sam Bradshaw (280379)"
+✅ "FR-B75C87 earned a B+ elevated to A" · ❌ "Student 280379 (Sam Bradshaw) …"
+If asked "who is user_id 280379?" → "I don't have the name mapping (FERPA Zone 2);
+check `grading/.deid_master.csv` locally."
+
+*Three real incidents. 2026-07-01 and 2026-07-02: an agent read/`head`-ed
+`.deid_master.csv` and surfaced a name — the READ failure, now also blocked by
+`grade_guardian`. 2026-07-28: an agent read names out of a legitimately-readable
+working file and printed them next to grades — the OUTPUT failure, which no read
+rule can catch. Both directions are covered above.*
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.15.0] — 2026-07-30
+
+**FERPA output discipline: being allowed to READ a name never makes you allowed to PRINT one (#254).**
+
+The constitution had input discipline (don't read `.deid_master.csv`) but no output rule. A 2026-07-28 field incident exposed the asymmetry: an agent read names out of a *legitimately readable* working file (`_computed_grades.csv`) and printed them next to grades. No read rule can catch that — the read was allowed.
+
+- **New Zone 2-ADJACENT file class** — `_computed_grades.csv`, `_gradebook_canvas.csv`, `_actual_grades.csv`, `FINAL_REVIEW_COMMENTS_*.md`. Read them freely; never echo a name out of them. Fills the gap between "never read" (Zone 2) and unclassified.
+- **The output rule is now unconditional** — students are referred to by `user_id`/`deid_code` in every response, summary, table, and commit message, *regardless of which file the name came from*. Added ✅/❌ pairs drawn from the actual incident phrasing.
+- The `grading` skill — where the incident happened — names the three working files it has you read and points at the constitution.
+- Incident note now records all three (2026-07-01, 2026-07-02 read failures; 2026-07-28 output failure) so the two directions are visibly distinct.
+
+Phases 1–2 of #254. Phase 3 (automated pre-output scanner) is **not** implementable as specified — no Claude Code hook can inspect or block assistant prose — and remains open for a scoped-down design; see the issue thread.
+
+---
+
 ## [1.14.1] — 2026-07-30
 
 **`cb_update` no longer gitignores the course's OWN skills (#271, #272).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.14.1"
+version = "1.15.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.14.1"
+version = "1.15.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Phases 1 and 2 of #254. Leaves the issue **open** for Phase 3 — see the note at the bottom.

The constitution had input discipline (don't read `.deid_master.csv`) but no output rule. The 2026-07-28 incident exposed the asymmetry precisely: an agent read names out of a **legitimately readable** working file (`_computed_grades.csv`) and printed them next to grades. No read rule can catch that — the read was allowed. `grade_guardian` was working as designed and the leak still happened.

### Changes

**New Zone 2-ADJACENT class** — `_computed_grades.csv`, `_gradebook_canvas.csv`, `_actual_grades.csv`, `FINAL_REVIEW_COMMENTS_*.md`. Read freely, never echo a name out of them. This fills the gap between Zone 2 ("never read") and unclassified, which is where every one of these files sat.

**The output rule is now unconditional** — `user_id`/`deid_code` in every response, summary, table, and commit message, *regardless of which file the name came from*. The existing "Use codes, not names" paragraph only implied this; it now says it, with ✅/❌ pairs drawn from the actual incident phrasing.

**The `grading` skill** — where the incident happened, and where an agent is actively reading `_computed_grades.csv` — names the three working files it has you read and points back at the constitution.

**The incident note** records all three, keeping the two failure directions visibly distinct: 2026-07-01 and 2026-07-02 were READ failures (now also blocked by `grade_guardian`); 2026-07-28 was an OUTPUT failure that no read rule can catch.

Scoped to this repo's constitution and skills. Consumer repos inherit via the pointer block `cb_update` refreshes, so `ds460-master` picks this up on its next `cb_update` — no per-repo edit needed.

### On Phase 3 — why it's not in this PR

Solution 3 asks for a "pre-output scanner to catch name leaks before conversation display." **That cannot be built.** Claude Code hooks fire on tool calls (`PreToolUse`/`PostToolUse`), prompt submit, and stop — there is no hook that can inspect or block assistant prose. Any "scanner" wired today would either run too late to prevent the leak or not run on the text at all.

Worth noting the gap is also narrower than the issue assumes:

- `lib/tools/grader_name_leak_check.py` already exists and scans deid outputs for roster names pre-cloud
- `grade_guardian` already blocks Zone-2 reads at **both** the Read tool and the shell (`cat`/`head`/`tail`/python `open()`), as of #270

Two realistic options remain — a `PostToolUse` hook that fires on a Zone-2-adjacent read and injects a don't-echo reminder at the moment of risk, or a post-hoc transcript audit (detection, not prevention). Left open for your call rather than guessed at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)