### PR TITLE
docs(ferpa): student-facing text is Zone 2-Adjacent; name it given+initial (#280)

### DIFF
--- a/.claude/skills/voicing/SKILL.md
+++ b/.claude/skills/voicing/SKILL.md
@@ -15,6 +15,22 @@ feedback that reads differently every time and doesn't match the instructor's.
 **Before drafting any student-facing comment, load the course's voicing profile and
 write in that voice. Never make up a new one when a profile exists.**
 
+## How to name the student in it
+
+**Given name plus last initial — never a full surname**, not in headers, not in
+parentheticals, not in peer mentions. This is Zone 2-Adjacent text (constitution →
+FERPA discipline): the artifact IS the student-facing text, so a name belongs in it,
+but the convention limits what accumulates in the repo and in transcripts. It is
+exposure minimization, **not** de-identification — a first name plus an initial
+usually resolves to one person in a small section, so it never makes a name safe to
+place beside a score, a rubric criterion, or a standing. That line is unconditional.
+
+Operator-facing scaffolding in a working file — what you need to locate and confirm
+the right thread before delivering into it — is not student-facing text and may carry
+full names. The test is necessity for navigation, not convenience: if removing it
+wouldn't make the artifact harder to find, it isn't scaffolding. It lives under an
+already-gitignored path. See the constitution's FERPA section for the full rule.
+
 ## Find the profile (check, in order)
 
 1. **`grading/FEEDBACK_VOICE.md`** — the canonical location (what DS250 / ITM327 use)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,23 +81,69 @@ the active pattern count so "present" can't be read as "covered".
 user_id, never the `sortable_name` column). Redirect to `/dev/null` or `cut` to
 columns 1,2 — never display raw rows.
 
-**These files are Zone 2-ADJACENT: read them freely, but NEVER echo a name out
-of them.** They're working files you legitimately need, and they carry names:
+**Zone 2-ADJACENT — names may be present, but NEVER beside an evaluation.** This
+tier covers both files you legitimately READ that carry names, and student-facing
+text you WRITE:
 
-- `grading/*/_computed_grades.csv` — computed grades, named
-- `grading/*/_gradebook_canvas.csv` — gradebook export, named
-- `grading/*/_actual_grades.csv` — pushed grades, named
-- `grading/*/FINAL_REVIEW_COMMENTS_*.md` — review comments, may name students
+- *Reading:* `grading/*/_computed_grades.csv`, `grading/*/_gradebook_canvas.csv`,
+  `grading/*/_actual_grades.csv`, `grading/*/FINAL_REVIEW_COMMENTS_*.md`
+- *Writing:* student-facing text you draft for the operator to deliver to one
+  identified student (a discussion reply, a message asking which data set they used)
 
 **Use codes, not names — no matter which file the name came from.** Tools accept
 `--deid-code`/`--user-id`; the *human* looks up the identifier locally and hands you
 the opaque code. You never re-identify, and **being allowed to read a name never
 makes you allowed to print one** — refer to students only by `user_id` or
-`deid_code` in every response, summary, table, and commit message.
+`deid_code` in every response, summary, table, and commit message. (Text you draft
+*for a student to read* is the one place a name belongs — see the convention below.
+Everything you write *about* a student uses codes.)
 ✅ "Reopened for user_id 280379" · ❌ "Reopened for Sam Bradshaw (280379)"
 ✅ "FR-B75C87 earned a B+ elevated to A" · ❌ "Student 280379 (Sam Bradshaw) …"
 If asked "who is user_id 280379?" → "I don't have the name mapping (FERPA Zone 2);
 check `grading/.deid_master.csv` locally."
