### PR TITLE
feat(build_deid_master): --roster-json + org_id column — the non-Canvas identity contract (#279)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.17.0] — 2026-08-04
+
+**The consumer can supply the roster: a documented identifier-map contract for courses with no LMS API (#279).**
+
+`cb_init`/`cb_update` modelled two repo shapes — vendored-into-Canvas, and standalone toolkit. There's a real third: vendored into a course repo with **no Canvas at all**, wanting everything except the Canvas API — the constitution, the skills, `grade_guardian`, the FERPA zone discipline, and the N-pass consensus grading method, none of which touch Canvas.
+
+The follow-up on the issue sharpened it from "declare a mode" to the thing that actually costs manual effort: the toolkit assumes one canonical student identifier because Canvas hands you one. A consumer without an API has several and no authoritative mapping between them.
+
+- **`build_deid_master.py --roster-json <path>`** builds the master from a local file and **reads no credentials at all**. The contract is deliberately the shape Canvas already returns, so everything downstream — deid codes, `.deid_master.csv`, `.known_names.txt`, de-id, re-id, push — works unchanged. Validation is strict and loud (missing `id`/`name`, non-integer `id`, malformed JSON, and **duplicate ids rejected rather than collapsed**): a hand-built identifier map is exactly where a silent error becomes a misattributed grade.
+- **New `org_id` column** in `.deid_master.csv` for the institution's id — D2L `OrgDefinedId`, Canvas `sis_user_id`, same concept, so Canvas repos get it populated too. **Stored, never a key.** The reporting consumer measured *zero* overlap between the two id spaces across a 25-student section, so treating them as interchangeable silently misattributes grades. Appended last and readers use `csv.DictReader`, so a master written before this release still parses — no rebuild required.
+- **`cb_update` names the third shape** when no Canvas course is configured: which tools are inert, which of the toolkit still fully applies, and the way through (`--roster-json`, `.claude/ferpa_zone2.txt`). It reports what it *observed* rather than asserting a mode — absent credentials aren't proof a course isn't on Canvas, and telling someone their tools are inert when they aren't is its own failure. Silent for configured Canvas repos.
+
+*Reported from a Brightspace course repo running the toolkit since 1.8.0.*
+
+---
+
 ## [1.16.0] — 2026-08-04
 
 **`grade_guardian`'s FERPA set is extensible, and says what it actually covers (#278).**

--- a/lib/tests/test_build_deid_master_helpers.py
+++ b/lib/tests/test_build_deid_master_helpers.py
@@ -9,8 +9,13 @@ Source: lib/tools/build_deid_master.py
 
 No Canvas API calls. No filesystem writes. Pure functions in/out.
 """
+import csv
+import io
+import json
 import sys
 from pathlib import Path
+
+import pytest
 
 _TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
 if str(_TOOLS_DIR) not in sys.path:
@@ -25,6 +30,7 @@ from build_deid_master import (  # noqa: E402
     render_csv_rows,
     render_known_names_lines,
     student_to_row,
+    load_roster_json,
 )
 
 
@@ -251,10 +257,13 @@ def test_multiple_collisions_all_reported():
 # ---------------------------------------------------------------------------
 
 def test_render_csv_rows_header_first():
-    """The first row must be the header."""
+    """The first row must be the header. `org_id` appended LAST (1.17.0, #279) so
+    the addition is positionally additive for anything reading by index."""
     rows = [StudentRow("S-AAAAAA", 1, "Alpha, A", 0)]
     out = render_csv_rows(rows)
-    assert out[0] == ["deid_code", "user_id", "sortable_name", "withdrawn"]
+    assert out[0] == ["deid_code", "user_id", "sortable_name", "withdrawn", "org_id"]
+    assert out[0][:4] == ["deid_code", "user_id", "sortable_name", "withdrawn"]
+    assert out[1][4] == ""          # absent org_id serializes empty, never "None"
 
 
 def test_render_csv_rows_sorted_by_name():
@@ -371,3 +380,88 @@ def test_known_names_sorted_by_sortable_name():
     # First non-comment line should be Alpha (sortable, since
     # sorted by sortable_name → 'alpha, a' < 'beta, b' < 'zeta, z')
     assert body[0] == "Alpha, A"
+
+
+# ---------------------------------------------------------------------------
+# roster.json — the non-Canvas identifier-map contract (#279)
+# ---------------------------------------------------------------------------
+
+def _roster(tmp_path, payload):
+    p = tmp_path / "roster.json"
+    p.write_text(json.dumps(payload), encoding="utf-8")
+    return p
+
+
+def test_roster_json_round_trips_into_the_same_rows_canvas_would_produce(tmp_path):
+    """The contract IS the Canvas /users shape, so a non-Canvas consumer reuses the
+    whole downstream pipeline (de-id codes, master, known_names, re-id, push)."""
+    users = load_roster_json(_roster(tmp_path, [
+        {"id": 1395396, "name": "Farmer, Andrew", "org_id": "0123456"},
+        {"id": 1395397, "name": "Rembert, Cristen", "withdrawn": True},
+    ]))
+    rows = [student_to_row(u, "S-", 6) for u in users]
+    assert rows[0].user_id == 1395396
+    assert rows[0].org_id == "0123456"
+    assert rows[0].withdrawn == 0
+    assert rows[1].withdrawn == 1                     # explicit flag, no enrollments
+    # identical code to what Canvas would produce for the same id — the join holds
+    assert rows[0].deid_code == deid_code_for(1395396, "S-", 6)
+
+
+def test_org_id_is_stored_but_never_becomes_the_key(tmp_path):
+    """The reporting consumer measured ZERO overlap between internal ids and
+    OrgDefinedId across a 25-student section. Keying on the wrong one silently
+    misattributes grades, so org_id must not influence the code or the join."""
+    users = load_roster_json(_roster(tmp_path, [
+        {"id": 111, "name": "A", "org_id": "999999"},
+        {"id": 222, "name": "B", "org_id": "888888"},
+    ]))
+    rows = [student_to_row(u, "S-", 6) for u in users]
+    assert [r.deid_code for r in rows] == [deid_code_for(111), deid_code_for(222)]
+    assert [r.org_id for r in rows] == ["999999", "888888"]     # carried, not keyed
+
+
+def test_canvas_sis_user_id_populates_org_id_too():
+    """Same column, both worlds — Canvas calls the institution id sis_user_id."""
+    row = student_to_row({"id": 5, "name": "X", "sis_user_id": "00123"}, "S-", 6)
+    assert row.org_id == "00123"
+
+
+def test_roster_json_rejects_a_duplicate_id(tmp_path):
+    """Canvas duplicates are an API artifact that dedupe_users merges; a duplicate
+    in a HAND-BUILT map is a mistake in the map, and the master is one row per
+    student. Collapsing it silently would hide the error that matters most."""
+    path = _roster(tmp_path, [{"id": 7, "name": "A"}, {"id": 7, "name": "B"}])
+    with pytest.raises(ValueError, match="duplicate id 7"):
+        load_roster_json(path)
+
+
+@pytest.mark.parametrize("payload,expected", [
+    ({"id": 1}, "expected a JSON array"),
+    ([{"name": "no id"}], "missing required field 'id'"),
+    ([{"id": 1}], "missing required field 'name'"),
+    ([{"id": "not-a-number", "name": "A"}], "'id' must be an integer"),
+    (["just a string"], "expected an object"),
+])
+def test_roster_json_validation_is_loud(tmp_path, payload, expected):
+    """A hand-built identifier map is exactly where a silent error becomes a
+    misattributed grade."""
+    with pytest.raises(ValueError, match=expected):
+        load_roster_json(_roster(tmp_path, payload))
+
+
+def test_roster_json_reports_bad_json_and_missing_file(tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not json", encoding="utf-8")
+    with pytest.raises(ValueError, match="not valid JSON"):
+        load_roster_json(bad)
+    with pytest.raises(ValueError, match="cannot read"):
+        load_roster_json(tmp_path / "nope.json")
+
+
+def test_older_master_without_org_id_still_parses():
+    """The column is additive: readers use csv.DictReader, so a master written
+    before 1.17.0 keeps working rather than needing a rebuild."""
+    old = "deid_code,user_id,sortable_name,withdrawn\nS-AAA,1,\"Alpha, A\",0\n"
+    row = next(csv.DictReader(io.StringIO(old)))
+    assert row["user_id"] == "1" and row.get("org_id") is None

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -53,6 +53,8 @@ from cb_update import (  # noqa: E402
     install_skill_symlinks,
     ensure_gitignore,
     print_zone2_coverage,
+    print_lms_mode,
+    canvas_configured,
     refresh_pointer,
 )
 
@@ -276,3 +278,41 @@ def test_warns_loudly_about_invalid_patterns(tmp_path, capsys):
     print_zone2_coverage(tmp_path)
     out = capsys.readouterr().out
     assert "not valid" in out and "IGNORED" in out and "[unclosed" in out
+
+
+# --- the third repo shape: vendored into a NON-Canvas course (#279) ---------
+
+def test_canvas_configured_reads_env_file(tmp_path, monkeypatch):
+    monkeypatch.delenv("CANVAS_COURSE_ID", raising=False)
+    assert canvas_configured(tmp_path) is False              # no .env at all
+    (tmp_path / ".env").write_text("CANVAS_BASE_URL=x\nCANVAS_COURSE_ID=\n",
+                                   encoding="utf-8")
+    assert canvas_configured(tmp_path) is False              # present but EMPTY
+    (tmp_path / ".env").write_text('CANVAS_COURSE_ID="12345"\n', encoding="utf-8")
+    assert canvas_configured(tmp_path) is True               # quoted value counts
+
+
+def test_canvas_configured_prefers_the_environment(tmp_path, monkeypatch):
+    monkeypatch.setenv("CANVAS_COURSE_ID", "999")
+    assert canvas_configured(tmp_path) is True               # no .env needed
+
+
+def test_non_canvas_repo_is_told_what_still_applies(tmp_path, monkeypatch, capsys):
+    """#279: the mode was undeclared, so a consumer had to infer tool by tool which
+    parts applied. Most of the toolkit never touches the Canvas API."""
+    monkeypatch.delenv("CANVAS_COURSE_ID", raising=False)
+    print_lms_mode(tmp_path)
+    out = capsys.readouterr().out
+    assert "No Canvas course configured" in out
+    assert "inert" in out                                     # what does NOT work
+    for still_applies in ("constitution", "grade_guardian", "consensus grading"):
+        assert still_applies in out                           # ...and what does
+    assert "--roster-json" in out                             # the way through
+
+
+def test_canvas_repo_gets_no_mode_noise(tmp_path, monkeypatch, capsys):
+    """The overwhelmingly common case must stay silent — a guardrail that chatters
+    at everyone gets tuned out."""
+    monkeypatch.setenv("CANVAS_COURSE_ID", "12345")
+    print_lms_mode(tmp_path)
+    assert capsys.readouterr().out == ""

--- a/lib/tools/build_deid_master.py
+++ b/lib/tools/build_deid_master.py
@@ -13,11 +13,19 @@ identity surface. This tool fixes that — one CSV, one row per enrolled
 student, with a stable opaque code the operator can hand to other tools
 WITHOUT ever speaking the student's name to the agent or the cloud LLM.
 
-THE 4-COLUMN CONTRACT
+THE COLUMN CONTRACT
   deid_code     — stable opaque code, e.g. S-95DBB6 (sha256(user_id)[:6])
-  user_id       — Canvas numeric user_id, the source of truth
+  user_id       — numeric id, the source of truth and the key everything joins on
   sortable_name — "Lastname, Firstname" (NEVER read by tools unless explicit)
   withdrawn     — 1 if enrollment state is inactive/completed/deleted else 0
+  org_id        — the INSTITUTION's id (Canvas sis_user_id, D2L OrgDefinedId).
+                  Stored for the operator's own cross-system lookups; never a key.
+                  Added 1.17.0 — additive, and readers use csv.DictReader, so an
+                  older master without this column still parses.
+
+  `org_id` is deliberately NOT interchangeable with `user_id`. On the LMS that
+  prompted this (#279) the two id spaces had ZERO overlap across a 25-student
+  section, so treating either as the other silently misattributes grades.
 
 The `sortable_name` column lets the OPERATOR look up a student in their
 LOCAL gitignored file ("find Sydney → S-95DBB6") and hand the agent / tool
@@ -62,7 +70,12 @@ COLLISION MATH (sha256, first N hex chars uppercase, ~birthday paradox)
   8 hex (4B codes):  1000 students → 0.01% | 5000 → 0.3% | 10000 → 1.2%
   10 hex: practically collision-free at any class size.
 
+  # NOT on Canvas? Supply the roster yourself — no credentials needed (#279).
+  # See load_roster_json() for the full contract.
+  uv run python lib/tools/build_deid_master.py --roster-json grading/roster.json
+
 REQUIRES in .env: CANVAS_API_TOKEN, CANVAS_BASE_URL, CANVAS_COURSE_ID
+  ...unless --roster-json is used, which reads no credentials at all.
 
 Resolves issue #109 — course-wide de-id master + per-student
 accommodation primitives (the accommodation tool consumes this CSV).
@@ -77,6 +90,7 @@ except ImportError:
     def force_utf8_console() -> None:
         pass  # No-op if _env_loader not available
 import csv
+import json
 import hashlib
 import os
 import sys
@@ -110,6 +124,7 @@ class StudentRow:
     user_id: int
     sortable_name: str
     withdrawn: int  # 0 or 1
+    org_id: str = ""  # institution id (Canvas sis_user_id / D2L OrgDefinedId); "" if none
 
 
 def deid_code_for(user_id: int, prefix: str = _DEFAULT_PREFIX,
@@ -139,14 +154,78 @@ def is_withdrawn(enrollments: list[dict]) -> int:
 
 
 def student_to_row(user: dict, prefix: str, hash_bits: int) -> StudentRow:
-    """Build one StudentRow from a Canvas /users response item."""
+    """Build one StudentRow from a Canvas /users item OR a roster.json entry.
+
+    Both shapes are accepted deliberately — the roster contract (#279) is defined as
+    "what Canvas already returns", so a non-Canvas consumer supplies the same dict and
+    every downstream tool works unchanged. `withdrawn` may be given directly (a roster
+    has no enrollment objects) or derived from `enrollments` (Canvas)."""
     uid = int(user["id"])
+    withdrawn = user.get("withdrawn")
     return StudentRow(
         deid_code=deid_code_for(uid, prefix, hash_bits),
         user_id=uid,
         sortable_name=user.get("sortable_name") or user.get("name") or "",
-        withdrawn=is_withdrawn(user.get("enrollments") or []),
+        withdrawn=int(bool(withdrawn)) if withdrawn is not None
+        else is_withdrawn(user.get("enrollments") or []),
+        # Canvas calls it sis_user_id, D2L calls it OrgDefinedId — same thing.
+        org_id=str(user.get("org_id") or user.get("sis_user_id") or ""),
     )
+
+
+def load_roster_json(path: Path) -> list[dict]:
+    """Read a consumer-supplied roster (#279) — the non-Canvas path into this tool.
+
+    THE CONTRACT: a JSON array of objects, one per enrolled student.
+
+        [{"id": 1395396, "name": "Farmer, Andrew",
+          "org_id": "0123456", "withdrawn": false}, ...]
+
+      id        REQUIRED. The identifier the consumer's grading artifacts are keyed
+                on — for Brightspace, the internal user id in a submission filename,
+                NOT OrgDefinedId. This becomes user_id and seeds the deid_code, so it
+                must be the one that appears in the files you will actually de-identify.
+      name      REQUIRED. Display name; `sortable_name` also accepted.
+      org_id    Optional. The institution's id (D2L OrgDefinedId, Canvas sis_user_id).
+                Stored, never used as a key — the reporting consumer measured ZERO
+                overlap between the two id spaces on a 25-student section, so treating
+                them as interchangeable silently misattributes grades.
+      withdrawn Optional bool, default false.
+
+    Validation is strict and loud. A hand-built identifier map is exactly where a
+    silent error becomes a misattributed grade, and this consumer's whole difficulty
+    is three competing identifiers with no authoritative mapping between them."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as e:
+        raise ValueError(f"cannot read {path}: {e}") from e
+    except json.JSONDecodeError as e:
+        raise ValueError(f"{path} is not valid JSON: {e}") from e
+    if not isinstance(data, list):
+        raise ValueError(f"{path}: expected a JSON array of student objects, "
+                         f"got {type(data).__name__}")
+    seen: dict[int, int] = {}
+    for i, entry in enumerate(data):
+        where = f"{path} entry {i}"
+        if not isinstance(entry, dict):
+            raise ValueError(f"{where}: expected an object, got {type(entry).__name__}")
+        if "id" not in entry:
+            raise ValueError(f"{where}: missing required field 'id'")
+        try:
+            uid = int(entry["id"])
+        except (TypeError, ValueError):
+            raise ValueError(f"{where}: 'id' must be an integer, got {entry['id']!r}") from None
+        if not (entry.get("name") or entry.get("sortable_name")):
+            raise ValueError(f"{where}: missing required field 'name'")
+        if uid in seen:
+            # NOT collapsed silently. Canvas duplicates are a known API artifact
+            # (one row per section) that dedupe_users merges; a duplicate in a
+            # hand-built map is a mistake in the map, and the master's contract is
+            # one row per student.
+            raise ValueError(f"{where}: duplicate id {uid} (also at entry {seen[uid]}). "
+                             f"The master is one row per student — fix the roster.")
+        seen[uid] = i
+    return data
 
 
 def dedupe_users(users: list[dict]) -> tuple[list[dict], int]:
@@ -189,10 +268,10 @@ def detect_collisions(rows: list[StudentRow]) -> list[tuple[str, list[int]]]:
 def render_csv_rows(rows: list[StudentRow]) -> list[list[str]]:
     """Build the CSV body (header + rows). Sorted by sortable_name for
     deterministic output across runs."""
-    header = ["deid_code", "user_id", "sortable_name", "withdrawn"]
+    header = ["deid_code", "user_id", "sortable_name", "withdrawn", "org_id"]
     sorted_rows = sorted(rows, key=lambda r: r.sortable_name.lower())
     return [header] + [
-        [r.deid_code, str(r.user_id), r.sortable_name, str(r.withdrawn)]
+        [r.deid_code, str(r.user_id), r.sortable_name, str(r.withdrawn), r.org_id]
         for r in sorted_rows
     ]
 
@@ -309,27 +388,45 @@ def main() -> int:
                     help="overwrite an existing master without prompting")
     ap.add_argument("--dry-run", action="store_true",
                     help="print rows that would be written, don't touch the file")
+    ap.add_argument("--roster-json", type=Path, default=None,
+                    help="build from a local roster file instead of the Canvas API "
+                         "(non-Canvas consumers) — see load_roster_json for the "
+                         "contract. Needs no CANVAS_* credentials.")
     args = ap.parse_args()
-
-    base_url = os.environ.get("CANVAS_BASE_URL", "").rstrip("/")
-    if base_url and not base_url.startswith("http"):
-        base_url = "https://" + base_url
-    course_id = os.environ.get("CANVAS_COURSE_ID", "")
-    token = os.environ.get("CANVAS_API_TOKEN", "")
-    if not (base_url and course_id and token):
-        print("ERROR: CANVAS_BASE_URL / CANVAS_COURSE_ID / CANVAS_API_TOKEN "
-              "must be set in .env or the environment.", file=sys.stderr)
-        return 2
 
     if args.out.exists() and not args.force and not args.dry_run:
         print(f"ERROR: {args.out} already exists. Re-run with --force to overwrite.",
               file=sys.stderr)
         return 2
 
-    print(f"Fetching all students (active + invited + inactive + completed)...")
-    users = fetch_all_students(base_url, course_id, token)
-    print(f"  {len(users)} student records returned")
-    users, collapsed = dedupe_users(users)
+    if args.roster_json:
+        # The non-Canvas path (#279): the consumer supplies the identifier map. No
+        # credentials are read or required — the whole point is that a course on
+        # another LMS reuses the de-id / grading / push machinery unchanged.
+        try:
+            users = load_roster_json(args.roster_json)
+        except ValueError as e:
+            print(f"ERROR: {e}", file=sys.stderr)
+            return 2
+        print(f"Roster: {len(users)} student(s) from {args.roster_json}")
+        collapsed = 0
+    else:
+        base_url = os.environ.get("CANVAS_BASE_URL", "").rstrip("/")
+        if base_url and not base_url.startswith("http"):
+            base_url = "https://" + base_url
+        course_id = os.environ.get("CANVAS_COURSE_ID", "")
+        token = os.environ.get("CANVAS_API_TOKEN", "")
+        if not (base_url and course_id and token):
+            print("ERROR: CANVAS_BASE_URL / CANVAS_COURSE_ID / CANVAS_API_TOKEN "
+                  "must be set in .env or the environment.\n"
+                  "       Not on Canvas? Supply the roster yourself: --roster-json "
+                  "<path> (see the tool docstring for the contract).", file=sys.stderr)
+            return 2
+
+        print("Fetching all students (active + invited + inactive + completed)...")
+        users = fetch_all_students(base_url, course_id, token)
+        print(f"  {len(users)} student records returned")
+        users, collapsed = dedupe_users(users)
     if collapsed:
         print(f"  collapsed {collapsed} duplicate record(s) from multi-section "
               f"enrollments → {len(users)} unique students (one row per student)")

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -232,6 +232,48 @@ def ensure_guardian_hook(course_root: Path, toolkit_subdir: str, apply: bool) ->
     return "installed"
 
 
+def canvas_configured(course_root: Path) -> bool:
+    """Whether this repo has a Canvas course wired up. Checks the environment and
+    the course `.env` for a non-empty CANVAS_COURSE_ID."""
+    if os.environ.get("CANVAS_COURSE_ID", "").strip():
+        return True
+    try:
+        text = (course_root / ".env").read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return False
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line.startswith("CANVAS_COURSE_ID") and "=" in line:
+            if line.split("=", 1)[1].strip().strip("'\""):
+                return True
+    return False
+
+
+def print_lms_mode(course_root: Path) -> None:
+    """Name the third repo shape (#279): vendored into a course with NO Canvas.
+
+    cb_init/cb_update modelled exactly two — vendored-into-Canvas and standalone —
+    so a consumer on another LMS ran in an undeclared mode and had to infer, tool by
+    tool, which parts applied to them. Most of what the toolkit offers doesn't touch
+    the Canvas API at all.
+
+    Deliberately reports what was OBSERVED rather than asserting a mode: absent
+    credentials are not proof a course isn't on Canvas (creds live elsewhere, a fresh
+    clone hasn't been configured yet), and telling someone their tools are inert when
+    they aren't is its own failure."""
+    if canvas_configured(course_root):
+        return
+    print("\nNo Canvas course configured here (no CANVAS_COURSE_ID in the environment "
+          "or .env).")
+    print("  ↳ If that's expected — a course on another LMS — the Canvas-API tools "
+          "(canvas_sync, grader_fetch, grader_push, grader_standing) are inert, but "
+          "the constitution, the skills, grade_guardian, the FERPA zone discipline, "
+          "and the N-pass consensus grading method don't need Canvas and all apply.")
+    print("     Build the de-id master without credentials: "
+          "build_deid_master.py --roster-json <path>")
+    print("     Add your own name-bearing files to " + _ZONE2_EXTRA_FILE + ".")
+
+
 def print_zone2_coverage(course_root: Path) -> None:
     """Report WHAT the guardian's FERPA set actually covers, not just that the hook
     is wired. `grade_guardian hook: present` was true and misleading in the same
@@ -309,6 +351,7 @@ def main() -> int:
         print("  ↳ this repo was missing the guardian — agents could hand-write "
               "Canvas writes / bypass gates. Now enforced at create/edit/run.")
     print_zone2_coverage(course_root)
+    print_lms_mode(course_root)
 
     print("\nReminder: `cd " + toolkit_subdir + " && git pull` keeps the toolkit "
           "(and the symlinked skills) current.")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.16.0"
+version = "1.17.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.16.0"
+version = "1.17.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #279 — taking the follow-up's framing rather than the original title's.

The issue was filed as "declare a third repo mode." The follow-up reframed it, correctly: the mode being undeclared is a symptom, and the thing actually costing manual effort is that **the toolkit assumes one canonical student identifier because Canvas hands you one**. A consumer without an API has several, with no authoritative mapping between them.

Both are addressed, but the identity contract is the substance.

### `build_deid_master.py --roster-json <path>`

Builds the master from a local file and **reads no credentials at all**.

The contract is deliberately *the shape Canvas already returns*, so this is a substitution at one seam rather than a parallel code path — everything downstream (deid codes, `.deid_master.csv`, `.known_names.txt`, de-id, re-id, push) works unchanged:

```json
[{"id": 1395396, "name": "Farmer, Andrew", "org_id": "01234567", "withdrawn": false}]
```

`id` is documented as **the identifier your grading artifacts are keyed on** — for Brightspace the internal user id in the submission filename, *not* OrgDefinedId — because that's the one that has to match the files you'll actually de-identify.

Validation is strict and loud: missing `id`/`name`, non-integer `id`, malformed JSON, and **duplicate ids rejected rather than collapsed**. Canvas duplicates are a known API artifact that `dedupe_users` merges; a duplicate in a hand-built map is a mistake *in the map*, and silently collapsing it would hide the error that matters most. A hand-built identifier map is exactly where a silent error becomes a misattributed grade.

### New `org_id` column

The institution's id — D2L `OrgDefinedId`, Canvas `sis_user_id`. Same concept, so **Canvas repos get it populated too** rather than this being dead weight for them.

**Stored, never a key.** The follow-up reports zero overlap between the two id spaces across a 25-student section, so treating them as interchangeable silently misattributes grades. A test pins that `deid_code` is derived from `id` alone and is unaffected by `org_id`.

Appended last, and the one in-repo reader uses `csv.DictReader` with `.get()`, so **a master written before this release still parses** — no rebuild required. Exactly one existing test needed updating (the header assertion), which is the schema change itself.

### `cb_update` names the third shape

When no Canvas course is configured, it says which tools are inert, which of the toolkit still fully applies (constitution, skills, `grade_guardian`, FERPA discipline, the N-pass consensus grading method — none of which touch Canvas), and the way through.

It reports what it **observed**, not a mode it inferred: absent credentials aren't proof a course isn't on Canvas — they may live elsewhere, or a fresh clone may not be configured yet — and telling someone their tools are inert when they aren't is its own failure. Silent for configured Canvas repos, since a guardrail that chatters at everyone gets tuned out.

### Verification

End-to-end with every `CANVAS_*` var unset — a 3-student roster produced the master, `.known_names.txt`, and the grading gitignore:

```
Roster: 3 student(s) from grading/roster.json
  2 active, 1 withdrawn
Wrote 3 rows to grading/.deid_master.csv

deid_code,user_id,sortable_name,withdrawn,org_id
S-6C858F,1395398,"Esten Joseph, Susan",1,01234569
S-8A0C1B,1395396,"Farmer, Andrew",0,01234567
S-E9CF6C,1395397,"Rembert, Cristen",0,01234568
```

15 new tests. 1130 pass; the 2 `test_sprint1.py` failures are live-Canvas integration tests against the sandbox and fail identically on unmodified `main`.

### Not addressed here

The follow-up also describes name-parsing breakage (curly apostrophes, LMS-doubled surnames, inconsistent casing) and a roster that structurally can't know a non-submitter. Both are consequences of deriving the roster from *submissions*; supplying one becomes the fix, so they're out of scope for this PR rather than unaddressed. If normalisation helpers are still wanted after adopting the contract, that's worth its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)