### PR TITLE
fix(ferpa): pin the VS Code denial contract; stop the Zone-2 nudge firing at everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,31 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.19.1] — 2026-08-04
+
+**Went and looked at what a faculty member actually sees. Found one thing working by accident and one nag that shouldn't exist.**
+
+### The VS Code path works — and now can't silently stop working
+
+A blocked push had never been observed in a GUI, only in a terminal. Read VS Code's git extension (`dist/main.js`) and ran a real blocked push against it. Its error path is `msg = stdout ? lines[last] : lines[0]`, shown in a **modal** dialog with the full text behind *Show Command Output*. So the instructor gets exactly one line of ours, and it happens to be the right one.
+
+That depends on two properties that are invisible in the source and silent to break:
+
+- **The first non-empty stderr line must stand alone.** Add a preamble like "Checking commits…" and the modal shows *that* instead of the denial.
+- **The hook must write nothing to stdout.** If stdout is non-empty VS Code takes the *last* line — and git appends its own `failed to push some refs` there. One stray `print()` replaces the whole message with something useless.
+
+Both are now pinned by tests that port VS Code's algorithm verbatim, verified by breaking each property and confirming the suite stops.
+
+### The Zone-2 nudge no longer fires at everyone
+
+1.16.0 shipped a prompt to create `.claude/ferpa_zone2.txt` on any repo lacking it — which is nearly every Canvas course, on every run, forever. The built-in patterns cover a Canvas course completely, so that was homework nobody owed. It's the exact failure #278 was filed about (a guardrail so noisy it gets tuned out), reintroduced one layer up by the fix for it.
+
+Now it fires only where it's actionable: a repo with no Canvas course configured. The pattern **count** still prints everywhere, because that's a fact rather than a chore. A Canvas repo that does keep its own name-bearing files gets pointed at the file by `print_ignore_coverage`, which fires on evidence.
+
+Net for a normal Canvas course: `cb_update` gained one status line across 1.16.0–1.19.0, not four.
+
+---
+
 ## [1.19.0] — 2026-08-04
 
 **A FERPA guard on the git layer: `grade_guardian` can't see `git push`, and a push can't be undone (#285).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -364,3 +364,29 @@ def test_coverage_report_still_flags_an_already_TRACKED_zone2_file(tmp_path, cap
 def test_coverage_report_skips_a_non_git_directory(tmp_path, capsys):
     print_ignore_coverage(tmp_path)
     assert capsys.readouterr().out == ""
+
+
+def test_zone2_nudge_is_silent_for_a_configured_canvas_repo(tmp_path, capsys, monkeypatch):
+    """The built-ins cover a Canvas course completely, so nudging every Canvas repo
+    to write ferpa_zone2.txt — on every run, forever — is homework they don't owe.
+    A guardrail that chatters at everyone gets tuned out."""
+    monkeypatch.setenv("CANVAS_COURSE_ID", "12345")
+    print_zone2_coverage(tmp_path)
+    out = capsys.readouterr().out
+    assert "Zone-2 patterns:" in out          # the FACT still prints
+    assert "one regex per line" not in out    # the homework doesn't
+
+
+def test_zone2_nudge_still_fires_for_a_non_canvas_repo(tmp_path, capsys, monkeypatch):
+    """Where it IS actionable — a consumer whose name-bearing files the built-ins
+    cannot know about."""
+    monkeypatch.delenv("CANVAS_COURSE_ID", raising=False)
+    print_zone2_coverage(tmp_path)
+    assert "one regex per line" in capsys.readouterr().out
+
+
+def test_coverage_report_points_at_the_extension_file(tmp_path, capsys):
+    """A Canvas repo that does keep its own name-bearing files gets pointed at
+    ferpa_zone2.txt here — on evidence, rather than as a standing nag."""
+    print_ignore_coverage(_cov_repo(tmp_path))
+    assert ".claude/ferpa_zone2.txt" in capsys.readouterr().out

--- a/lib/tests/test_ferpa_pre_push.py
+++ b/lib/tests/test_ferpa_pre_push.py
@@ -271,3 +271,61 @@ def test_installed_hook_actually_runs_on_a_real_push(tmp_path):
     r = _git(repo, "push", "origin", "HEAD:refs/heads/main")
     assert r.returncode != 0, "git push should have been refused"
     assert "PUSH BLOCKED" in (r.stdout + r.stderr)
+
+
+# --- the GUI rendering contract (genchi genbutsu, then jidoka) ---------------
+#
+# Verified by reading VS Code's git extension (dist/main.js) and running a real
+# blocked push. Its error path is, verbatim:
+#
+#   b = (stderr || stdout || message).replace(/^error: /mi,"")
+#         .split(/[\r\n]/).filter(s => !!s)
+#   msg = stdout ? b[b.length-1] : b[0]
+#   showErrorMessage(msg, {modal: true}, "Open Git Log", "Show Command Output")
+#
+# So a faculty member pushing from VS Code gets a MODAL dialog containing ONE line
+# of ours — and the full text only behind a button. Two properties make that line
+# the right one, and both are silent to break. These are the andon cord.
+
+def _vscode_modal_line(stderr: str, stdout: str) -> str:
+    """Port of the algorithm above. If VS Code changes, this test is where we find
+    out — better here than in front of an instructor."""
+    import re
+    b = re.sub(r"^error: ", "", stderr, flags=re.I | re.M)
+    lines = [s for s in re.split(r"[\r\n]", b) if s]
+    if not lines:
+        return "Git error"
+    return lines[-1] if stdout else lines[0]
+
+
+def test_vscode_modal_states_the_actual_reason(tmp_path):
+    """PROPERTY 1: the first non-empty stderr line must stand alone. VS Code shows
+    b[0] and hides the rest behind 'Show Command Output'. Add a preamble to stderr
+    and the instructor's modal reads that instead — which is how a carefully written
+    denial becomes an unexplained wall."""
+    repo = _repo(tmp_path)
+    (repo / "grading").mkdir()
+    (repo / "grading" / ".deid_master.csv").write_text("x\n", encoding="utf-8")
+    _git(repo, "add", "-f", "grading/.deid_master.csv")
+    _git(repo, "commit", "-qm", "leak")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    r = _run_hook(repo, sha, _NULL)
+
+    modal = _vscode_modal_line(r.stderr, r.stdout)
+    assert "PUSH BLOCKED" in modal and "FERPA" in modal, modal
+    assert "failed to push" not in modal
+
+
+def test_hook_writes_nothing_to_stdout(tmp_path):
+    """PROPERTY 2: VS Code switches to the LAST line when stdout is non-empty — and
+    git appends its own 'error: failed to push some refs' last. So a single stray
+    print() to stdout silently replaces the whole denial with git's generic message.
+    Everything this hook says must go to stderr."""
+    repo = _repo(tmp_path)
+    (repo / "grading").mkdir()
+    (repo / "grading" / ".keymap.json").write_text("{}", encoding="utf-8")
+    _git(repo, "add", "-f", "grading/.keymap.json")
+    _git(repo, "commit", "-qm", "leak")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    r = _run_hook(repo, sha, _NULL)
+    assert r.stdout == "", f"stdout must stay empty; got {r.stdout!r}"

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -283,6 +283,8 @@ def print_ignore_coverage(course_root: Path) -> None:
           "`.gitignore` containing")
     print("    `*` inside the directory itself, which survives edits to the root "
           "ignore file.")