+
+**In student-facing text, the convention governs the TEXT, not the file.** Refer to
+a student by given name plus last initial — never a full surname, not in headers,
+not in parentheticals, not in peer mentions. This is **exposure minimization, not
+de-identification**: in a small section a first name plus an initial usually resolves
+to one person, and the student's full name is already visible on the thread the draft
+is destined for. What it limits is what accumulates in the repo and in transcripts.
+
+**Operator-facing scaffolding** — the material required to LOCATE and CONFIRM the
+right artifact before delivering into it — is not student-facing text and may carry
+full names. Typically the platform's printed name, the thread title and the
+timestamp; where those don't uniquely identify a thread it may include a short
+excerpt of the post, or another participant's name where that is what disambiguates.
+**The test is necessity for navigation, not convenience:** if removing it wouldn't
+make the artifact harder to find, it isn't scaffolding. Never a licence for
+name-bearing prose.
+
+A *peer's* name is the sharpest case — the naming convention above bans peer mentions
+in student-facing text, so admitting one here needs the strictest reading of that
+test: last resort, when name-plus-timestamp-plus-excerpt still doesn't disambiguate.
+
+Scaffolding must live under an **already-gitignored path** — a per-directory
+`.gitignore` containing `*`, written when the directory is created, as
+`build_deid_master.py` already does for `grading/`. Protection that ships with the
+directory survives edits to the root ignore file; a root rule is only as durable as
+the next person restructuring it. (A consumer restructuring theirs found a blanket
+grading-directory deny had been the only thing covering three other name-bearing
+paths, and a replacement line matched nothing because a trailing comment became part
+of the pattern. Both caught by checking, not by design.)
+
+**Operator-supplied names.** This rule governs what you produce on your own
+initiative. A name the operator supplies in the same turn may be used
+conversationally *within that turn* — repeating it discloses nothing they did not
+just write, and refusing teaches them the rule is unusable. It must not otherwise be
+persisted: not to a file, not to a commit message, not to any artifact outlasting
+the exchange.
+
+**Unchanged and unconditional: a name never appears beside a score, a rubric
+criterion, a grade band, or a standing.** No exception, no tier, no turn scope.
+
+*The judgment call has not been eliminated, only moved* — from "is this a
+facilitation draft?" to "is there an evaluation next to this name?" The second is a
+condition you can check; the first is an inference about intent. Keep checking.
 
 *Three real incidents. 2026-07-01 and 2026-07-02: an agent read/`head`-ed
 `.deid_master.csv` and surfaced a name — the READ failure, now also blocked by

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.18.0] — 2026-08-04
+
+**The output rule gets the half it was missing: what to write, not just what not to (#280).**
+
+1.15.0 made the FERPA output rule unconditional — codes, never names. Correct for everything written *about* a student, and unworkable for text written *for* one. A discussion reply is name-addressed by construction: the artifact IS the student-facing text, its destination is that student's own thread, and it carries no score.
+
+Filed as a request for a facilitation carve-out; the reporter then withdrew that ask and argued against it themselves, on the grounds that an exception you must classify into at the moment of writing is the wrong shape. Shipping their replacement instead.
+
+- **Zone 2-Adjacent now covers authored outputs, not just files you read.** The tier was defined as "files you legitimately READ that carry names" — all inputs. Student-facing text you WRITE is now explicitly in it, rather than filed there by analogy.
+- **The naming convention governs the TEXT, not the file:** given name plus last initial in student-facing text. Documented as **exposure minimization, not de-identification** — in a small section a first name plus an initial usually resolves to one person, and the student's full name is already on the thread the draft is destined for. What it limits is what accumulates in the repo and in transcripts. Labelling it de-identification invites "…therefore it's safe beside a grade," which is the exact boundary this rule exists to hold.
+- **Operator-facing scaffolding** — what you need to locate and confirm the right thread — may carry full names, gated on a **necessity-for-navigation test** rather than a field list: if removing it wouldn't make the artifact harder to find, it isn't scaffolding. A peer's name is called out as the sharpest case, since the convention bans peer mentions. Must live under an already-gitignored path, because protection that ships with the directory survives edits to the root ignore file.
+- **Operator-supplied names are scoped to the turn.** A name you were just handed may be used conversationally in that turn — repeating it discloses nothing the operator didn't just write, and refusing teaches them the rule is unusable. It must not be persisted beyond it.
+- **The hard line is unchanged and unconditional:** a name never appears beside a score, a rubric criterion, a grade band, or a standing.
+- The shipped text says plainly that **the judgment call moved rather than disappeared** — from "is this a facilitation draft?" to "is there an evaluation next to this name?" The second is checkable; the first is an inference about intent. A reader told "no classification needed" stops checking.
+- The `voicing` skill — loaded whenever student-facing text is drafted — carries the convention, so it's present where the decision is actually made.
+
+---
+
 ## [1.17.0] — 2026-08-04
 
 **The consumer can supply the roster: a documented identifier-map contract for courses with no LMS API (#279).**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.17.0"
+version = "1.18.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.17.0"
+version = "1.18.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #280 — shipping the reporter's **replacement** for what they filed, not the original ask.

1.15.0 made the output rule unconditional: codes, never names. Right for everything written *about* a student, unworkable for text written *for* one. A discussion reply is name-addressed by construction — the artifact **is** the student-facing text, its destination is that student's own thread, and it carries no score.

The issue asked for a facilitation carve-out. The reporter then withdrew that ask and argued against it themselves: an exception you have to classify into at the moment of writing is the same shape as the failure it's meant to prevent. That's the right call, and this ships what they proposed instead.

### What changed

- **Zone 2-Adjacent now covers authored outputs.** The tier was defined as "files you legitimately READ that carry names" — every member an input. Student-facing text you *write* is now explicitly in it, rather than filed there by analogy. A tier that accumulates members by resemblance stops meaning anything.
- **The convention governs the TEXT, not the file** — given name plus last initial. Documented as **exposure minimization, not de-identification**: in a small section a first name plus an initial usually resolves to one person, and the student's full name is already visible on the thread the draft is destined for. Labelling it de-identification invites "…therefore it's safe beside a grade," which is the exact boundary this exists to hold.
- **Scaffolding is gated on a test, not a field list** — what you need to locate and confirm the right thread may carry full names, if *removing it would make the artifact harder to find*. A peer's name is called out as the sharpest case, since the convention bans peer mentions. Must live under an **already-gitignored path**.
- **Operator-supplied names are scoped to the turn.** A name you were just handed may be used conversationally in that turn; it must not be persisted. Refusing to use a name the operator literally just typed teaches them the rule is unusable, which costs far more than it protects.
- **Unchanged and unconditional:** a name never appears beside a score, a rubric criterion, a grade band, or a standing.
- The `voicing` skill — loaded whenever student-facing text is drafted — carries the convention, so it's present at the moment the decision is made rather than only in the constitution.

### Two things I pushed back on, and one I got wrong

**Wrong:** my first draft had the convention governing whole *files*. That would have made their facilitation worksheet non-compliant the day it was written, since thread titles collide badly (17 of 23 in one module) and locating a thread means matching the platform's printed name. Their fix — the convention attaches to text destined for a student, not the file it lives in — is right and generalises cleanly.

**Pushed back, accepted:** the proposal claimed to eliminate the judgment call. It relocates it. The shipped text says so plainly — from "is this a facilitation draft?" to "is there an evaluation next to this name?" The second is checkable; the first is an inference about intent. A reader told "no classification needed" stops checking.

**Pushed back, then corrected myself:** I proposed bounding scaffolding to an enumerated three fields. They objected that this states a field list where the principle is a purpose, and hard-codes one platform's fields into a rule other consumers inherit — which is precisely the mistake #278 and #279 were both about. Their necessity-for-navigation test is better and is what shipped.

### Also fixed while in there

"Refer to students only by `user_id` or `deid_code` in **every response**" and "given name plus last initial in student-facing text" read as contradictory. Added the boundary explicitly: text drafted *for a student to read* is the one place a name belongs; everything written *about* a student uses codes. That ambiguity is exactly what produces an agent refusing to help write a reply.

1130 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests against the sandbox and fail identically on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)