### PR TITLE
feat(grade_guardian): course-local Zone-2 patterns + honest coverage reporting (#278)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,12 @@ surface:
 - `grading/*/feedback/_grader*.csv` — grading sheets with names
 - `grading/**/submissions_raw/**` — raw submissions (potential name leaks)
 
+**A course adds its own Zone-2 files in `.claude/ferpa_zone2.txt`** (one regex per
+line). The list above is Canvas filenames; a course on another LMS has different
+name-bearing files, and `grade_guardian` enforces only what it knows about — an
+installed hook covering none of your files is worse than no hook. `cb_update` prints
+the active pattern count so "present" can't be read as "covered".
+
 **Verify with `wc -l` or `ls` only.** To confirm a code exists, filter columns:
 `grep "S-95DBB6" grading/.deid_master.csv | cut -d',' -f1,2` (shows deid_code +
 user_id, never the `sortable_name` column). Redirect to `/dev/null` or `cut` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.16.0] — 2026-08-04
+
+**`grade_guardian`'s FERPA set is extensible, and says what it actually covers (#278).**
+
+The Zone-2 pattern set was hardcoded to Canvas workflow filenames with no extension point. A non-Canvas consumer got the hook installed, got told `present`, and was protected against nothing — their name-bearing files had *zero* overlap with the pattern set. As the reporter put it, that line is true and misleading in the same breath: "present" reads as "covered."
+
+- **Course-local `.claude/ferpa_zone2.txt`** — one regex per line, `#` comments, unioned into both matchers. Consumer patterns are never anchored, since over-matching only blocks more reads while under-matching leaks. Invalid patterns are dropped rather than raised (a guardrail must never brick a session) but are reported loudly, because a silently-ignored pattern is the same false confidence in a new costume.
+- **`cb_update` prints the active pattern count** and, on a repo with no extension file, names the file to create. "Present" is no longer something the operator has to interpret.
+- **One source list, two compiled forms.** `_FERPA_PATH` and `_FERPA_FILE` were two hand-maintained regexes carrying a "kept in sync by hand" comment — and had already drifted: one was case-sensitive, and they disagreed on `.*` vs `[^/\\]*`. Both now derive from one list. **The path form is now case-insensitive**, closing a real hole: on a case-insensitive filesystem (macOS default) `Read .DEID_MASTER.csv` passed a block that `cat` caught.
+- **A D2L/Brightspace Classlist export is blocked out of the box.** It's the complete identity join for a section — name, username, email, and institutional id, one row per student — and it's the file most likely to be sitting in a downloads folder. Shipped as a default rather than left to config: the whole complaint is a hook that enforces nothing, and an unconfigured consumer would still be exposed on their most identifying artifact. The course code, term and timestamp around it vary; `Classlist_Export` is D2L's own export naming and doesn't. Costs Canvas repos nothing.
+
+*Reported from a Brightspace course repo running the toolkit since 1.8.0.*
+
+---
+
 ## [1.15.1] — 2026-08-04
 
 **Fix the 1.14.1 gitignore lines, which matched nothing they were meant to match (#277).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -52,6 +52,7 @@ from cb_update import (  # noqa: E402
     plan_skill_symlinks,
     install_skill_symlinks,
     ensure_gitignore,
+    print_zone2_coverage,
     refresh_pointer,
 )
 
@@ -243,3 +244,35 @@ def test_refresh_pointer_injects_into_course_agents(tmp_path):
 
 def test_refresh_pointer_reports_missing_when_no_agents_file(tmp_path):
     assert refresh_pointer(tmp_path, apply=True)[1] == "missing"