+    print(f"    If these are this course's OWN name-bearing files, add them to "
+          f"{_ZONE2_EXTRA_FILE} too, so the guardian and the pre-push hook cover them.")
 
 
 def canvas_configured(course_root: Path) -> bool:
@@ -344,10 +346,18 @@ def print_zone2_coverage(course_root: Path) -> None:
               f"regex and are being IGNORED — you are not covered on those:")
         for bad in s["invalid"]:
             print(f"      {bad}")
-    elif not s["source"]:
-        print(f"  ↳ built-ins are Canvas filenames. If this course keeps names in files "
-              f"of its own, list them in {_ZONE2_EXTRA_FILE} (one regex per line) — "
-              f"otherwise the hook is installed but not covering them.")
+    elif not s["source"] and not canvas_configured(course_root):
+        # The nudge fires ONLY where it's actionable. The built-ins are Canvas
+        # filenames and cover a Canvas course completely, so telling every Canvas
+        # repo to write this file — on every run, forever — is homework they don't
+        # owe. A guardrail that chatters at everyone gets tuned out, which is the
+        # failure #278 was filed about; shipping it as a permanent nag reintroduces
+        # it one layer up. A Canvas repo that DOES keep its own name-bearing files
+        # gets pointed here by `print_ignore_coverage`, which fires on evidence.
+        print(f"  ↳ built-ins are Canvas filenames and this repo has no Canvas course "
+              f"configured. If it keeps names in files of its own, list them in "
+              f"{_ZONE2_EXTRA_FILE} (one regex per line) — otherwise the hook is "
+              f"installed but not covering them.")
 
 
 def main() -> int:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.19.0"
