### PR TITLE
fix(cb_update): drop the trailing slash — it matched no symlink (#277)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.15.1] — 2026-08-04
+
+**Fix the 1.14.1 gitignore lines, which matched nothing they were meant to match (#277).**
+
+`ensure_gitignore()` emitted `.claude/skills/<name>/` **with a trailing slash**. In gitignore a trailing slash matches *directories only*, and `install_skill_symlinks()` creates **symlinks** — which git treats as files. So the corrected ignore set matched none of the artifacts the tool actually creates: on migration, all eight toolkit skills flipped to untracked, and a `git add -A` would have committed eight symlinks pointing into the gitignored vendored toolkit. Regression introduced by the #271 fix in 1.14.1; shipped in 1.14.1 and 1.15.0.
+
+- **Emit the pattern without a trailing slash.** A slashless pattern matches both the symlink and the real directory of the Windows copy fallback, so it's correct on either install path.
+- **Migrate the 1.14.1/1.15.0 lines too**, not just the pre-1.14 blanket line — otherwise every repo that took the last two releases keeps the broken patterns. Multiple legacy lines collapse to one corrected set, in place.
+- **The tests now ask real git about a real symlink.** The 1.14.1 tests shelled out to `git check-ignore` but passed it a trailing-slash *path*, which git resolves as a directory — a directory-only pattern matched a directory-shaped query, and the assertion confirmed itself. Two tests now install the actual symlink and assert on `git status --porcelain` of the worktree, pathspec-scoped so the vendored originals can't be mistaken for the links pointing at them. Verified by reintroducing the bug: 6 tests fail, including both real-git ones.
+
+*Reported by a Brightspace consumer running `cb_update --apply` at 1.15.0.*
+
+---
+
 ## [1.15.0] — 2026-07-30
 
 **FERPA output discipline: being allowed to READ a name never makes you allowed to PRINT one (#254).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -142,11 +142,13 @@ def _gi_lines(tmp_path):
 
 def test_ensure_gitignore_ignores_toolkit_skills_by_name_not_the_directory(tmp_path):
     """The blanket `.claude/skills/` also swallowed course-OWNED skills (#271).
-    Ignore only the names this tool installs."""
+    Ignore only the names this tool installs — and with NO trailing slash (#277),
+    since a trailing slash matches directories only and these are symlinks."""
     assert ensure_gitignore(tmp_path, ["grading", "audit"], apply=True) == "added"
     lines = _gi_lines(tmp_path)
-    assert ".claude/skills/grading/" in lines and ".claude/skills/audit/" in lines
+    assert ".claude/skills/grading" in lines and ".claude/skills/audit" in lines
     assert ".claude/skills/" not in lines                   # never the whole directory
+    assert not any(ln.startswith(".claude/skills/") and ln.endswith("/") for ln in lines)
     assert ensure_gitignore(tmp_path, ["grading", "audit"], apply=True) == "present"
 
 
@@ -160,37 +162,74 @@ def test_ensure_gitignore_migrates_the_legacy_blanket_line(tmp_path):
     assert ".claude/skills/" in _gi_lines(tmp_path)          # dry-run wrote nothing
     assert ensure_gitignore(tmp_path, ["grading"], apply=True) == "migrated"
     lines = _gi_lines(tmp_path)
-    assert lines == ["*.pyc", ".claude/skills/grading/", ".env"]  # in place, nothing lost
+    assert lines == ["*.pyc", ".claude/skills/grading", ".env"]  # in place, nothing lost
     assert ensure_gitignore(tmp_path, ["grading"], apply=True) == "present"  # idempotent
+
+
+def test_ensure_gitignore_migrates_1_14_1_trailing_slash_lines(tmp_path):
+    """1.14.1/1.15.0 wrote directory-only patterns that match no symlink (#277).
+    Those repos need migrating too, not just the pre-1.14 blanket ones."""
+    (tmp_path / ".gitignore").write_text(
+        "*.pyc\n.claude/skills/grading/\n.claude/skills/audit/\n.env\n", encoding="utf-8")
+    assert ensure_gitignore(tmp_path, ["grading", "audit"], apply=False) == "would-migrate"
+    assert ensure_gitignore(tmp_path, ["grading", "audit"], apply=True) == "migrated"
+    # both slashed lines collapse to the corrected set, in place, nothing else lost
+    assert _gi_lines(tmp_path) == [
+        "*.pyc", ".claude/skills/grading", ".claude/skills/audit", ".env"]
+    assert ensure_gitignore(tmp_path, ["grading", "audit"], apply=True) == "present"
 
 
 def test_ensure_gitignore_adds_only_newly_shipped_skills(tmp_path):
     ensure_gitignore(tmp_path, ["grading"], apply=True)
     assert ensure_gitignore(tmp_path, ["grading", "improve"], apply=True) == "added"
-    assert _gi_lines(tmp_path).count(".claude/skills/grading/") == 1   # no duplicate
+    assert _gi_lines(tmp_path).count(".claude/skills/grading") == 1   # no duplicate
+
+
+def _git(tmp_path, *args, **kw):
+    return subprocess.run(["git", "-C", str(tmp_path), *args],
+                          capture_output=True, text=True, **kw)
+
+
+def _untracked(tmp_path):
+    """What git sees under the COURSE-ROOT skills dir. Pathspec-scoped so the
+    vendored `canvas-toolbox/.claude/skills/<s>/` originals (untracked in these
+    fixtures) can't be mistaken for the symlinks that point at them."""
+    return _git(tmp_path, "status", "--porcelain", "-uall", "--", ".claude/skills").stdout
+
+
+def test_real_git_ignores_the_installed_symlink_not_just_the_pattern(tmp_path):
+    """#277 — the regression a pattern-only assertion cannot see. `check-ignore`
+    happily matches a trailing-slash pattern against a trailing-slash PATH, so the
+    only honest check is to install the real artifact and ask git about the worktree.
+    A symlink is a file to git; a directory-only pattern never matches it."""
+    course = _fake_course(tmp_path)
+    _git(course, "init", "-q", ".")
+    status = install_skill_symlinks(
+        plan_skill_symlinks(course, "canvas-toolbox", ["grading"]), apply=True)[0][1]
+    assert status in ("linked", "copied")          # the real artifact now exists
+    ensure_gitignore(course, ["grading"], apply=True)
+    assert "skills/grading" not in _untracked(course)
 
 
 def test_course_owned_skill_stays_visible_to_git(tmp_path):
-    """The bug as the consumer felt it: a course-authored skill added AFTER
-    cb_update ran was untracked AND ignored, so `git add -A` silently skipped it."""
-    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
-    owned = tmp_path / ".claude" / "skills" / "my-course-skill"
+    """The bug as the consumer felt it (#271): a course-authored skill added AFTER
+    cb_update ran was untracked AND ignored, so `git add -A` silently skipped it.
+    Asserted against a real worktree so it also covers #277 in the other direction —
+    the toolkit's own symlink must actually disappear from `git status`."""
+    course = _fake_course(tmp_path)
+    _git(course, "init", "-q", ".")
+    owned = course / ".claude" / "skills" / "my-course-skill"
     owned.mkdir(parents=True)
     (owned / "SKILL.md").write_text("course's own\n", encoding="utf-8")
-    (tmp_path / ".gitignore").write_text(".claude/skills/\n", encoding="utf-8")  # legacy
+    (course / ".gitignore").write_text(".claude/skills/\n", encoding="utf-8")  # legacy
+    install_skill_symlinks(
+        plan_skill_symlinks(course, "canvas-toolbox", ["grading"]), apply=True)
 
-    def ignored(rel):
-        return subprocess.run(["git", "-C", str(tmp_path), "check-ignore", "-q", rel]
-                              ).returncode == 0
-
-    assert ignored(".claude/skills/my-course-skill/SKILL.md")      # the bug
-    ensure_gitignore(tmp_path, ["grading"], apply=True)
-    assert not ignored(".claude/skills/my-course-skill/SKILL.md")  # fixed
-    assert ignored(".claude/skills/grading/")                      # toolkit's own still ignored
-    status = subprocess.run(["git", "-C", str(tmp_path), "status", "--short", "-uall"],
-                            capture_output=True, text=True).stdout
-    assert "my-course-skill/SKILL.md" in status   # the consumer can finally commit it
-    assert "skills/grading" not in status         # toolkit symlinks still stay out
+    assert "my-course-skill" not in _untracked(course)      # the bug: silently hidden
+    assert ensure_gitignore(course, ["grading"], apply=True) == "migrated"
+    after = _untracked(course)
+    assert "my-course-skill/SKILL.md" in after   # the consumer can finally commit it
+    assert "skills/grading" not in after         # toolkit's symlink still stays out
 
 
 def test_refresh_pointer_injects_into_course_agents(tmp_path):

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -134,27 +134,37 @@ def ensure_gitignore(course_root: Path, skills: list[str], apply: bool) -> str:
     `git status` then silently skipped (#271, #272).
 
     Ignoring `SKILLS` by name makes the ignore set exactly what this tool creates, so
-    a course-owned skill is protected by construction. It also fails safe in the
-    right direction: a newly shipped toolkit skill shows up as a tracked symlink
-    (visible, trivially fixed) instead of a course-owned skill vanishing untracked.
+    a course-owned skill is protected by construction.
 
-    Returns present/would-add/added/would-migrate/migrated ("migrate" = a legacy
-    blanket line was replaced in place; without that, every repo already updated by
-    an older cb_update would keep the blanket line forever)."""
+    **NO TRAILING SLASH on the emitted lines.** In gitignore a trailing slash matches
+    DIRECTORIES ONLY, and what this tool creates is a *symlink* — which git treats as
+    a file. 1.14.1 shipped `.claude/skills/<s>/` and so matched nothing it creates:
+    every toolkit skill flipped to untracked on migration, and a `git add -A` would
+    have committed symlinks pointing into the gitignored vendored toolkit (#277). A
+    slashless pattern matches both the symlink AND the real directory of the Windows
+    copy fallback, so it stays correct on either path. Tests assert against real git,
+    on a real symlink — a pattern-only assertion cannot see this class of bug.
+
+    Returns present/would-add/added/would-migrate/migrated ("migrate" = legacy lines
+    were replaced in place: 1.13-and-earlier's blanket `.claude/skills/`, or 1.14.1's
+    trailing-slash per-skill lines. Without that, repos already updated by an older
+    cb_update would keep the broken lines forever)."""
     gi = course_root / ".gitignore"
     existing = gi.read_text(encoding="utf-8") if gi.is_file() else ""
     lines = existing.splitlines()
-    wanted = [f".claude/skills/{s}/" for s in skills]
+    wanted = [f".claude/skills/{s}" for s in skills]        # no trailing slash — see above
+    legacy = {_BLANKET, *(f"{w}/" for w in wanted)}         # blanket, and 1.14.1's slashed
 
-    if _BLANKET in lines:
+    if any(ln in legacy for ln in lines):
         if not apply:
             return "would-migrate"
-        out = []
+        out, replaced = [], False
         for ln in lines:
-            if ln == _BLANKET:
-                out.extend(w for w in wanted if w not in lines)  # replace in place
-            else:
+            if ln not in legacy:
                 out.append(ln)
+            elif not replaced:                    # first legacy line → the corrected set
+                out.extend(w for w in wanted if w not in lines)
+                replaced = True                   # any further legacy lines just drop
         gi.write_text("\n".join(out) + "\n", encoding="utf-8")
         return "migrated"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.15.0"
+version = "1.15.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.15.0"
+version = "1.15.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #277. The reporter is right on every point, including the two docstring claims.

Regression from my #271 fix in 1.14.1, shipped in 1.14.1 and 1.15.0.

`ensure_gitignore()` emitted `.claude/skills/<name>/` **with a trailing slash**. In gitignore a trailing slash matches *directories only*, and `install_skill_symlinks()` creates **symlinks**, which git treats as files. So the "corrected" ignore set matched none of the artifacts the tool actually creates. On migration all eight toolkit skills flipped to untracked, and a `git add -A` would have committed eight symlinks pointing into the gitignored vendored toolkit.

Reproduced exactly as filed:

```
WITH trailing slash:     ?? .claude/skills/     <- NOT ignored
WITHOUT trailing slash:  (empty)                <- ignored
```

### Fix

- **Emit slashless.** Matches both the symlink and the real directory of the Windows copy fallback, so it holds on either install path — as the issue notes.
- **Migrate the 1.14.1/1.15.0 lines too**, not just the pre-1.14 blanket line. Without it, every repo that took the last two releases keeps the broken patterns. Multiple legacy lines collapse to one corrected set, in place.
- Corrected both docstring claims the issue flagged as now-inaccurate, and recorded *why* the slash is wrong so this doesn't get "tidied" back in.

### On why the suite stayed green

The issue says `test_cb_update.py` never shells out to `git check-ignore`. Close, but the actual failure is worse and worth recording: the 1.14.1 tests *did* call `check-ignore` — and passed it `.claude/skills/grading/`, a trailing-slash **path**, which git resolves as a directory. A directory-only pattern matched a directory-shaped query, against a symlink that wasn't even created in the fixture. The assertion confirmed itself.

So "add a `check-ignore` test" would not have been enough. The tests now **install the real symlink and ask git about the worktree**:

- `test_real_git_ignores_the_installed_symlink_not_just_the_pattern` — installs via `install_skill_symlinks()`, then asserts `git status --porcelain` is clean under the course-root skills dir
- `test_course_owned_skill_stays_visible_to_git` — now covers both directions on a real worktree: the course-owned skill appears, the toolkit's symlink disappears
- `test_ensure_gitignore_migrates_1_14_1_trailing_slash_lines` — the new migration path
- `_untracked()` is pathspec-scoped to `.claude/skills`, because the vendored `canvas-toolbox/.claude/skills/<s>/` originals are untracked in these fixtures and were substring-matching as false positives (caught while writing this)

**Verified the tests actually catch it** by reintroducing the trailing slash: 6 fail, including both real-git ones. That check is the thing that was missing last time.

1103 pass. The 2 failures in `test_sprint1.py` are live-Canvas integration tests hitting the sandbox course and fail identically on unmodified `main` — unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)