+
+
+# --- guardian Zone-2 coverage reporting (#278) ------------------------------
+
+def test_reports_zone2_coverage_and_names_the_extension_file(tmp_path, capsys):
+    """`grade_guardian hook: present` was true and misleading for a non-Canvas
+    consumer — installed, enforcing a Canvas-only set that matched none of their
+    files. Coverage has to be stated, not inferred."""
+    print_zone2_coverage(tmp_path)
+    out = capsys.readouterr().out
+    assert "Zone-2 patterns:" in out and "built-in" in out
+    assert ".claude/ferpa_zone2.txt" in out          # tells them where to extend
+
+
+def test_reports_course_local_pattern_count(tmp_path, capsys):
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "ferpa_zone2.txt").write_text(
+        "_all_posts\\.md\n_roster\\.json\n", encoding="utf-8")
+    print_zone2_coverage(tmp_path)
+    out = capsys.readouterr().out
+    assert "2 course-local" in out
+    assert "one regex per line" not in out           # already extended — no nag
+
+
+def test_warns_loudly_about_invalid_patterns(tmp_path, capsys):
+    """A dropped pattern is a silent hole — the exact false sense of coverage #278
+    is about. It must be impossible to miss."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "ferpa_zone2.txt").write_text("[unclosed\n", encoding="utf-8")
+    print_zone2_coverage(tmp_path)
+    out = capsys.readouterr().out
+    assert "not valid" in out and "IGNORED" in out and "[unclosed" in out

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -15,7 +15,8 @@ if str(_TOOLS_DIR) not in sys.path:
     sys.path.insert(0, str(_TOOLS_DIR))
 
 from grade_guardian import (evaluate, ensure_hook, hook_command,  # noqa: E402
-                            _extract_script_paths, ask_reason, _grader_push_checkpoint)
+                            _extract_script_paths, ask_reason, _grader_push_checkpoint,
+                            load_zone2, compile_zone2, zone2_summary)
 
 _BYPASS_BODY = ('import requests\n'
                 'requests.put("https://x.instructure.com/api/v1/courses/1/assignments/2/'
@@ -358,3 +359,132 @@ def test_bash_exempts_sanctioned_reidentify_reading_keymap():
     cmd = ("uv run python canvas-toolbox/lib/tools/grader_reidentify.py "
            "--challenge-dir grading/kc3 --map grading/kc3/.keymap.json")
     assert evaluate("Bash", {"command": cmd}) is None
+
+
+# --- Zone-2 pattern set: one source, two forms, course-local extension (#278) ---
+
+def test_both_zone2_forms_derive_from_one_list_and_cannot_drift():
+    """They were two hand-maintained regexes with a 'kept in sync by hand' comment,
+    and had already drifted (case sensitivity, `.*` vs `[^/\\]*`). Same source now."""
+    entries, invalid = load_zone2(Path("/nonexistent"))
+    assert invalid == []
+    path_re, file_re = compile_zone2(entries)
+    for stem in (".deid_master.csv", ".known_names.txt", ".keymap.json",
+                 ".fetch_log.json", ".review.csv"):
+        assert path_re.search(f"grading/{stem}"), stem      # anchored form
+        assert file_re.search(f"cat grading/{stem}"), stem  # shell form
+
+
+def test_zone2_path_form_is_case_insensitive():
+    """It used to be case-sensitive while the shell form wasn't, so on a
+    case-insensitive filesystem `Read .DEID_MASTER.csv` passed a block `cat` caught."""
+    path_re, _ = compile_zone2(load_zone2(Path("/nonexistent"))[0])
+    assert path_re.search("grading/.DEID_MASTER.CSV")
+
+
+def test_course_local_patterns_extend_the_set(tmp_path):
+    """The Brightspace case (#278): a non-Canvas consumer's name-bearing files have
+    ZERO overlap with the Canvas defaults, so the hook enforced an empty set."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "ferpa_zone2.txt").write_text(
+        "# a Brightspace course's name-bearing files\n"
+        "\n"
+        r"_all_posts\.md" "\n"
+        r"_roster\.json" "\n"
+        r"/txt_full/" "\n",
+        encoding="utf-8")
+    entries, invalid = load_zone2(tmp_path)
+    assert invalid == []
+    path_re, file_re = compile_zone2(entries)
+    assert path_re.search("discussions/m3/_all_posts.md")
+    assert file_re.search("cat discussions/m3/_roster.json")
+    assert file_re.search("head discussions/txt_full/x.txt")
+    assert path_re.search("grading/.keymap.json")     # defaults still enforced
+
+
+def test_invalid_course_patterns_are_dropped_but_reported(tmp_path):
+    """A typo must not brick the session — but a silently ignored pattern is the
+    false sense of coverage this issue is about, so it has to surface."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "ferpa_zone2.txt").write_text(
+        "_all_posts\\.md\n[unclosed\n", encoding="utf-8")
+    entries, invalid = load_zone2(tmp_path)
+    assert invalid == ["[unclosed"]
+    compile_zone2(entries)                            # the good ones still compile
+    assert zone2_summary(tmp_path)["invalid"] == ["[unclosed"]
+
+
+def test_zone2_summary_reports_counts_and_source(tmp_path):
+    bare = zone2_summary(tmp_path)
+    assert bare["extra"] == 0 and bare["source"] is None   # nothing to mislead about
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "ferpa_zone2.txt").write_text("_all_posts\\.md\n", encoding="utf-8")
+    s = zone2_summary(tmp_path)
+    assert s["default"] > 0 and s["extra"] == 1 and s["source"].endswith("ferpa_zone2.txt")
+
+
+def test_missing_or_unreadable_extension_file_is_silent(tmp_path):
+    """Absent file is the overwhelmingly common case (every Canvas repo) — no noise,
+    no failure."""
+    assert load_zone2(tmp_path) == (load_zone2(Path("/nonexistent"))[0], [])
+
+
+def test_hook_process_actually_blocks_a_course_local_zone2_file(tmp_path):
+    """End-to-end through the REAL hook process, because that's the only thing that
+    proves the extension point works. The pure-function tests above can all pass
+    while `evaluate()` still consults a stale module-level regex — the same class of
+    self-confirming test that let #277 ship. Run the hook the way Claude Code does:
+    tool call on stdin, CLAUDE_PROJECT_DIR set, exit 2 = blocked."""
+    import os
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "ferpa_zone2.txt").write_text(r"_all_posts\.md" "\n",
+                                                          encoding="utf-8")
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": str(tmp_path)}
+
+    def run(payload):
+        return subprocess.run([sys.executable, str(HOOK)], env=env, text=True,
+                              input=json.dumps(payload), capture_output=True)
+
+    blocked = run({"tool_name": "Read",
+                   "tool_input": {"file_path": "discussions/m3/_all_posts.md"}})
+    assert blocked.returncode == 2, blocked.stderr
+    assert "FERPA" in blocked.stderr
+
+    # the shell form too — `cat` was the #270 hole, and it must cover extras as well
+    shell = run({"tool_name": "Bash",
+                 "tool_input": {"command": "cat discussions/m3/_all_posts.md"}})
+    assert shell.returncode == 2, shell.stderr
+
+    # and a file NOT in either set still passes — the extension must not over-block
+    ok = run({"tool_name": "Read", "tool_input": {"file_path": "README.md"}})
+    assert ok.returncode == 0
+
+
+def test_hook_process_without_course_patterns_still_enforces_defaults(tmp_path):
+    """No extension file (every Canvas repo) — defaults must be untouched."""
+    import os
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": str(tmp_path)}
+    r = subprocess.run([sys.executable, str(HOOK)], env=env, text=True, capture_output=True,
+                       input=json.dumps({"tool_name": "Read",
+                                         "tool_input": {"file_path": "grading/.keymap.json"}}))
+    assert r.returncode == 2, r.stderr
+
+
+def test_classlist_export_is_blocked_out_of_the_box(tmp_path):
+    """The sharpest artifact from #278's follow-up: a D2L Classlist export is the
+    complete identity join for a section (name + username + email + institutional id,
+    one row per student). Shipped as a default rather than left to config, because an
+    unconfigured consumer is exactly the 'installed and enforcing nothing' case the
+    issue is about. `Classlist_Export` is D2L's invariant export naming — the course
+    code, term and timestamp around it vary, that substring doesn't."""
+    import os
+    real = "DAT 300 Data Mining 25EW6_Classlist_Export_2026-08-04-120000.csv"
+    path_re, file_re = compile_zone2(load_zone2(Path("/nonexistent"))[0])
+    assert path_re.search(f"rosters/{real}")
+    assert file_re.search(f"cat '~/Downloads/{real}'")     # where it actually lands
+
+    env = {**os.environ, "CLAUDE_PROJECT_DIR": str(tmp_path)}   # NO config file
+    r = subprocess.run([sys.executable, str(HOOK)], env=env, text=True, capture_output=True,
+                       input=json.dumps({"tool_name": "Read",
+                                         "tool_input": {"file_path": f"rosters/{real}"}}))
+    assert r.returncode == 2, r.stderr

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -51,8 +51,12 @@ from sync_grading_protocol import inject_grading_pointer
 
 try:
     from grade_guardian import ensure_hook as _ensure_guardian_hook