+version = "1.19.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.19.0"
+version = "1.19.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Follow-up to #286. Went and looked at what a faculty member actually sees instead of assuming, and found one thing working by accident and one thing that shouldn't have shipped.

## The VS Code path works — and now can't silently stop working

#285 flagged that a blocked push lands on non-technical users. The denial was written carefully for that, but it had only ever been observed in a terminal.

Read VS Code's git extension (`dist/main.js`) and ran a real blocked push through it. The error path is:

```js
b = (stderr || stdout || message).replace(/^error: /mi,"").split(/[\r\n]/).filter(s => !!s)
msg = stdout ? b[b.length-1] : b[0]
showErrorMessage(msg, {modal: true}, "Open Git Log", "Show Command Output")
```

**It's modal**, so it can't be missed, and the instructor sees:

```
Git: ⛔ PUSH BLOCKED — FERPA Zone-2 data in the commits being pushed.
     [Open Git Log]  [Show Command Output]   ← the full 34 lines
```

That's the right outcome. But it holds because of two properties that are invisible in the source and silent to break:

1. **The first non-empty stderr line must stand alone.** VS Code shows `b[0]`. A preamble like `"Checking commits…"` would put *that* in the modal and hide the denial behind a button.
2. **The hook must write nothing to stdout.** If stdout is non-empty VS Code switches to the **last** line — and git appends its own `error: failed to push some refs` there. A single stray `print()` swaps a carefully written denial for git's most useless message.

Nobody editing this file would infer either. Both are now pinned by tests that port VS Code's algorithm verbatim, so if the contract breaks — or if VS Code changes it — we find out here rather than in front of an instructor.

Verified by breaking each property: adding a stderr preamble fails 1 test; adding a stdout `print()` fails 2.

## The Zone-2 nudge fired at everyone, forever

Asked whether this work had added technical debt for non-technical users. Measured it, and one thing had.

1.16.0 shipped a prompt to create `.claude/ferpa_zone2.txt` on any repo lacking it — which is nearly every Canvas course, on every `cb_update` run, permanently. The built-in patterns cover a Canvas course completely, so it was homework nobody owed.

That's the exact failure #278 was filed about — a guardrail so noisy it gets tuned out — reintroduced one layer up by the fix for it. I wrote *"a guardrail that chatters at everyone gets tuned out"* in that same PR.

It now fires only where it's actionable: a repo with no Canvas course configured. The pattern **count** still prints everywhere, because that's a fact rather than a chore. A Canvas repo that does keep its own name-bearing files gets pointed at the file by `print_ignore_coverage`, which fires on evidence rather than on principle.

**Before / after for a normal Canvas course:**

```
  FERPA Zone-2 patterns: 8 built-in
- ↳ built-ins are Canvas filenames. If this course keeps names in files of its own,
-   list them in .claude/ferpa_zone2.txt (one regex per line) — otherwise the hook
-   is installed but not covering them.
```

Net across 1.16.0–1.19.0, `cb_update` gained **one** status line for a normal Canvas course, not four.

## Remaining honest cost

The pre-push hook can still stop a faculty member sharing work. That's the intended trade and #285 argued it's worth paying — but it isn't free, and the VS Code check above is what makes it survivable.

1158 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests against the sandbox and fail identically on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)