### PR TITLE
feat(ferpa): pre-push guard on the git layer + ignore-coverage report (#285)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,14 @@ name-bearing files, and `grade_guardian` enforces only what it knows about — a
 installed hook covering none of your files is worse than no hook. `cb_update` prints
 the active pattern count so "present" can't be read as "covered".
 
+**The git layer is guarded too.** `grade_guardian` stops *you* reading these; it
+cannot see `git push`, and a push can't be undone. `cb_update` installs a
+`pre-push` hook reading that same pattern file, which checks the commit RANGE —
+history is what gets published, and a later commit deleting a file doesn't unpublish
+it. Path checks run by default; content scans (uid→name maps, roster surnames) are
+opt-in via `.claude/ferpa_scan_content`, because surname matching false-positives on
+ordinary prose. `cb_update` also reports name-bearing directories git isn't ignoring.
+
 **Verify with `wc -l` or `ls` only.** To confirm a code exists, filter columns:
 `grep "S-95DBB6" grading/.deid_master.csv | cut -d',' -f1,2` (shows deid_code +
 user_id, never the `sortable_name` column). Redirect to `/dev/null` or `cut` to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,27 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.19.0] — 2026-08-04
+
+**A FERPA guard on the git layer: `grade_guardian` can't see `git push`, and a push can't be undone (#285).**
+
+The toolkit protected the agent layer well and the git layer not at all. All three incidents in the constitution's record are agent-side — which isn't evidence the git layer is safe, only that it hadn't been exercised.
+
+A `pre-commit` guard isn't sufficient. It misses anything committed before the hook existed, with `--no-verify`, on another machine, or **anything correct at commit time that a later ignore-rule change exposes**. That last one actually happened: a consumer inverted a grading ignore block from deny-with-allowlist to source-tracked-by-default, and the blanket line removed turned out to be the sole cover for three other name-bearing paths. Nothing in that sequence is visible to a commit hook.
+
+- **New `lib/tools/ferpa_pre_push.py`**, installed by `cb_update` at `.git/hooks/pre-push`. Checks the **commit range**, not the working tree — history is what gets published, and a later commit deleting a file doesn't unpublish it. Handles the new-branch case (`--not --remotes`) that a naive `remote..local` gets wrong.
+- **One pattern list, not two.** It reads the same `.claude/ferpa_zone2.txt` as `grade_guardian`. A second list would drift, which is precisely the 1.16.0 bug one layer down.
+- **Graded, not all-on.** Path checks by default (cheap, deterministic, near-zero false positives). Content scans — uid→name maps, roster surnames — opt-in via `.claude/ferpa_scan_content`, because surname matching trips on ordinary prose, citations and package names, and for an operator who can't read the regex that's an unexplainable wall in front of their own work. It never silently degrades: if a scan is off, the denial says so.
+- **The denial is written for the person who hits it.** A blocked push lands on someone trying to share their work, and "rewrite history" is beyond most faculty — so the message leads with the non-destructive fix (a fresh branch from a clean tree), then history rewriting with a caution, then how to narrow a false-positive pattern. A message that only says what's wrong produces `--no-verify`.
+- **Filenames are withheld from output.** A matched filename may itself be a student name; the report names directories only.
+- **`cb_update` reports name-bearing directories git isn't ignoring** — catching the ignore-restructure class at update time, blocking nothing.
+
+**Not `core.hooksPath`.** The issue proposed it, since hooks aren't cloned. But git consults `core.hooksPath` *instead of* `.git/hooks/`, so setting it makes an existing `.git/hooks/pre-commit` inert — and `pre-commit install` then refuses to run, so it can't be recovered. That would silently disable the ruff/actionlint gate in this repo and any consumer using the pre-commit framework: the same "installed and enforcing nothing" failure #278 was filed about. Installing to the path git already reads has no such collateral, and the not-cloned problem is solved by `cb_update` being the per-clone step. A regression test pins that an existing `pre-commit` hook survives installation.
+
+*Reported, with a working implementation, from a Brightspace course repo.*
+
+---
+
 ## [1.18.0] — 2026-08-04
 
 **The output rule gets the half it was missing: what to write, not just what not to (#280).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -54,6 +54,7 @@ from cb_update import (  # noqa: E402
     ensure_gitignore,
     print_zone2_coverage,
     print_lms_mode,
+    print_ignore_coverage,
     canvas_configured,
     refresh_pointer,
 )
@@ -315,4 +316,51 @@ def test_canvas_repo_gets_no_mode_noise(tmp_path, monkeypatch, capsys):
     at everyone gets tuned out."""
     monkeypatch.setenv("CANVAS_COURSE_ID", "12345")
     print_lms_mode(tmp_path)
+    assert capsys.readouterr().out == ""
+
+
+# --- ignore-coverage report (#285) ------------------------------------------
+
+def _cov_repo(tmp_path):
+    subprocess.run(["git", "init", "-q", str(tmp_path)], check=True)
+    (tmp_path / "grading" / "kc3" / "submissions_raw").mkdir(parents=True)
+    (tmp_path / "grading" / ".deid_master.csv").write_text("x\n", encoding="utf-8")
+    (tmp_path / "grading" / "kc3" / "submissions_raw" / "Last_First_9.docx").write_text(
+        "x\n", encoding="utf-8")
+    (tmp_path / "README.md").write_text("ok\n", encoding="utf-8")
+    return tmp_path
+
+
+def test_reports_name_bearing_files_git_is_not_ignoring(tmp_path, capsys):
+    """The near-miss: an ignore-rule restructure left three name-bearing paths
+    uncovered at once, caught by checking rather than by design."""
+    print_ignore_coverage(_cov_repo(tmp_path))
+    out = capsys.readouterr().out
+    assert "grading/" in out and "submissions_raw/" in out
+    assert "Last_First_9.docx" not in out      # leaf withheld — it may BE a name
+
+
+def test_coverage_report_is_silent_when_properly_ignored(tmp_path, capsys):
+    """`git ls-files --others` lists IGNORED files unless --exclude-standard is
+    passed, so without it this fires even on a covered repo — and a warning that
+    always fires gets tuned out."""
+    repo = _cov_repo(tmp_path)
+    (repo / ".gitignore").write_text("grading/\n", encoding="utf-8")
+    print_ignore_coverage(repo)
+    assert capsys.readouterr().out == ""
+
+
+def test_coverage_report_still_flags_an_already_TRACKED_zone2_file(tmp_path, capsys):
+    """gitignore does not untrack. A committed Zone-2 file is exposed no matter what
+    the ignore rules say, so it must still be reported."""
+    repo = _cov_repo(tmp_path)
+    (repo / ".gitignore").write_text("grading/\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "-f", "grading/.deid_master.csv"],
+                   check=True, capture_output=True)
+    print_ignore_coverage(repo)
+    assert "grading/" in capsys.readouterr().out
+
+
+def test_coverage_report_skips_a_non_git_directory(tmp_path, capsys):
+    print_ignore_coverage(tmp_path)
     assert capsys.readouterr().out == ""

--- a/lib/tests/test_ferpa_pre_push.py
+++ b/lib/tests/test_ferpa_pre_push.py
@@ -1,0 +1,273 @@
+"""Unit + integration tests — the pre-push FERPA guard (#285).
+
+The agent-layer guardian can't see `git push`, and a push cannot be undone. These
+pin the two things that matter: it BLOCKS Zone-2 data reaching a remote, and it does
+not get in the way of ordinary work (a guard that cries wolf gets `--no-verify`'d).
+
+The end-to-end tests drive the real hook process in a real git repo, because the
+range logic is where this can silently do nothing — a pattern-only assertion is what
+let #277 ship.
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from ferpa_pre_push import (  # noqa: E402
+    _UID_NAME_MAP,
+    _dirs_of,
+    ensure_pre_push_hook,
+    format_block,
+    match_paths,
+    parse_push_specs,
+    range_args,
+)
+from grade_guardian import compile_zone2, load_zone2  # noqa: E402
+
+HOOK = _TOOLS_DIR / "ferpa_pre_push.py"
+_NULL = "0" * 40
+
+
+def _git(repo, *args, **kw):
+    return subprocess.run(["git", "-C", str(repo), *args],
+                          capture_output=True, text=True, **kw)
+
+
+def _repo(tmp_path):
+    """A real git repo with an origin it can push to (a bare remote)."""
+    bare = tmp_path / "origin.git"
+    _git(tmp_path, "init", "--bare", "-q", str(bare))
+    work = tmp_path / "work"
+    work.mkdir()
+    _git(work, "init", "-q", ".")
+    _git(work, "config", "user.email", "t@t.t")
+    _git(work, "config", "user.name", "T")
+    _git(work, "remote", "add", "origin", str(bare))
+    (work / "README.md").write_text("hi\n", encoding="utf-8")
+    _git(work, "add", "-A")
+    _git(work, "commit", "-qm", "init")
+    return work
+
+
+# --- stdin parsing + range resolution ---------------------------------------
+
+def test_parse_push_specs_skips_a_branch_deletion():
+    """A deletion publishes nothing — blocking it would be pure obstruction."""
+    text = (f"refs/heads/x {_NULL} refs/heads/x abc123\n"
+            f"refs/heads/y def456 refs/heads/y {_NULL}\n")
+    assert parse_push_specs(text) == [("def456", _NULL)]
+
+
+def test_parse_push_specs_ignores_malformed_lines():
+    assert parse_push_specs("garbage\n\n") == []
+
+
+def test_range_args_handles_a_new_branch():
+    """The case a naive `remote..local` gets wrong. With no base, exclude what's
+    already published anywhere rather than walking all history and blocking on an
+    ancient commit that isn't being pushed."""
+    assert range_args("abc", _NULL) == ["abc", "--not", "--remotes"]
+    assert range_args("abc", "def") == ["def..abc"]
+
+
+# --- path matching -----------------------------------------------------------
+
+def test_match_paths_uses_the_shared_zone2_list(tmp_path):
+    """One pattern source, not two. A second list would drift — the bug 1.16.0 fixed
+    a layer down after the guardian's own two regexes had already diverged."""
+    (tmp_path / ".claude").mkdir()
+    (tmp_path / ".claude" / "ferpa_zone2.txt").write_text(r"_all_posts\.md" "\n",
+                                                          encoding="utf-8")
+    path_re, _ = compile_zone2(load_zone2(tmp_path)[0])
+    hits = match_paths(
+        ["README.md", "grading/.deid_master.csv", "discussions/m3/_all_posts.md"],
+        path_re)
+    assert hits == ["grading/.deid_master.csv", "discussions/m3/_all_posts.md"]
+
+
+def test_uid_name_map_pattern_catches_serializations_but_not_prose():
+    for carrier in ('{"806485": "Jane Doe"}', "806485 = 'Jane Doe'",
+                    '1395396,"Farmer, Andrew"'):
+        assert _UID_NAME_MAP.search(carrier), carrier
+    for benign in ("version = '1.18.0'", "see RFC 2119", "{'count': 42}"):
+        assert not _UID_NAME_MAP.search(benign), benign
+
+
+# --- output never leaks a filename ------------------------------------------
+
+def test_output_withholds_leaf_filenames():
+    """A matched FILENAME may itself be a student name. Directories only — the whole
+    point of the guard is undone if the denial prints what it caught."""
+    hits = ["grading/kc3/submissions_raw/Lastname_Firstname_9912.docx"]
+    assert _dirs_of(hits) == ["grading/kc3/submissions_raw/"]
+    msg = format_block(hits, [], scanned_content=True)
+    assert "Lastname" not in msg and "Firstname" not in msg
+    assert "grading/kc3/submissions_raw/" in msg
+
+
+def test_block_message_leads_with_the_non_destructive_fix():
+    """A blocked push lands on someone trying to share their work, and 'rewrite
+    history' is beyond most faculty. A message that only says what's wrong produces
+    --no-verify."""
+    msg = format_block(["grading/.deid_master.csv"], [], scanned_content=True)
+    assert msg.index("git switch -c clean-work") < msg.index("filter-repo")
+    assert "--no-verify" in msg and "cannot be undone" in msg
+    assert "FALSE POSITIVE" in msg          # and how to narrow it
+
+
+def test_block_message_says_when_content_scanning_is_off():
+    """Never silently degrade — a guard that quietly does less is the same false
+    confidence #278 was filed about."""
+    off = format_block(["grading/.deid_master.csv"], [], scanned_content=False)
+    assert "content scanning is OFF" in off
+    on = format_block(["grading/.deid_master.csv"], [], scanned_content=True)
+    assert "content scanning is OFF" not in on
+
+
+# --- installer ---------------------------------------------------------------
+
+def test_installs_to_git_hooks_not_hookspath(tmp_path):
+    """NOT core.hooksPath: git consults that INSTEAD OF .git/hooks/, so setting it
+    silently disables an existing .git/hooks/pre-commit — and `pre-commit install`
+    then refuses to run. That would recreate the very failure #278 was about."""
+    repo = _repo(tmp_path)
+    assert ensure_pre_push_hook(repo, "canvas-toolbox", apply=False) == "would-install"
+    assert not (repo / ".git" / "hooks" / "pre-push").exists()
+    assert ensure_pre_push_hook(repo, "canvas-toolbox", apply=True) == "installed"
+    hook = repo / ".git" / "hooks" / "pre-push"
+    assert hook.is_file() and hook.stat().st_mode & 0o111       # executable
+    assert ensure_pre_push_hook(repo, "canvas-toolbox", apply=True) == "present"
+    assert _git(repo, "config", "--get", "core.hooksPath").stdout.strip() == ""
+
+
+def test_pre_commit_framework_hook_survives_install(tmp_path):
+    """The concrete regression: canvas-toolbox itself drives ruff/actionlint through
+    the pre-commit framework at .git/hooks/pre-commit. Installing must not touch it."""
+    repo = _repo(tmp_path)
+    pc = repo / ".git" / "hooks" / "pre-commit"
+    pc.write_text("#!/bin/sh\n# pre-commit framework\nexit 0\n", encoding="utf-8")
+    ensure_pre_push_hook(repo, "canvas-toolbox", apply=True)
+    assert "pre-commit framework" in pc.read_text(encoding="utf-8")
+
+
+def test_never_clobbers_a_foreign_pre_push_hook(tmp_path):
+    repo = _repo(tmp_path)
+    hook = repo / ".git" / "hooks" / "pre-push"
+    hook.write_text("#!/bin/sh\necho theirs\n", encoding="utf-8")
+    assert ensure_pre_push_hook(repo, "canvas-toolbox", apply=True) == "skip-foreign"
+    assert "theirs" in hook.read_text(encoding="utf-8")
+
+
+def test_reports_no_git_outside_a_repo(tmp_path):
+    assert ensure_pre_push_hook(tmp_path, "canvas-toolbox", apply=True) == "no-git"
+
+
+# --- end to end, through the real hook process -------------------------------
+
+def _run_hook(repo, local_sha, remote_sha):
+    return subprocess.run(
+        [sys.executable, str(HOOK)], cwd=str(repo), text=True, capture_output=True,
+        input=f"refs/heads/main {local_sha} refs/heads/main {remote_sha}\n")
+
+
+def test_clean_history_passes(tmp_path):
+    repo = _repo(tmp_path)
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    r = _run_hook(repo, sha, _NULL)
+    assert r.returncode == 0, r.stderr
+
+
+def test_a_zone2_file_in_the_range_blocks(tmp_path):
+    repo = _repo(tmp_path)
+    (repo / "grading").mkdir()
+    (repo / "grading" / ".deid_master.csv").write_text(
+        "deid_code,user_id\nS-A,1\n", encoding="utf-8")
+    _git(repo, "add", "-f", "grading/.deid_master.csv")
+    _git(repo, "commit", "-qm", "oops")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    r = _run_hook(repo, sha, _NULL)
+    assert r.returncode == 1
+    assert "PUSH BLOCKED" in r.stderr
+    assert "grading/" in r.stderr
+
+
+def test_deleting_the_file_later_still_blocks(tmp_path):
+    """History is what gets published. A later commit removing the file does not
+    unpublish it — checking the worktree instead of the range would miss this."""
+    repo = _repo(tmp_path)
+    (repo / "grading").mkdir()
+    (repo / "grading" / ".keymap.json").write_text("{}", encoding="utf-8")
+    _git(repo, "add", "-f", "grading/.keymap.json")
+    _git(repo, "commit", "-qm", "add")
+    _git(repo, "rm", "-q", "grading/.keymap.json")
+    _git(repo, "commit", "-qm", "remove")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    r = _run_hook(repo, sha, _NULL)
+    assert r.returncode == 1, "worktree is clean but history still carries it"
+
+
+def test_course_local_pattern_blocks_through_the_real_hook(tmp_path):
+    """The Brightspace case end-to-end: a consumer's own name-bearing file, at a
+    path no shipped pattern knows, blocked because the git layer reads the same
+    .claude/ferpa_zone2.txt the agent layer does."""
+    repo = _repo(tmp_path)
+    (repo / ".claude").mkdir()
+    (repo / ".claude" / "ferpa_zone2.txt").write_text(r"_all_posts\.md" "\n",
+                                                      encoding="utf-8")
+    (repo / "discussions").mkdir()
+    (repo / "discussions" / "_all_posts.md").write_text("post\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "posts")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    r = _run_hook(repo, sha, _NULL)
+    assert r.returncode == 1
+    assert "discussions/" in r.stderr
+    assert "_all_posts.md" not in r.stderr        # leaf withheld even here
+
+
+def test_content_scan_is_off_by_default_and_catches_when_enabled(tmp_path):
+    """A uid->name map at an unremarkable path: invisible to path checks, which is
+    exactly why the scan exists. Opt-in because surname scanning false-positives."""
+    repo = _repo(tmp_path)
+    (repo / "notes.md").write_text('{"806485": "Jane Doe"}\n', encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "notes")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    assert _run_hook(repo, sha, _NULL).returncode == 0        # default: path only
+    (repo / ".claude").mkdir(exist_ok=True)
+    (repo / ".claude" / "ferpa_scan_content").write_text("", encoding="utf-8")
+    r = _run_hook(repo, sha, _NULL)
+    assert r.returncode == 1 and "CONTENT" in r.stderr
+    assert "Jane" not in r.stderr                             # never echoes the name
+
+
+def test_fails_open_on_unparseable_stdin(tmp_path):
+    """A guardrail must never brick a repo."""
+    repo = _repo(tmp_path)
+    r = subprocess.run([sys.executable, str(HOOK)], cwd=str(repo), text=True,
+                       capture_output=True, input="not a push spec\n")
+    assert r.returncode == 0
+
+
+def test_installed_hook_actually_runs_on_a_real_push(tmp_path):
+    """The whole point. Install it the way cb_update does, then run a real
+    `git push` and assert git refuses."""
+    repo = _repo(tmp_path)
+    toolkit = repo / "canvas-toolbox" / "lib" / "tools"
+    toolkit.mkdir(parents=True)
+    for mod in ("ferpa_pre_push.py", "grade_guardian.py"):
+        (toolkit / mod).write_text((_TOOLS_DIR / mod).read_text(encoding="utf-8"),
+                                   encoding="utf-8")
+    ensure_pre_push_hook(repo, "canvas-toolbox", apply=True)
+    (repo / "grading").mkdir()
+    (repo / "grading" / ".known_names.txt").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-f", "grading/.known_names.txt", "canvas-toolbox")
+    _git(repo, "commit", "-qm", "leak")
+
+    r = _git(repo, "push", "origin", "HEAD:refs/heads/main")
+    assert r.returncode != 0, "git push should have been refused"
+    assert "PUSH BLOCKED" in (r.stdout + r.stderr)

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -52,11 +52,18 @@ from sync_grading_protocol import inject_grading_pointer
 try:
     from grade_guardian import ensure_hook as _ensure_guardian_hook
     from grade_guardian import zone2_summary as _zone2_summary
+    from grade_guardian import load_zone2 as _load_zone2
+    from grade_guardian import compile_zone2 as _compile_zone2
     from grade_guardian import _ZONE2_EXTRA_FILE
 except ImportError:
     _ensure_guardian_hook = None
-    _zone2_summary = None
+    _zone2_summary = _load_zone2 = _compile_zone2 = None
     _ZONE2_EXTRA_FILE = ".claude/ferpa_zone2.txt"
+
+try:
+    from ferpa_pre_push import ensure_pre_push_hook as _ensure_pre_push
+except ImportError:
+    _ensure_pre_push = None
 
 SKILLS = ["grading", "course-build", "audit", "accommodations", "ferpa-deid",
           "title-iv", "voicing", "improve"]
@@ -232,6 +239,52 @@ def ensure_guardian_hook(course_root: Path, toolkit_subdir: str, apply: bool) ->
     return "installed"
 
 
+def print_ignore_coverage(course_root: Path) -> None:
+    """Report name-bearing files that git is NOT ignoring (#285).
+
+    The near-miss this catches: a consumer inverted a grading ignore block from
+    deny-with-allowlist to source-tracked-by-default, and the blanket line removed
+    turned out to have been the SOLE cover for three other name-bearing paths. All
+    three were exposed at once, and were caught by checking rather than by design.
+
+    A pre-push hook catches that at the moment of danger; this catches it at update
+    time, blocks nothing, and so can't wall anyone off from their own work.
+
+    LEAF FILENAMES ARE WITHHELD — a matched filename may itself carry a student
+    name. Pattern, count and directory only."""
+    if _zone2_summary is None or _load_zone2 is None or _compile_zone2 is None:
+        return
+    if not (course_root / ".git").is_dir():
+        return
+    entries, _ = _load_zone2(course_root)
+    path_re, _ = _compile_zone2(entries)
+
+    # --exclude-standard is load-bearing: without it `--others` lists IGNORED files
+    # too, so this fires even on a correctly-covered repo — and a warning that always
+    # fires gets tuned out, which is the #278 failure in a new place.
+    # `--cached` has no such flag by design: a TRACKED file is already exposed
+    # regardless of what .gitignore says, so it belongs in the report.
+    r = subprocess.run(["git", "-C", str(course_root), "ls-files",
+                        "--cached", "--others", "--exclude-standard", "-z"],
+                       capture_output=True, text=True)
+    if r.returncode != 0:
+        return
+    exposed = sorted({str(Path(p).parent) + "/"
+                      for p in r.stdout.split("\0") if p and path_re.search(p)})
+    if not exposed:
+        return
+    print(f"\n⚠ {len(exposed)} director(ies) hold name-bearing files git is NOT "
+          f"ignoring:")
+    for d in exposed:
+        print(f"      {d.replace('./', '')}")
+    print("  ↳ filenames withheld (they may contain names). These are one `git add "
+          "-A` from a remote,")
+    print("    and a push cannot be undone. Add them to .gitignore — ideally a "
+          "`.gitignore` containing")
+    print("    `*` inside the directory itself, which survives edits to the root "
+          "ignore file.")
+
+
 def canvas_configured(course_root: Path) -> bool:
     """Whether this repo has a Canvas course wired up. Checks the environment and
     the course `.env` for a non-empty CANVAS_COURSE_ID."""
@@ -351,6 +404,18 @@ def main() -> int:
         print("  ↳ this repo was missing the guardian — agents could hand-write "
               "Canvas writes / bypass gates. Now enforced at create/edit/run.")
     print_zone2_coverage(course_root)
+
+    if _ensure_pre_push is not None:
+        pp = _ensure_pre_push(course_root, toolkit_subdir, args.apply)
+        print(f"FERPA pre-push guard (.git/hooks/pre-push): {pp}")
+        if pp in ("installed", "would-install"):
+            print("  ↳ the agent-layer guardian can't see `git push`. This checks the "
+                  "commit RANGE, since history is what gets published.")
+        elif pp == "skip-foreign":
+            print("  ↳ a pre-push hook already exists that we didn't write — left "
+                  "alone. Chain this in manually if you want both.")
+
+    print_ignore_coverage(course_root)
     print_lms_mode(course_root)
 
     print("\nReminder: `cd " + toolkit_subdir + " && git pull` keeps the toolkit "

--- a/lib/tools/ferpa_pre_push.py
+++ b/lib/tools/ferpa_pre_push.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""pre-push FERPA guard — the git layer (#285).
+
+WHY THIS EXISTS
+  `grade_guardian` stops the AGENT reading or shell-reading a Zone-2 file. Nothing
+  stopped the same data reaching a remote. All three incidents in the constitution's
+  record are agent-side; that isn't evidence the git layer is safe, only that it
+  hasn't been exercised. And unlike a bad read, **a push cannot be undone** — it is
+  cloned, cached and indexed by things you don't control.
+
+WHY NOT JUST A pre-commit HOOK
+  A commit hook catches a mistake as you make it and misses: anything committed
+  before the hook existed, anything committed with --no-verify, anything committed
+  on another machine, and anything correct at commit time that a LATER ignore-rule
+  change exposes. That last one is the one that actually happened: a consumer
+  inverted a grading ignore block from deny-with-allowlist to source-tracked-by-
+  default, and the blanket line removed had been the sole cover for three other
+  name-bearing paths. Nothing about that sequence is visible to a commit hook. It is
+  visible at push.
+
+  So this checks the COMMIT RANGE, not the working tree. History is what gets
+  published; a later commit deleting a file does not unpublish it.
+
+ONE PATTERN LIST, NOT TWO
+  Patterns come from `grade_guardian.load_zone2()` — the same `.claude/ferpa_zone2.txt`
+  the agent-layer hook reads. A second list would drift, which is the exact bug 1.16.0
+  fixed one layer down after `_FERPA_PATH` and `_FERPA_FILE` had already diverged.
+
+GRADED, NOT ALL-ON
+  Path checks run by default: cheap, deterministic, near-zero false positives.
+  Content scans are OPT-IN (`touch .claude/ferpa_scan_content`) because a roster
+  surname scan blocks on any tracked file containing a common surname — ordinary
+  prose, citations and package names all trip it, and for an operator who can't read
+  the regex that's an unexplainable wall in front of their own work.
+
+  It never silently degrades. If a scan is skipped, it says so — a guard that quietly
+  does less is the same false confidence #278 was filed about.
+
+FILENAMES ARE WITHHELD FROM OUTPUT
+  A matched path may itself carry a student name (`submissions_raw/Lastname_First…`).
+  The report names the PATTERN and the containing directory, never the leaf, and
+  tells the operator how to list them locally.
+
+HOW GIT INVOKES IT
+  Installed at `.git/hooks/pre-push` by cb_update. Git pipes
+  `<local ref> <local sha> <remote ref> <remote sha>` lines on stdin. Exit non-zero
+  blocks the push. Fails OPEN on internal error — a guardrail must never brick a repo.
+
+  NOT via `core.hooksPath`: that is consulted INSTEAD OF `.git/hooks/`, so setting it
+  makes an existing `.git/hooks/pre-commit` inert (and `pre-commit install` then
+  refuses to run). Installing to the path git already reads avoids that entirely, and
+  cb_update is itself the per-clone step, which is what "hooks aren't cloned" needs.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    from _env_loader import force_utf8_console
+except ImportError:
+    def force_utf8_console() -> None:
+        pass
+
+try:
+    from grade_guardian import load_zone2, compile_zone2
+except ImportError:                      # standalone / partial vendoring
+    load_zone2 = compile_zone2 = None
+
+_NULL_SHA = "0" * 40
+_SCAN_CONTENT_FLAG = ".claude/ferpa_scan_content"
+
+# A uid -> name mapping in any serialization: the single most dangerous artifact,
+# because it re-identifies every code in the repo at once. Deterministic enough to
+# be worth scanning for; unlike a surname it can't collide with ordinary prose.
+# `[ ,]{1,2}` not `[ ,]`: the CSV form is `1395396,"Farmer, Andrew"` — a comma AND a
+# space between the name parts. That's the .deid_master.csv shape, i.e. the case this
+# most needs to catch. Deliberately not `\s`, which would span newlines.
+_UID_NAME_MAP = re.compile(
+    r"""["']?\b\d{4,9}\b["']?[ ]*[:=,][ ]*["'][A-Z][a-z]+(?:[ ,]{1,2}[A-Z][a-z]+)+["']"""
+)
+
+
+def parse_push_specs(stdin_text: str) -> list[tuple[str, str]]:
+    """Git's pre-push stdin → [(local_sha, remote_sha)] worth checking.
+
+    Skips branch DELETIONS (local sha all-zeros): nothing is being published. A
+    remote sha of all-zeros means a NEW branch — the caller resolves that range
+    against all remotes rather than a nonexistent base."""
+    out = []
+    for line in stdin_text.splitlines():
+        parts = line.split()
+        if len(parts) != 4:
+            continue
+        _, local_sha, _, remote_sha = parts
+        if local_sha == _NULL_SHA:
+            continue                       # deleting a ref — publishes nothing
+        out.append((local_sha, remote_sha))
+    return out
+
+
+def range_args(local_sha: str, remote_sha: str) -> list[str]:
+    """`git log` args for the commits this push would publish.
+
+    New branch (remote all-zeros) is the case a naive `remote..local` gets wrong —
+    there is no base, so `--not --remotes` excludes everything already published
+    anywhere rather than walking the repo's entire history and blocking on an
+    ancient commit that is not being pushed."""
+    if remote_sha == _NULL_SHA:
+        return [local_sha, "--not", "--remotes"]
+    return [f"{remote_sha}..{local_sha}"]
+
+
+def _git(repo: Path, *args: str) -> str:
+    r = subprocess.run(["git", "-C", str(repo), *args],
+                       capture_output=True, text=True)
+    return r.stdout if r.returncode == 0 else ""
+
+
+def changed_paths(repo: Path, args: list[str]) -> list[str]:
+    """Every path touched by the commits in range, deduped. Uses --name-only over
+    the RANGE (not the worktree) so a file added and later deleted is still caught —
+    it is in the history being published either way."""
+    out = _git(repo, "log", "--format=", "--name-only", *args)
+    return sorted({ln.strip() for ln in out.splitlines() if ln.strip()})
+
+
+def match_paths(paths: list[str], path_re) -> list[str]:
+    return [p for p in paths if path_re.search(p)]
+
+
+def scan_content(repo: Path, args: list[str], paths: list[str],
+                 roster: list[str]) -> list[str]:
+    """OPT-IN. Returns the paths whose blob in this range carries a uid->name map or
+    a roster surname. Reads blobs from git rather than the worktree, since the
+    worktree may no longer contain what history does."""
+    hits = []
+    for p in paths:
+        blob = ""
+        for sha in _git(repo, "log", "--format=%H", *args).split():
+            blob = _git(repo, "show", f"{sha}:{p}")
+            if blob:
+                break
+        if not blob:
+            continue
+        if _UID_NAME_MAP.search(blob):
+            hits.append(p)
+            continue
+        for name in roster:
+            if name and re.search(rf"\b{re.escape(name)}\b", blob):
+                hits.append(p)
+                break
+    return hits
+
+
+def _load_roster(repo: Path) -> list[str]:
+    """Surnames for the opt-in scan. Reading `.known_names.txt` here is the same
+    sanctioned exception `grader_name_leak_check.py` already relies on — a local
+    tool may read it; nothing is surfaced to an LLM and no name is ever printed."""
+    try:
+        text = (repo / "grading" / ".known_names.txt").read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return []
+    names = []
+    for raw in text.splitlines():
+        line = raw.strip()
+        if line and not line.startswith("#"):
+            names.extend(t for t in re.split(r"[\s,]+", line) if len(t) >= 4)
+    return sorted(set(names))
+
+
+def _dirs_of(paths: list[str]) -> list[str]:
+    """Containing directories, deduped. The LEAF is withheld deliberately — a
+    matched filename may itself carry a student name."""
+    return sorted({(str(Path(p).parent) + "/").replace("./", "") or "./" for p in paths})
+
+
+def format_block(path_hits: list[str], content_hits: list[str],
+                 scanned_content: bool) -> str:
+    """The denial an operator actually has to act on. A blocked push arrives at the
+    moment someone is trying to share their work, and the honest remedy (rewriting
+    history) is beyond most faculty — so this leads with the fix that does NOT
+    require it. A message that only says what is wrong produces `--no-verify`."""
+    n = len(set(path_hits) | set(content_hits))
+    lines = [
+        "",
+        "⛔ PUSH BLOCKED — FERPA Zone-2 data in the commits being pushed.",
+        "",
+        f"  {n} file(s) in this push match a protected pattern.",
+        "  Filenames are withheld here on purpose — a matched filename may itself",
+        "  contain a student name. Directories only:",
+        "",
+    ]
+    for d in _dirs_of(path_hits + content_hits):
+        lines.append(f"      {d}")
+    if content_hits:
+        lines += ["", "  Some matched on CONTENT (a uid→name map or a roster name),",
+                  "  not just their path."]
+    if not scanned_content:
+        lines += ["", "  NOTE: content scanning is OFF (path checks only). Enable with",
+                  f"  `touch {_SCAN_CONTENT_FLAG}` — it catches name-bearing files at",
+                  "  unremarkable paths, at the cost of occasional false positives."]
+    lines += [
+        "",
+        "WHAT TO DO — in order:",
+        "",
+        "  1. See which files, locally:",
+        "       git log --format= --name-only <your-branch> | sort -u",
+        "",
+        "  2. If they should never have been committed, the SAFEST fix — no history",
+        "     rewriting, nothing destructive:",
+        "       git switch -c clean-work            # fresh branch",
+        "       # re-add only the files you mean to publish, commit, then:",
+        "       git push -u origin clean-work",
+        "",
+        "  3. Rewriting history (git filter-repo, interactive rebase) removes them",
+        "     from past commits, but is easy to get wrong and rewrites what others",
+        "     may have pulled. Ask before doing this on a shared repo.",
+        "",
+        "  4. FALSE POSITIVE? If the match carries no student data, narrow the",
+        "     pattern in .claude/ferpa_zone2.txt — don't disable the hook.",
+        "",
+        "  --no-verify would publish this. That cannot be undone.",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+HOOK_BODY = """\
+#!/bin/sh
+# canvas-toolbox FERPA pre-push guard (#285). Reinstalled by cb_update.
+# FAILS OPEN if the toolkit is missing — a guardrail must never brick a repo.
+f="$(git rev-parse --show-toplevel)/{subdir}/lib/tools/ferpa_pre_push.py"
+[ -f "$f" ] || exit 0
+exec python3 "$f"
+"""
+
+
+def ensure_pre_push_hook(repo: Path, toolkit_subdir: str, apply: bool) -> str:
+    """Install `.git/hooks/pre-push`. Returns present/would-install/installed/
+    skip-foreign/no-git.
+
+    Deliberately NOT `core.hooksPath`: git consults that INSTEAD OF `.git/hooks/`,
+    so setting it silently disables an existing `.git/hooks/pre-commit` (and
+    `pre-commit install` then refuses to run at all). Writing the file git already
+    reads has no such collateral. The "hooks aren't cloned" problem is real — and is
+    solved by cb_update being the per-clone step, not by moving the hooks directory.
+
+    Never clobbers a hook we didn't write."""
+    hooks = repo / ".git" / "hooks"
+    if not (repo / ".git").is_dir():
+        return "no-git"
+    body = HOOK_BODY.format(subdir=toolkit_subdir)
+    target = hooks / "pre-push"
+    if target.is_file():
+        existing = target.read_text(encoding="utf-8", errors="replace")
+        if "canvas-toolbox FERPA pre-push guard" not in existing:
+            return "skip-foreign"          # someone else's hook — theirs to keep
+        if existing == body:
+            return "present"
+    if not apply:
+        return "would-install"
+    hooks.mkdir(parents=True, exist_ok=True)
+    target.write_text(body, encoding="utf-8")
+    target.chmod(0o755)
+    return "installed"
+
+
+def main() -> int:
+    force_utf8_console()
+    if "--help" in sys.argv[1:]:
+        print(__doc__.split("\n")[0])
+        return 0
+    if load_zone2 is None:
+        return 0                            # no pattern source → fail open
+    repo = Path(_git(Path.cwd(), "rev-parse", "--show-toplevel").strip() or ".")
+    try:
+        specs = parse_push_specs(sys.stdin.read())
+    except (OSError, ValueError):
+        return 0
+    if not specs:
+        return 0
+
+    entries, _ = load_zone2(repo)
+    path_re, _ = compile_zone2(entries)
+    scan_on = (repo / _SCAN_CONTENT_FLAG).exists()
+    roster = _load_roster(repo) if scan_on else []
+
+    path_hits, content_hits = [], []
+    for local_sha, remote_sha in specs:
+        args = range_args(local_sha, remote_sha)
+        paths = changed_paths(repo, args)
+        path_hits += match_paths(paths, path_re)
+        if scan_on:
+            rest = [p for p in paths if p not in set(path_hits)]
+            content_hits += scan_content(repo, args, rest, roster)
+
+    if not (path_hits or content_hits):
+        return 0
+    print(format_block(sorted(set(path_hits)), sorted(set(content_hits)), scan_on),
+          file=sys.stderr)
+    return 1
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except SystemExit:
+        raise
+    except Exception:                       # noqa: BLE001 — fail OPEN, always
+        raise SystemExit(0) from None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.18.0"
+version = "1.19.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.18.0"
+version = "1.19.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #285. The argument is right: the toolkit protected the agent layer well and the git layer not at all. `grade_guardian` is a PreToolUse hook — it stops *you* reading a Zone-2 file and cannot see `git push`. And unlike a bad read, **a push cannot be undone**.

Their point that all three incidents in the record being agent-side isn't evidence the git layer is safe — only that it hasn't been exercised — is the correct read.

### One design change: not `core.hooksPath`

The issue's central mechanism would have caused the failure it was written to prevent, and I can show it rather than argue it.

Git consults `core.hooksPath` **instead of** `.git/hooks/`, not in addition. This repo drives ruff and actionlint through the pre-commit framework at `.git/hooks/pre-commit` — setting `core.hooksPath` makes that inert, and `pre-commit install` then **refuses to run** while it's set, so it can't be recovered without knowing why. That's "installed and enforcing nothing," which is #278.

The underlying observation — hooks aren't cloned, so a tracked hook file is present and inert — is correct and important. But the answer isn't relocating the hooks directory: **`cb_update` is already the per-clone step**. It writes `.git/hooks/pre-push` directly, which is the path git reads natively, doesn't collide with the framework's `pre-commit` file, and needs no config change. `test_pre_commit_framework_hook_survives_install` pins it.

### Everything else is as specified

- **Checks the commit range, not the working tree.** History is what gets published; a later commit deleting a file doesn't unpublish it. Also handles the new-branch case (`--not --remotes`) that a naive `remote..local` gets wrong by walking all history.
- **One pattern list.** Reads the same `.claude/ferpa_zone2.txt` as `grade_guardian`, for exactly the reason given — a second list drifts, which is the 1.16.0 bug a layer down.
- **Graded rollout.** Path checks default; content scans (uid→name maps, roster surnames) opt-in via `.claude/ferpa_scan_content`. Never silently degrades — if a scan is off, the denial says so.
- **Filenames withheld from output**, since a matched filename may itself be a student name. Directories only, plus how to list them locally.

### The denial message

Their strongest point was that this lands on non-technical users at the moment they're trying to share work, and that "rewrite history" produces `--no-verify` or an abandoned repo. So it leads with the non-destructive fix:

```
  1. See which files, locally: git log --format= --name-only <branch> | sort -u
  2. SAFEST fix — no history rewriting:
       git switch -c clean-work
       # re-add only what you mean to publish, then push that branch
  3. Rewriting history … easy to get wrong. Ask before doing this on a shared repo.
  4. FALSE POSITIVE? Narrow the pattern in .claude/ferpa_zone2.txt — don't disable the hook.
```

A test asserts the safe fix appears before `filter-repo` in the message.

### Also shipped: `cb_update` ignore-coverage report

Not in the issue, but it targets the near-miss the issue *describes*. Their incident was a blanket ignore being load-bearing for paths nobody knew it covered. `cb_update` now reports name-bearing directories git isn't ignoring — catching that class at update time, blocking nothing, so it can't wall anyone off.

Writing it surfaced a bug worth recording: `git ls-files --others` lists **ignored** files unless `--exclude-standard` is passed, so the first version warned even on a correctly-covered repo. A warning that always fires gets tuned out — the #278 failure in a new place. Caught by smoke-testing the output rather than by a test, and now pinned by one.

### Verification

23 new tests. Beyond the unit level, an end-to-end test installs the hook the way `cb_update` does, runs a **real `git push`**, and asserts git refuses.

Verified by reintroducing both design errors:
- checking the worktree instead of the range → `test_deleting_the_file_later_still_blocks` fails
- naive `remote..local` → 6 fail, including all three end-to-end ones

1153 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests against the sandbox and fail identically on unmodified `main`.

### Note

I wrote this fresh from the design description — their implementation is on a machine I can't reach. If theirs handles a case mine doesn't, worth diffing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)