+    from grade_guardian import zone2_summary as _zone2_summary
+    from grade_guardian import _ZONE2_EXTRA_FILE
 except ImportError:
     _ensure_guardian_hook = None
+    _zone2_summary = None
+    _ZONE2_EXTRA_FILE = ".claude/ferpa_zone2.txt"
 
 SKILLS = ["grading", "course-build", "audit", "accommodations", "ferpa-deid",
           "title-iv", "voicing", "improve"]
@@ -228,6 +232,29 @@ def ensure_guardian_hook(course_root: Path, toolkit_subdir: str, apply: bool) ->
     return "installed"
 
 
+def print_zone2_coverage(course_root: Path) -> None:
+    """Report WHAT the guardian's FERPA set actually covers, not just that the hook
+    is wired. `grade_guardian hook: present` was true and misleading in the same
+    breath for a non-Canvas consumer: the hook was installed and enforcing a set of
+    Canvas filenames that matched none of their name-bearing files (#278). "Present"
+    reads as "covered." Printing the counts — and naming the extension file when a
+    repo has none — keeps that from being an inference the operator has to make."""
+    if _zone2_summary is None:
+        return
+    s = _zone2_summary(course_root)
+    extra = f" + {s['extra']} course-local" if s["extra"] else ""
+    print(f"  FERPA Zone-2 patterns: {s['default']} built-in{extra}")
+    if s["invalid"]:
+        print(f"  ⚠ {len(s['invalid'])} pattern(s) in {_ZONE2_EXTRA_FILE} are not valid "
+              f"regex and are being IGNORED — you are not covered on those:")
+        for bad in s["invalid"]:
+            print(f"      {bad}")
+    elif not s["source"]:
+        print(f"  ↳ built-ins are Canvas filenames. If this course keeps names in files "
+              f"of its own, list them in {_ZONE2_EXTRA_FILE} (one regex per line) — "
+              f"otherwise the hook is installed but not covering them.")
+
+
 def main() -> int:
     force_utf8_console()
     ap = argparse.ArgumentParser(
@@ -281,6 +308,7 @@ def main() -> int:
     if hook_status in ("installed", "would-install"):
         print("  ↳ this repo was missing the guardian — agents could hand-write "
               "Canvas writes / bypass gates. Now enforced at create/edit/run.")
+    print_zone2_coverage(course_root)
 
     print("\nReminder: `cd " + toolkit_subdir + " && git pull` keeps the toolkit "
           "(and the symlinked skills) current.")

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -56,8 +56,10 @@ HOW CLAUDE CODE INVOKES IT
 from __future__ import annotations
 
 import json
+import os
 import re
 import sys
+from pathlib import Path
 
 # A write verb: an HTTP mutation, however the script spells it.
 _WRITE_VERB = re.compile(
@@ -87,29 +89,103 @@ _TOOLS_PATH = re.compile(r"/lib/tools/[^/\\]+\.py$")
 _DOC_PATH = re.compile(r"\.(md|markdown|rst|txt)$", re.IGNORECASE)
 
 # FERPA Zone-2 files — never surface to an LLM (AGENTS.md → FERPA discipline, #212).
-_FERPA_PATH = re.compile(
-    r"\.deid_master\.csv$"
-    r"|\.known_names\.txt$"
-    r"|\.keymap\.json$"
-    r"|\.fetch_log\.json$"
-    r"|\.review\.csv$"
-    r"|/submissions_raw/"
-    r"|feedback/_grader.*\.csv$"
-)
+#
+# ONE source list, two compiled forms. They were two hand-maintained regexes with a
+# "kept in sync by hand" comment, and they had already drifted: one was case-sensitive
+# and used `.*` where the other used `[^/\\]*`. Deriving both removes the hazard.
+#
+# `(pattern, anchor)` — anchor=True appends `$` in PATH form (a filename suffix, e.g.
+# `.keymap.json`); anchor=False is a path fragment that can appear mid-path (e.g.
+# `/submissions_raw/`). FILE form is never anchored: it matches anywhere in a shell
+# command string, so the Bash branch catches `cat .keymap.json` (#270).
+_ZONE2_DEFAULT: list[tuple[str, bool]] = [
+    (r"\.deid_master\.csv", True),
+    (r"\.known_names\.txt", True),
+    (r"\.keymap\.json", True),
+    (r"\.fetch_log\.json", True),
+    (r"\.review\.csv", True),
+    (r"/submissions_raw/", False),
+    (r"feedback/_grader[^/\\]*\.csv", True),   # stricter of the two drifted forms
+    # The one non-Canvas default, and it earns its place: a D2L/Brightspace Classlist
+    # export is the complete identity join for a section — name, username, email, and
+    # institutional id on one row per student. The consumer who reported #278 argued
+    # no shipped pattern could anticipate it because the filename carries course code,
+    # term and timestamp. True of those parts, but `Classlist_Export` is D2L's own
+    # export naming and is invariant across institutions — so this IS anticipatable,
+    # and it matters: the complaint is that the hook installs and enforces nothing, and
+    # a consumer who never writes the config file below would still be unprotected on
+    # the most identifying file they hold. Costs Canvas repos nothing (no Canvas
+    # artifact is named this). Also matches it sitting in ~/Downloads, unanchored.
+    (r"Classlist_Export[^/\\]*\.csv", True),
+]
 
-# The same Zone-2 files, matched anywhere in a SHELL command (no end-anchor), so the
-# Bash branch can catch `cat .keymap.json` — the Read-tool block above doesn't cover a
-# shell read (#270). Kept in sync with _FERPA_PATH by hand.
-_FERPA_FILE = re.compile(
-    r"\.deid_master\.csv"
-    r"|\.known_names\.txt"
-    r"|\.keymap\.json"
-    r"|\.fetch_log\.json"
-    r"|\.review\.csv"
-    r"|/submissions_raw/"
-    r"|feedback/_grader[^/\\]*\.csv",
-    re.IGNORECASE,
-)
+# Course-local additions (#278). The defaults are Canvas-workflow filenames; a
+# consumer on another LMS has entirely different name-bearing files (a Brightspace
+# course's are `_all_posts.md`, `_roster.json`, `txt_full/` — zero overlap), and
+# before this the hook installed, reported `present`, and enforced an empty set for
+# them. One regex per line, `#` comments and blanks ignored. Consumer patterns are
+# NEVER anchored: over-matching only blocks more reads, under-matching leaks.
+_ZONE2_EXTRA_FILE = ".claude/ferpa_zone2.txt"
+
+
+def _course_root() -> Path | None:
+    """The course root as Claude Code reports it to the hook. None outside a hook run."""
+    d = os.environ.get("CLAUDE_PROJECT_DIR")
+    return Path(d) if d else None
+
+
+def load_zone2(course_root: Path | None = None) -> tuple[list[tuple[str, bool]], list[str]]:
+    """Resolved Zone-2 entries + any extra lines that failed to compile.
+
+    Invalid patterns are DROPPED rather than raised — a guardrail must never brick a
+    session over a typo in a config file. They're returned so `zone2_summary()` can
+    surface them, because a silently-ignored pattern is exactly the false sense of
+    coverage this issue is about."""
+    entries, invalid = list(_ZONE2_DEFAULT), []
+    root = course_root if course_root is not None else _course_root()
+    if root is None:
+        return entries, invalid
+    try:
+        text = (root / _ZONE2_EXTRA_FILE).read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return entries, invalid
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        try:
+            re.compile(line)
+        except re.error:
+            invalid.append(line)
+            continue
+        entries.append((line, False))       # unanchored — see above
+    return entries, invalid
+
+
+def compile_zone2(entries: list[tuple[str, bool]]) -> tuple[re.Pattern, re.Pattern]:
+    """(PATH form, FILE form) from one entry list. Both IGNORECASE — the PATH form
+    used to be case-sensitive, which on a case-insensitive filesystem (macOS default)
+    meant `Read .DEID_MASTER.csv` sailed through a block that `cat` caught."""
+    path_src = "|".join(p + ("$" if anchor else "") for p, anchor in entries)
+    file_src = "|".join(p for p, _ in entries)
+    return (re.compile(path_src, re.IGNORECASE), re.compile(file_src, re.IGNORECASE))
+
+
+def zone2_summary(course_root: Path | None = None) -> dict:
+    """For `cb_update` to report — so `present` can't be read as 'covering your
+    files'. {'default': int, 'extra': int, 'invalid': [str], 'source': str|None}."""
+    entries, invalid = load_zone2(course_root)
+    root = course_root if course_root is not None else _course_root()
+    src = root / _ZONE2_EXTRA_FILE if root else None
+    return {
+        "default": len(_ZONE2_DEFAULT),
+        "extra": len(entries) - len(_ZONE2_DEFAULT),
+        "invalid": invalid,
+        "source": str(src) if src and src.is_file() else None,
+    }
+
+
+_FERPA_PATH, _FERPA_FILE = compile_zone2(load_zone2()[0])
 
 # Raw display / read of a file's contents. The constitution forbids these on Zone-2
 # files ("not with Read, cat, head, tail, or bare grep"). Deliberately EXCLUDES the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.15.1"
+version = "1.16.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.15.1"
+version = "1.16.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #278.

The framing in the issue is the right one and worth keeping: a hook that installs, reports `present`, and enforces a pattern set matching none of your files is **worse than no hook**, because the operator reads "present" as "covered." This makes coverage a stated fact instead of an inference.

### Course-local extension point

`.claude/ferpa_zone2.txt` — one regex per line, `#` comments, unioned into both matchers.

- Consumer patterns are **never anchored**. Over-matching only blocks more reads; under-matching leaks. The asymmetry decides it.
- Invalid patterns are **dropped, not raised** — a guardrail must never brick a session over a typo — but are **reported loudly**, because a silently ignored pattern is the same false confidence in a new costume.

### `cb_update` states the coverage

```
  FERPA Zone-2 patterns: 8 built-in
  ↳ built-ins are Canvas filenames. If this course keeps names in files of its own,
    list them in .claude/ferpa_zone2.txt (one regex per line) — otherwise the hook
    is installed but not covering them.

  FERPA Zone-2 patterns: 8 built-in + 2 course-local
  ⚠ 1 pattern(s) in .claude/ferpa_zone2.txt are not valid regex and are being IGNORED
    — you are not covered on those:
      [oops
```

### One source list, two forms — and a real hole closed

Both smaller asks in the issue, done. `_FERPA_PATH` and `_FERPA_FILE` carried a "kept in sync by hand" comment and **had already drifted**: one was case-sensitive, and they disagreed on `.*` vs `[^/\\]*`. Both now derive from one list.

Deriving them surfaced a live bug: the path form was case-sensitive while the shell form wasn't, so on a **case-insensitive filesystem (macOS default)** `Read .DEID_MASTER.csv` sailed through a block that `cat .DEID_MASTER.csv` caught. Both are `IGNORECASE` now.

### One disagreement — the Classlist export ships as a default

The follow-up comment says the D2L Classlist export is *"nothing a shipped pattern could anticipate, which is the point."* Half right, and I think the other half matters more.

The course code, course name, term and timestamp do vary. But `Classlist_Export` is **D2L's own export naming**, invariant across institutions and terms — so it *is* anticipatable. And it should be anticipated, because the entire complaint here is a hook that enforces nothing: a consumer who never learns the config file exists would still be unprotected on the **complete identity join for their whole section** (name + username + email + institutional id, one row per student), in the file most likely to be sitting in a downloads folder.

Config alone would have left exactly the gap this issue is about. It's shipped as a default and covered by a test using the real filename from the comment. Costs Canvas repos nothing — no Canvas artifact is named that. The extension point still exists for everything genuinely local (`_all_posts.md`, `_roster.json`, `txt_full/`).

### Tests

12 new. Critically, two drive **the real hook process** with `CLAUDE_PROJECT_DIR` set and a tool call on stdin, asserting exit 2 — not just the pure functions. A pure-function test can pass while `evaluate()` still consults a stale module-level regex, which is precisely the self-confirming shape that let #277 ship.

Verified by breaking the extension point: 4 tests fail, including the end-to-end one.

1115 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests against the sandbox and fail identically on unmodified `main`.

### Not in this PR

#279's follow-up comment reframes that issue substantially — from "declare a third mode" to "model an identifier map as a first-class input," which is a design contract rather than a detection tweak. Left for a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)