### PR TITLE
feat(credentials): ~/.canvas/config fallback, migration, token check, and guard coverage (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,33 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.20.0] — 2026-08-06
+
+**One place to rotate the Canvas token — and the guardrails follow it there (#288).**
+
+Canvas now expires API tokens every 29 days across all institutions. An operator running five course repos was editing five `.env` files a month, and the one they forgot 401'd silently until a grading run failed — which is exactly what happened on 2026-08-06, blocking eight courses.
+
+- **`~/.canvas/config` global fallback**, resolved in `_env_loader.load_env()` — the one function all 90 tools already call, whose docstring anticipated precisely this ("a future improvement, e.g. multi-file precedence, lands in ONE place instead of twelve"). Precedence is unchanged and conventional: environment variable → repo `.env` → global. Demoting the env var, as the issue proposed, would have broken CI and one-off `CANVAS_API_TOKEN=x uv run …` overrides.
+- **An empty value counts as absent.** `cb_init` scaffolds a bare `CANVAS_API_TOKEN=` into every new repo; treating that as a value would make each new repo shadow the global file with an empty string and break on day one. A real repo in that state already existed in the field.
+- **The global file takes an ALLOWLIST — `CANVAS_API_TOKEN`, `CANVAS_BASE_URL` — and never a course id.** This is the safety property, not an oversight. `canvas_course_guard` (#27) exists because a stale `CANVAS_COURSE_ID` silently sends writes to the wrong course; a global one would manufacture that. An allowlist rather than a denylist because one field repo carries **eight** course-id-ish keys (`S1`/`S2`/`S3_COURSE_ID`, `BLUEPRINT_`, `MASTER_`, `PROTECTED_`, `SANDBOX_`), and missing one means grades in the wrong course. A course id in the global file is ignored *and reported*.
+- **Parsed with python-dotenv, not by hand.** `export CANVAS_API_TOKEN="1234~ab#cd"` defeats a naive `startswith()`, keeps the quotes, and truncates at the `#` — each silently, leaving "no token found" while the token sits in the file.
+- **`cb_update` migrates the installed base**, which is the whole problem — `cb_init` gets new repos right for free. It detects multi-course from sibling repos (directory names only; it never reads another repo's `.env`), consolidates the token, and **comments out** the local copy rather than deleting it. Idempotent and self-consolidating: run it in any repo, in any order, re-run freely. Single-course operators are untouched — a repo tool writing secrets into `$HOME` needs positive evidence, and the detection fails safe toward "single". `--multi-course` / `--single-course` override.
+- **When there's no token worth seeding, it scaffolds the file empty at `0600`.** The moment anyone consolidates is the moment their token expired — that's the reason they're there — so every local copy may be stale.
+- **`cb_update` now verifies the token** with one read-only `GET /users/self`: `valid` / `REJECTED` / `unreachable` / `no-token`. Consolidating rotation says nothing about whether the token is *current*, so the failure mode was otherwise unchanged. `unreachable` is deliberately distinct from `REJECTED` — reporting a network blip as a bad credential would send someone to regenerate a working one, and `cb_update` has always worked offline. `--no-token-check` opts out.
+- The `REJECTED` message names **three causes that are indistinguishable from outside**, led by the one found the hard way: a user-generated token can need **accepting** in Canvas → Account → Settings, and is listed as active the entire time it doesn't work.
+
+### The guardrails moved with the credential
+
+Consolidation made the token a better target: five repo-local gitignored files became one well-known path holding the single credential for every course, outside any repo.
+
+- **`grade_guardian` now covers credentials**, extending the existing hook rather than adding a second one that could be missing or inert. Graded on purpose: `~/.canvas/config` blocks both `Read` and shell display, since it holds a credential and nothing else; `.env` blocks raw shell display only, because blocking `Read` would also block `Edit` (the harness requires a read first), leaving blind whole-file overwrite — worse than the leak it prevents. `.env.example`, `.envrc`, and key-name inspection (`grep -o '^[A-Z_]*='`) stay allowed.
+- It catches the form that **actually leaks a token**: not `cat`, but a script calling `.read_text()` and printing. Mistake-proofing that only covered `cat`/`head` would have missed the real incident this was built from and felt safe.
+- **The pre-push guard blocks a committed credential too.** A pushed token is worse than a pushed name in one way that matters: it's usable by anyone who finds it, with no institutional relationship required, and revocation is the only remedy.
+
+*Verified end-to-end on a six-repo installation: migration applied, all six resolving the global token, all authenticating.*
+
+---
+
 ## [1.19.1] — 2026-08-04
 
 **Went and looked at what a faculty member actually sees. Found one thing working by accident and one nag that shouldn't exist.**

--- a/docs/UPGRADING.md
+++ b/docs/UPGRADING.md
@@ -1,12 +1,7 @@
 # Upgrading canvas-toolbox
 
-For early adopters running an older version (v0.35.x and earlier). This
-is the migration guide; for the mechanical per-version diff, see
-[`CHANGELOG.md`](../CHANGELOG.md).
-
-Usage is still small enough (a handful of consumer repos as of
-2026-06-15) that we can be specific about what changed and how to
-handle it. This file gets shorter over time as adopters catch up.
+The migration guide — what changes about your *workflow*. For the
+mechanical per-version diff, see [`CHANGELOG.md`](../CHANGELOG.md).
 
 ---
 
@@ -16,10 +11,10 @@ Any grader tool's `--version` reports the toolkit version:
 
 ```bash
 uv run python canvas-toolbox/lib/tools/grader_fetch.py --version
-# → canvas-toolbox 0.35.4
+# → canvas-toolbox 1.13.0
 ```
 
-The current latest is **v0.50.1**.
+The current latest is **v1.20.0**.
 
 ---
 
@@ -30,19 +25,114 @@ repo (the recommended layout for m119 / ds460 / ds250 / itm327 /
 aol-student style adopters):
 
 ```bash
-cd canvas-toolbox
-git pull
-uv sync                              # picks up any new deps
-uv run python lib/tools/grader_fetch.py --version
-# → canvas-toolbox 0.50.1
+cd canvas-toolbox && git pull && uv sync
+cd .. && uv run python canvas-toolbox/lib/tools/cb_update.py          # dry run
+uv run python canvas-toolbox/lib/tools/cb_update.py --apply
 ```
 
-That's it for the upgrade itself. Read the "Behavior changes worth
-knowing" section below before your next run.
+`cb_update` is the re-init step: it makes new toolkit standards active
+in a repo that was set up months ago. **It is dry-run by default** —
+run it without `--apply` first and read what it says it will do.
 
 ---
 
-## Behavior changes worth knowing (v0.35 → v0.50)
+## Behavior changes worth knowing (v1.13 → v1.20)
+
+Three of these change what happens when you run something you already
+run. None require code changes, but two can stop you mid-workflow if
+they surprise you.
+
+### `cb_update --apply` now installs a hook that can BLOCK a push (1.19.0)
+
+The biggest change. `grade_guardian` protects the *agent* layer and
+cannot see `git push` — and unlike a bad read, a push can't be undone.
+`cb_update` now installs `.git/hooks/pre-push`, which checks the commit
+**range** (history is what gets published; deleting a file later doesn't
+unpublish it) and refuses a push carrying FERPA Zone-2 files or a
+credential.
+
+If it fires, the message tells you what to do in order, and **leads with
+the fix that doesn't rewrite history** — branch fresh from a clean tree
+and push that. The one thing not to do is `--no-verify`; that publishes
+the data.
+
+It installs to `.git/hooks/pre-push`, **not** via `core.hooksPath` —
+that setting is consulted *instead of* `.git/hooks/`, so it would
+silently disable an existing `pre-commit` hook (and `pre-commit install`
+then refuses to run). If you already have your own `pre-push`, yours is
+left alone and `cb_update` reports `skip-foreign`.
+
+Path checks run by default. Content scanning (uid→name maps, roster
+surnames) is opt-in via `touch .claude/ferpa_scan_content`, because
+surname matching trips on ordinary prose.
+
+### `cb_update --apply` may move your Canvas token (1.20.0)
+
+Canvas now expires API tokens every 29 days. If you run **more than one
+course repo**, `cb_update` consolidates the token into
+`~/.canvas/config` (chmod 600) and **comments out** — not deletes — the
+`CANVAS_API_TOKEN` line in that repo's `.env`. Rotation becomes one edit
+instead of one per repo.
+
+- **Single-course operators are untouched.** Detection is by sibling
+  repos and fails safe toward "single"; `--multi-course` forces it.
+- **Course ids never move.** `~/.canvas/config` accepts only
+  `CANVAS_API_TOKEN` and `CANVAS_BASE_URL`. A `CANVAS_COURSE_ID` there
+  is ignored and reported — a global course id would silently send
+  writes to whichever course was configured last.
+- Precedence is unchanged: environment variable → repo `.env` → global.
+  A real per-repo token still wins; an empty one doesn't count.
+- `cb_update` now verifies the token with one read-only call and reports
+  `valid` / `REJECTED` / `unreachable`. `--no-token-check` skips it.
+
+**If it says `REJECTED`, check first whether the token needs *accepting*
+in Canvas → Account → Settings.** A user-generated token is listed as
+active the entire time it doesn't work, so this looks exactly like an
+expired token. It cost the maintainer twenty minutes.
+
+### Agents can no longer `cat` your `.env` (1.20.0)
+
+`grade_guardian` now denies raw display of credential files — including
+the `python -c "...read_text()"` form, which is how it actually happens.
+`Read .env` still works (blocking it would also block `Edit`), as do
+`.env.example`, `.envrc`, and `grep -o '^[A-Z_]*=' .env` for key names.
+`~/.canvas/config` is blocked outright; nothing legitimate reads it.
+
+### Your course-owned skills become visible to git (1.14.1, 1.15.1)
+
+`cb_update` used to write a blanket `.claude/skills/` ignore, which also
+hid skills *you* wrote there. It now ignores the toolkit's skills by
+name and migrates the old line. After upgrading, a course-owned skill
+that was silently untracked will start showing in `git status` — that's
+the fix, not a regression. If you added `.gitignore` negations as a
+workaround, they're now redundant and harmless.
+
+### `.deid_master.csv` gained an `org_id` column (1.17.0)
+
+The institution's id — Canvas `sis_user_id`, D2L `OrgDefinedId`. It is
+**stored, never a key**. Appended last, and readers use `csv.DictReader`,
+so a master written before 1.17.0 still parses; no rebuild needed.
+
+### Student names in agent output (1.15.0, 1.18.0)
+
+Agents now refer to students by `user_id` / `deid_code` in anything
+written *about* a student, and by given name + last initial in text
+written *for* one (a discussion reply). A name never appears beside a
+score, criterion, or standing. If an agent starts declining to use a
+name you just typed, that's over-application — the rule scopes to what
+the agent surfaces on its own, not what you supplied in the same turn.
+
+### Not on Canvas? (1.16.0, 1.17.0)
+
+Courses on another LMS can now use the toolkit's constitution, skills,
+FERPA discipline and consensus grading without the Canvas API:
+`.claude/ferpa_zone2.txt` teaches `grade_guardian` your own name-bearing
+files, and `build_deid_master.py --roster-json` builds the de-id master
+from a local roster with no credentials.
+
+---
+
+## Older behavior changes (v0.35 → v0.50)
 
 These are operator-visible changes that might surprise a workflow you
 already have. None require code changes on your side, but you may want
@@ -111,9 +201,10 @@ handles m119-style task-level feedback dirs too.
 
 ---
 
-## What's actually new (the new tools you might want)
+## Tools added in the v0.35 → v0.50 window
 
-These shipped between v0.35.4 and v0.50.0. The order below is roughly
+Still current and still worth knowing if you skipped that window — but
+these are no longer the newest additions. The order below is roughly
 "most likely to be useful first".
 
 | Tool | What it does | When to reach for it |
@@ -155,11 +246,18 @@ When you're working in a consumer repo and notice `canvas-toolbox`
 isn't at the latest version, surface this file:
 
 > _The toolkit at `canvas-toolbox/` is at v{X}.{Y}.{Z}; latest is
-> v0.50.x. The upgrade is a `cd canvas-toolbox && git pull && uv sync`.
-> Behavior changes worth knowing in `canvas-toolbox/UPGRADING.md`._
+> v1.20.x. The upgrade is `cd canvas-toolbox && git pull && uv sync`,
+> then `cb_update.py` (dry-run) and `--apply`. Behavior changes worth
+> knowing in `canvas-toolbox/docs/UPGRADING.md` — from 1.19 onward
+> `--apply` installs a pre-push hook and may move the Canvas token._
 
 The toolkit doesn't auto-upgrade — that's by design (operator control).
 But agents can and should notice the gap.
+
+**Run `cb_update` without `--apply` first and show the operator the
+output.** From 1.19 it installs a hook that can block a push, and from
+1.20 it can rewrite `.env` and write to `$HOME`. All of that is correct
+and wanted — but it's the operator's call to see it before it happens.
 
 ---
 

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -55,6 +55,9 @@ from cb_update import (  # noqa: E402
     print_zone2_coverage,
     print_lms_mode,
     print_ignore_coverage,
+    count_sibling_course_repos,
+    migrate_token_to_global,
+    check_token,
     canvas_configured,
     refresh_pointer,
 )
@@ -390,3 +393,152 @@ def test_coverage_report_points_at_the_extension_file(tmp_path, capsys):
     ferpa_zone2.txt here — on evidence, rather than as a standing nag."""
     print_ignore_coverage(_cov_repo(tmp_path))
     assert ".claude/ferpa_zone2.txt" in capsys.readouterr().out
+
+
+# --- global Canvas credentials (#288) ---------------------------------------
+#
+# EVERY test that reaches an apply path monkeypatches cb_update._GLOBAL_CONFIG.
+# Without that these would write a token into the developer's real ~/.canvas/config.
+
+import cb_update as _cbu  # noqa: E402
+
+
+def _course(tmp_path, name, token="OLD_expired", n_siblings=0):
+    root = tmp_path / name
+    (root / "canvas-toolbox").mkdir(parents=True)
+    (root / ".env").write_text(
+        f"CANVAS_BASE_URL=https://x.instructure.com\n"
+        f"CANVAS_API_TOKEN={token}\nCANVAS_COURSE_ID=12345\n", encoding="utf-8")
+    for i in range(n_siblings):
+        sib = tmp_path / f"sibling{i}-master"
+        (sib / "canvas-toolbox").mkdir(parents=True)
+        (sib / ".env").write_text("CANVAS_API_TOKEN=x\n", encoding="utf-8")
+    return root
+
+
+def test_multi_course_is_detected_from_siblings(tmp_path):
+    """Counts DIRECTORIES only — never reads another repo's .env to make a
+    convenience decision."""
+    one, many = tmp_path / "one", tmp_path / "many"
+    one.mkdir(); many.mkdir()
+    assert count_sibling_course_repos(_course(one, "solo")) == 1
+    assert count_sibling_course_repos(_course(many, "a", n_siblings=4)) == 5
+
+
+def test_a_scaffold_without_env_is_not_a_course_repo(tmp_path):
+    root = _course(tmp_path, "a")
+    (tmp_path / "not-configured" / "canvas-toolbox").mkdir(parents=True)  # no .env
+    assert count_sibling_course_repos(root) == 1
+
+
+def test_single_course_never_touches_home(tmp_path, monkeypatch):
+    """A repo tool writing secrets into $HOME needs positive evidence. One course
+    gains nothing from a second location."""
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    root = _course(tmp_path, "solo")
+    assert migrate_token_to_global(root, multi=False, apply=True) == "single-course"
+    assert not target.exists()
+    assert "CANVAS_API_TOKEN=OLD_expired" in (root / ".env").read_text(encoding="utf-8")
+
+
+def test_multi_course_creates_the_global_file_and_comments_out_the_local(tmp_path, monkeypatch):
+    """The 29-day rotation problem: N repos, N .env edits a month, a silent 401 on
+    the one you forget."""
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    root = _course(tmp_path, "a", token="TOK_abc", n_siblings=4)
+
+    assert migrate_token_to_global(root, multi=True, apply=False) == "would-create"
+    assert not target.exists()                       # dry run wrote nothing
+
+    assert migrate_token_to_global(root, multi=True, apply=True) == "created"
+    assert "CANVAS_API_TOKEN=TOK_abc" in target.read_text(encoding="utf-8")
+    assert target.stat().st_mode & 0o777 == 0o600    # it holds a token
+    env = (root / ".env").read_text(encoding="utf-8")
+    assert "# CANVAS_API_TOKEN=TOK_abc" in env       # commented, NOT deleted
+    assert "CANVAS_COURSE_ID=12345" in env           # course id untouched
+
+
+def test_migration_is_idempotent_and_self_consolidating(tmp_path, monkeypatch):
+    """Run it in any repo, in any order, re-run freely — there's no list to track."""
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    root = _course(tmp_path, "a", n_siblings=4)
+    migrate_token_to_global(root, multi=True, apply=True)
+    assert migrate_token_to_global(root, multi=True, apply=True) == "present"
+
+
+def test_a_second_repo_consolidates_rather_than_recreating(tmp_path, monkeypatch):
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    first = _course(tmp_path, "a", token="TOK_first", n_siblings=4)
+    migrate_token_to_global(first, multi=True, apply=True)
+    second = _course(tmp_path, "b", token="TOK_stale")
+    assert migrate_token_to_global(second, multi=True, apply=True) == "consolidated"
+    assert "TOK_first" in target.read_text(encoding="utf-8")   # first one wins, not clobbered
+    assert "# CANVAS_API_TOKEN=TOK_stale" in (second / ".env").read_text(encoding="utf-8")
+
+
+def test_migration_handles_an_export_prefixed_token(tmp_path, monkeypatch):
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    root = _course(tmp_path, "a", n_siblings=4)
+    (root / ".env").write_text('export CANVAS_API_TOKEN="TOK_quoted"\n', encoding="utf-8")
+    assert migrate_token_to_global(root, multi=True, apply=True) == "created"
+    assert "CANVAS_API_TOKEN=TOK_quoted" in target.read_text(encoding="utf-8")
+
+
+def test_scaffolds_an_empty_config_when_there_is_no_token_to_seed(tmp_path, monkeypatch):
+    """The moment anyone consolidates is the moment their token expired — that's the
+    reason they're here — so every local copy may be stale and there may be nothing
+    worth seeding. An empty 0600 file to paste into beats 'no-token' and no guidance.
+    (Real instance: a repo scaffolded with `CANVAS_API_TOKEN=` and never filled.)"""
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    root = _course(tmp_path, "a", token="", n_siblings=4)      # empty = absent
+
+    assert migrate_token_to_global(root, multi=True, apply=False) == "would-scaffold"
+    assert not target.exists()
+    assert migrate_token_to_global(root, multi=True, apply=True) == "scaffolded"
+    body = target.read_text(encoding="utf-8")
+    assert body.rstrip().endswith("CANVAS_API_TOKEN=")         # ready to paste into
+    assert target.stat().st_mode & 0o777 == 0o600              # perms set regardless
+    assert "IGNORED" in body                                    # the course-id warning
+    # once it exists, a repo with nothing to contribute is a no-op
+    assert migrate_token_to_global(root, multi=True, apply=True) == "present"
+
+
+def test_token_check_reports_no_token_without_a_network_call(monkeypatch):
+    for v in ("CANVAS_API_TOKEN", "CANVAS_BASE_URL"):
+        monkeypatch.delenv(v, raising=False)
+    assert check_token() == "no-token"
+
+
+def test_token_check_distinguishes_rejected_from_unreachable(monkeypatch):
+    """The distinction that matters. cb_update has always worked offline; reporting
+    a network failure as a bad token would send someone to regenerate a perfectly
+    good credential."""
+    import urllib.error
+    import urllib.request
+    monkeypatch.setenv("CANVAS_API_TOKEN", "tok")
+    monkeypatch.setenv("CANVAS_BASE_URL", "byui.instructure.com")
+
+    def _401(*a, **kw):
+        raise urllib.error.HTTPError("u", 401, "Unauthorized", {}, None)
+    monkeypatch.setattr(urllib.request, "urlopen", _401)
+    assert check_token() == "REJECTED"
+
+    def _offline(*a, **kw):
+        raise OSError("nodename nor servname provided")
+    monkeypatch.setattr(urllib.request, "urlopen", _offline)
+    assert check_token() == "unreachable"
+
+
+def test_token_check_never_returns_the_token(monkeypatch):
+    monkeypatch.setenv("CANVAS_API_TOKEN", "SECRET_tok")
+    monkeypatch.setenv("CANVAS_BASE_URL", "byui.instructure.com")
+    import urllib.request
+    monkeypatch.setattr(urllib.request, "urlopen",
+                        lambda *a, **kw: (_ for _ in ()).throw(OSError("x")))
+    assert "SECRET" not in check_token()

--- a/lib/tests/test_env_loader.py
+++ b/lib/tests/test_env_loader.py
@@ -1,0 +1,145 @@
+"""Unit tests — credential resolution, including the global fallback (#288).
+
+Canvas expires API tokens every 29 days across all institutions, so an operator with
+N course repos was editing N `.env` files a month and 401'ing silently on the one
+they forgot. `~/.canvas/config` makes that one edit.
+
+The safety property under test is that the global file can supply the TOKEN and
+never the COURSE ID. `canvas_course_guard` (#27) exists because a stale course id
+sends writes to the wrong course; a global course id would manufacture that.
+
+Every test monkeypatches GLOBAL_CONFIG — without it these would read, and the
+migration tests would write, the developer's real ~/.canvas/config.
+"""
+import os
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+import _env_loader  # noqa: E402
+from _env_loader import GLOBAL_KEYS, global_config_problems, load_env  # noqa: E402
+
+_CANVAS_VARS = ("CANVAS_API_TOKEN", "CANVAS_BASE_URL", "CANVAS_COURSE_ID")
+
+
+def _clean_env(monkeypatch):
+    for v in _CANVAS_VARS:
+        monkeypatch.delenv(v, raising=False)
+
+
+def _global(tmp_path, monkeypatch, text):
+    cfg = tmp_path / "home" / ".canvas" / "config"
+    cfg.parent.mkdir(parents=True, exist_ok=True)
+    cfg.write_text(text, encoding="utf-8")
+    cfg.chmod(0o600)
+    monkeypatch.setattr(_env_loader, "GLOBAL_CONFIG", cfg)
+    return cfg
+
+
+def _repo(tmp_path, monkeypatch, env_text):
+    repo = tmp_path / "course"
+    repo.mkdir(parents=True, exist_ok=True)
+    (repo / ".env").write_text(env_text, encoding="utf-8")
+    monkeypatch.chdir(repo)
+    return repo
+
+
+def test_global_fills_a_token_the_repo_env_lacks(tmp_path, monkeypatch):
+    """The whole point: rotate in one place, every course repo picks it up."""
+    _clean_env(monkeypatch)
+    _global(tmp_path, monkeypatch, "CANVAS_API_TOKEN=GLOBAL_tok\n")
+    _repo(tmp_path, monkeypatch, "CANVAS_COURSE_ID=12345\n")
+    load_env()
+    assert os.environ["CANVAS_API_TOKEN"] == "GLOBAL_tok"
+    assert os.environ["CANVAS_COURSE_ID"] == "12345"     # still per-repo
+
+
+def test_an_empty_scaffolded_token_does_not_shadow_the_global(tmp_path, monkeypatch):
+    """cb_init scaffolds a bare `CANVAS_API_TOKEN=` into every new repo. Treating
+    that as a value would make each new repo shadow the global file with an empty
+    string and break on day one."""
+    _clean_env(monkeypatch)
+    _global(tmp_path, monkeypatch, "CANVAS_API_TOKEN=GLOBAL_tok\n")
+    _repo(tmp_path, monkeypatch, "CANVAS_API_TOKEN=\nCANVAS_COURSE_ID=1\n")
+    load_env()
+    assert os.environ["CANVAS_API_TOKEN"] == "GLOBAL_tok"
+
+
+def test_a_real_repo_token_still_wins(tmp_path, monkeypatch):
+    """Per-repo override survives — a sandbox token, a service account, a colleague
+    running one repo as themselves."""
+    _clean_env(monkeypatch)
+    _global(tmp_path, monkeypatch, "CANVAS_API_TOKEN=GLOBAL_tok\n")
+    _repo(tmp_path, monkeypatch, "CANVAS_API_TOKEN=REPO_tok\n")
+    load_env()
+    assert os.environ["CANVAS_API_TOKEN"] == "REPO_tok"
+
+
+def test_an_existing_environment_variable_beats_both(tmp_path, monkeypatch):
+    """Highest precedence, unchanged. Demoting it — as the issue proposed — would
+    break CI and one-off `CANVAS_API_TOKEN=x uv run …` overrides."""
+    _clean_env(monkeypatch)
+    monkeypatch.setenv("CANVAS_API_TOKEN", "ENV_tok")
+    _global(tmp_path, monkeypatch, "CANVAS_API_TOKEN=GLOBAL_tok\n")
+    _repo(tmp_path, monkeypatch, "CANVAS_API_TOKEN=REPO_tok\n")
+    load_env()
+    assert os.environ["CANVAS_API_TOKEN"] == "ENV_tok"
+
+
+def test_the_global_file_can_never_supply_a_course_id(tmp_path, monkeypatch):
+    """THE safety property. A global course id means a repo with a missing or
+    partial .env silently inherits whichever course was configured last — and
+    pushes grades there. Allowlist, not denylist: a denylist would need extending
+    for every future per-course key."""
+    _clean_env(monkeypatch)
+    _global(tmp_path, monkeypatch,
+            "CANVAS_API_TOKEN=GLOBAL_tok\nCANVAS_COURSE_ID=99999\nS1_COURSE_ID=88\n")
+    _repo(tmp_path, monkeypatch, "CANVAS_BASE_URL=https://x.instructure.com\n")
+    load_env()
+    assert os.environ["CANVAS_API_TOKEN"] == "GLOBAL_tok"
+    assert "CANVAS_COURSE_ID" not in os.environ
+    assert "S1_COURSE_ID" not in os.environ
+    assert "CANVAS_COURSE_ID" not in GLOBAL_KEYS
+
+
+def test_a_course_id_in_the_global_file_is_reported_not_swallowed(tmp_path, monkeypatch):
+    """Ignoring it silently would leave someone convinced it's configured."""
+    _clean_env(monkeypatch)
+    _global(tmp_path, monkeypatch, "CANVAS_API_TOKEN=t\nCANVAS_COURSE_ID=99999\n")
+    problems = " ".join(global_config_problems())
+    assert "CANVAS_COURSE_ID" in problems and "IGNORED" in problems
+    assert "configured last" in problems          # says the CONSEQUENCE, not just "no"
+
+
+def test_world_readable_credentials_are_flagged(tmp_path, monkeypatch):
+    """It holds an API token. ~/.ssh refuses outright; this warns with the exact
+    command, since blocking a faculty member out of their own tools is worse."""
+    cfg = _global(tmp_path, monkeypatch, "CANVAS_API_TOKEN=t\n")
+    cfg.chmod(0o644)
+    problems = " ".join(global_config_problems())
+    assert "readable by other users" in problems and "chmod 600" in problems
+    cfg.chmod(0o600)
+    assert not any("readable" in p for p in global_config_problems())
+
+
+def test_export_prefixes_and_quotes_are_parsed(tmp_path, monkeypatch):
+    """python-dotenv, not a hand-rolled split. `export KEY="v#al"` defeats
+    startswith(), keeps the quotes, and truncates at the `#` — each silently."""
+    _clean_env(monkeypatch)
+    _global(tmp_path, monkeypatch, 'export CANVAS_API_TOKEN="1234~ab#cd"\n')
+    _repo(tmp_path, monkeypatch, "CANVAS_COURSE_ID=1\n")
+    load_env()
+    assert os.environ["CANVAS_API_TOKEN"] == "1234~ab#cd"
+
+
+def test_absent_global_file_changes_nothing(tmp_path, monkeypatch):
+    """The overwhelmingly common case today — must be a silent no-op."""
+    _clean_env(monkeypatch)
+    monkeypatch.setattr(_env_loader, "GLOBAL_CONFIG", tmp_path / "nope" / "config")
+    _repo(tmp_path, monkeypatch, "CANVAS_API_TOKEN=REPO_tok\n")
+    assert load_env() is not None
+    assert os.environ["CANVAS_API_TOKEN"] == "REPO_tok"
+    assert global_config_problems() == []

--- a/lib/tests/test_ferpa_pre_push.py
+++ b/lib/tests/test_ferpa_pre_push.py
@@ -329,3 +329,30 @@ def test_hook_writes_nothing_to_stdout(tmp_path):
     sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
     r = _run_hook(repo, sha, _NULL)
     assert r.stdout == "", f"stdout must stay empty; got {r.stdout!r}"
+
+
+def test_a_committed_credential_file_blocks_the_push(tmp_path):
+    """A pushed token is worse than a pushed name in one specific way: it's usable
+    by anyone who finds it, with no institutional relationship required, and
+    revocation is the only remedy. .env is gitignored today — but #285 exists
+    because an ignore restructure quietly stopped covering three paths."""
+    repo = _repo(tmp_path)
+    (repo / ".env").write_text("CANVAS_API_TOKEN=10706~secret\n", encoding="utf-8")
+    _git(repo, "add", "-f", ".env")
+    _git(repo, "commit", "-qm", "oops")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    r = _run_hook(repo, sha, _NULL)
+    assert r.returncode == 1, r.stderr
+    assert "PUSH BLOCKED" in r.stderr
+    assert "secret" not in r.stderr          # never echoes what it caught
+
+
+def test_an_env_template_does_not_block_the_push(tmp_path):
+    """Repos track .env.example on purpose. Blocking it would train people to
+    --no-verify, which costs more than it protects."""
+    repo = _repo(tmp_path)
+    (repo / ".env.example").write_text("CANVAS_API_TOKEN=\n", encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "commit", "-qm", "template")
+    sha = _git(repo, "rev-parse", "HEAD").stdout.strip()
+    assert _run_hook(repo, sha, _NULL).returncode == 0

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -488,3 +488,53 @@ def test_classlist_export_is_blocked_out_of_the_box(tmp_path):
                        input=json.dumps({"tool_name": "Read",
                                          "tool_input": {"file_path": f"rosters/{real}"}}))
     assert r.returncode == 2, r.stderr
+
+
+# --- credentials (#288) -----------------------------------------------------
+#
+# Zone-2 protected student data; nothing protected the API token. Consolidating it
+# into ~/.canvas/config made that sharper: five repo-local gitignored files became
+# ONE well-known path holding the single credential for every course.
+
+def test_global_credential_file_is_blocked_for_read_and_shell():
+    """It holds a credential and nothing else, so blocking it costs nothing —
+    load_env() reads it in-process, which is never a tool call."""
+    assert evaluate("Read", {"file_path": "/Users/x/.canvas/config"}) is not None
+    assert evaluate("Bash", {"command": "cat ~/.canvas/config"}) is not None
+
+
+def test_env_blocks_shell_display_but_not_read():
+    """Graded deliberately. Blocking Read on .env would also block Edit — the
+    harness requires a read first — leaving only blind whole-file overwrite, which
+    is worse than the leak it prevents. .env also holds course ids and settings an
+    agent legitimately works with."""
+    assert evaluate("Bash", {"command": "cat .env"}) is not None
+    assert evaluate("Bash", {"command": "head -5 ds460-master/.env"}) is not None
+    assert evaluate("Read", {"file_path": "ds460-master/.env"}) is None
+
+
+def test_blocks_the_python_read_form_that_actually_leaked_a_token():
+    """The real incident this is built from: not `cat`, but a script printing the
+    file. Any mistake-proofing that only covers cat/head misses how it happens."""
+    cmd = ("python3 -c \"from pathlib import Path; "
+           "print(Path('ds460-master/.env').read_text())\"")
+    assert evaluate("Bash", {"command": cmd}) is not None
+
+
+def test_key_name_inspection_still_works():
+    """The escape hatch. Checking WHICH keys are configured is legitimate and
+    frequent; it lists no values and isn't a raw-display verb."""
+    assert evaluate("Bash", {"command": "grep -o '^[A-Z_]*=' .env"}) is None
+
+
+def test_templates_and_direnv_are_not_credentials():
+    """Pure friction if blocked — neither carries a secret."""
+    assert evaluate("Bash", {"command": "cat .env.example"}) is None
+    assert evaluate("Bash", {"command": "cat .envrc"}) is None
+    assert evaluate("Read", {"file_path": "scaffold/.env.example"}) is None
+
+
+def test_credential_denial_says_where_the_value_comes_from_instead():
+    """A denial that doesn't name the alternative gets worked around."""
+    msg = evaluate("Read", {"file_path": "/Users/x/.canvas/config"})
+    assert "load_env" in msg and "grep" in msg

--- a/lib/tools/__toolbox_version__.py
+++ b/lib/tools/__toolbox_version__.py
@@ -13,10 +13,11 @@ Resolution order (first match wins):
   3. Hardcoded fallback `"0.0.0+unknown"` — only if both above fail (vendored
      copy missing pyproject.toml; manual file copy out of repo).
 
-Canonical scheme is the v0.x semver line (matches `git describe` and the
-AGENTS.md Active Context). A separate `v1.x` git tag series exists in
-history; it is NOT part of the v0.x line and is not maintained — treat v0.x
-as canonical going forward.
+Canonical scheme is the **v1.x** semver line — `pyproject.toml` is the source
+of truth and CHANGELOG.md tracks it. This paragraph previously said the
+opposite ("treat v0.x as canonical going forward"), which was already stale:
+the 1.x line has been the maintained one for 75 releases. A v0.x tag series
+exists in history and is not maintained.
 
 Downstream repos that vendor `lib/tools/` can print the version via any
 primary sync tool's `--version` flag to detect drift from upstream:

--- a/lib/tools/_env_loader.py
+++ b/lib/tools/_env_loader.py
@@ -61,12 +61,94 @@ import sys
 from pathlib import Path
 
 
+GLOBAL_CONFIG = Path.home() / ".canvas" / "config"
+
+# What the GLOBAL file is allowed to supply. An allowlist, not a denylist: a
+# denylist would have to be extended for every future per-course key (S3_COURSE_ID,
+# the next one nobody has thought of), and the cost of missing one is a grade pushed
+# to the wrong course.
+#
+# CANVAS_COURSE_ID is excluded ON PURPOSE and this is the whole safety property.
+# canvas_course_guard (#27) exists because "a stale or hand-edited .env can silently
+# point CANVAS_COURSE_ID at the wrong course". If a course id could come from a
+# global file, a repo with a missing or partial .env would silently inherit whichever
+# course was configured last — manufacturing exactly that failure. The token is
+# per-USER and rotates; the course id is per-REPO and doesn't. Only the first belongs
+# in a shared file.
+GLOBAL_KEYS = ("CANVAS_API_TOKEN", "CANVAS_BASE_URL")
+
+
+def _global_values() -> tuple[dict, list[str]]:
+    """(allowed values, rejected key names) from ~/.canvas/config.
+
+    Parsed with python-dotenv, not by hand. `export CANVAS_API_TOKEN="1234~ab#cd"`
+    is a real line shape: a naive `line.startswith(KEY)` misses the export prefix
+    entirely, a naive split keeps the quotes, and a naive comment-strip truncates at
+    the `#`. Each of those fails SILENTLY — you get "no token found" while the token
+    sits in the file."""
+    try:
+        from dotenv import dotenv_values
+    except ImportError:
+        return {}, []
+    if not GLOBAL_CONFIG.is_file():
+        return {}, []
+    try:
+        raw = dotenv_values(GLOBAL_CONFIG)
+    except (OSError, ValueError):
+        return {}, []
+    allowed = {k: v for k, v in raw.items() if k in GLOBAL_KEYS and v}
+    rejected = [k for k in raw if k not in GLOBAL_KEYS]
+    return allowed, rejected
+
+
+def global_config_problems() -> list[str]:
+    """Human-readable warnings about ~/.canvas/config — for tools to surface rather
+    than swallow. Never raises; a credential file problem must not brick a tool."""
+    out = []
+    if not GLOBAL_CONFIG.is_file():
+        return out
+    try:
+        mode = GLOBAL_CONFIG.stat().st_mode
+        if mode & 0o077:
+            out.append(f"{GLOBAL_CONFIG} is readable by other users. "
+                       f"It holds an API token — run: chmod 600 {GLOBAL_CONFIG}")
+    except OSError:
+        pass
+    _, rejected = _global_values()
+    for k in rejected:
+        if "COURSE_ID" in k.upper():
+            out.append(f"{GLOBAL_CONFIG} sets {k} — IGNORED. A course id must live in "
+                       f"the course's own .env; a global one silently sends writes to "
+                       f"whichever course was configured last.")
+        else:
+            out.append(f"{GLOBAL_CONFIG} sets {k} — ignored (only {', '.join(GLOBAL_KEYS)} "
+                       f"are read from the global file).")
+    return out
+
+
 def load_env() -> Path | None:
-    """Resolve and load the nearest .env. Returns the path loaded, or None."""
+    """Resolve and load the nearest .env, then fill gaps from ~/.canvas/config.
+
+    Precedence, highest first:
+      1. an already-set environment variable  (CI, one-off `TOKEN=x uv run …`)
+      2. the repo's .env                       (per-repo override)
+      3. ~/.canvas/config                      (the shared, rotating secret)
+
+    Canvas expires API tokens every 29 days, so an operator running N course repos was
+    editing N .env files a month — and the one they forgot 401'd silently until a
+    grading run failed. The global file makes that one edit.
+
+    EMPTY COUNTS AS ABSENT. cb_init scaffolds a bare `CANVAS_API_TOKEN=` into every new
+    repo's .env; treating that as a value would mean each new repo shadows the global
+    file with an empty string and breaks on day one. Only a REAL value overrides.
+
+    Returns the .env path loaded (unchanged contract — 90 tools call this), or None."""
     try:
         from dotenv import find_dotenv, load_dotenv
     except ImportError:
         return None
+
+    loaded: Path | None = None
 
     # 1. CWD-anchored upward walk (python-dotenv's built-in)
     #    Documented invocation pattern: operator runs from course-repo root,
@@ -74,19 +156,41 @@ def load_env() -> Path | None:
     found = find_dotenv(usecwd=True)
     if found:
         load_dotenv(found)
-        return Path(found)
+        loaded = Path(found)
+    else:
+        # 2. __file__-anchored upward walk (fallback for unusual layouts)
+        #    Catches the case where the tool is invoked from outside the repo
+        #    tree (e.g. an absolute-path invocation from a different CWD).
+        p = Path(__file__).resolve()
+        for parent in p.parents:
+            candidate = parent / ".env"
+            if candidate.exists():
+                load_dotenv(candidate)
+                loaded = candidate
+                break
 
-    # 2. __file__-anchored upward walk (fallback for unusual layouts)
-    #    Catches the case where the tool is invoked from outside the repo
-    #    tree (e.g. an absolute-path invocation from a different CWD).
-    p = Path(__file__).resolve()
-    for parent in p.parents:
-        candidate = parent / ".env"
-        if candidate.exists():
-            load_dotenv(candidate)
-            return candidate
+    # 3. Global fallback — only for keys still missing or empty, and only the
+    #    allowlisted ones. Applied key-by-key rather than via load_dotenv() on the
+    #    file, so an unexpected key in there can never reach the environment.
+    import os
+    allowed, _ = _global_values()
+    for key in GLOBAL_KEYS:
+        if not os.environ.get(key) and allowed.get(key):
+            os.environ[key] = allowed[key]
 
-    return None
+    return loaded
+
+
+def token_source() -> str:
+    """Where the token in the current environment came from — for reporting.
+    'env'/'repo .env'/'~/.canvas/config'/'none'. Best-effort, never raises."""
+    import os
+    if not os.environ.get("CANVAS_API_TOKEN"):
+        return "none"
+    allowed, _ = _global_values()
+    if os.environ["CANVAS_API_TOKEN"] == allowed.get("CANVAS_API_TOKEN"):
+        return str(GLOBAL_CONFIG)
+    return "repo .env or environment"
 
 
 def force_utf8_console() -> None:

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -65,6 +65,13 @@ try:
 except ImportError:
     _ensure_pre_push = None
 
+try:
+    from _env_loader import GLOBAL_CONFIG as _GLOBAL_CONFIG
+    from _env_loader import global_config_problems as _global_problems
+except ImportError:
+    _GLOBAL_CONFIG = Path.home() / ".canvas" / "config"
+    _global_problems = None
+
 SKILLS = ["grading", "course-build", "audit", "accommodations", "ferpa-deid",
           "title-iv", "voicing", "improve"]
 
@@ -287,6 +294,155 @@ def print_ignore_coverage(course_root: Path) -> None:
           f"{_ZONE2_EXTRA_FILE} too, so the guardian and the pre-push hook cover them.")
 
 
+def count_sibling_course_repos(course_root: Path) -> int:
+    """How many course repos sit alongside this one — the multi-course signal (#288).
+
+    Counts DIRECTORIES ONLY. It never reads another repo's `.env`: knowing a sibling
+    exists is enough to decide, and reading other repos' secrets to make a
+    convenience decision would be a bad trade.
+
+    A repo counts if it vendors the toolkit AND has a `.env` — i.e. it's a configured
+    course, not a scaffold. Fails SAFE: if the layout isn't flat (repos elsewhere on
+    disk), this undercounts and the operator is treated as single-course, which
+    declines to touch $HOME. The surprising action needs positive evidence."""
+    try:
+        siblings = list(course_root.resolve().parent.iterdir())
+    except OSError:
+        return 1
+    n = 0
+    for d in siblings:
+        try:
+            if d.is_dir() and (d / "canvas-toolbox").is_dir() and (d / ".env").is_file():
+                n += 1
+        except OSError:
+            continue
+    return max(n, 1)
+
+
+def _write_global_config(token: str | None) -> None:
+    """Create `~/.canvas/config` at 0600. `token=None` scaffolds it empty for the
+    operator to paste into — chmod happens either way, because the file is about to
+    hold a secret whether or not it does yet."""
+    _GLOBAL_CONFIG.parent.mkdir(parents=True, exist_ok=True)
+    _GLOBAL_CONFIG.write_text(
+        "# canvas-toolbox global credentials — rotate the token HERE, once, for\n"
+        "# every course repo. Canvas expires tokens every 29 days.\n"
+        "#\n"
+        "# Only CANVAS_API_TOKEN and CANVAS_BASE_URL are read from this file.\n"
+        "# A CANVAS_COURSE_ID here is IGNORED on purpose: it belongs in each course's\n"
+        "# own .env. A global one would silently send writes to whichever course was\n"
+        "# configured last.\n"
+        f"CANVAS_API_TOKEN={token or ''}\n", encoding="utf-8")
+    _GLOBAL_CONFIG.chmod(0o600)
+
+
+def migrate_token_to_global(course_root: Path, multi: bool, apply: bool) -> str:
+    """Consolidate a rotating token into `~/.canvas/config` (#288).
+
+    Canvas expires tokens every 29 days across all institutions now, so an operator
+    with N course repos edits N `.env` files a month and 401s on the one they forget.
+    The installed base is the whole problem — `cb_init` gets new repos right for free.
+
+    Only acts for MULTI-course operators: a single-course user gains nothing from a
+    second location and shouldn't have a repo tool writing secrets into their home
+    directory. Idempotent and self-consolidating — run it in any repo, in any order,
+    and re-running is a no-op, so there's no list to keep track of.
+
+    The local token is COMMENTED OUT, never deleted: visible in the diff, recoverable,
+    and if it was a deliberate per-repo override you can put it back.
+
+    Returns single-course/no-token/present/would-*/created/consolidated."""
+    if not multi:
+        return "single-course"
+    env_path = course_root / ".env"
+    try:
+        env_text = env_path.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return "no-token"
+    local = ""
+    for raw in env_text.splitlines():
+        line = raw.strip()
+        if line.startswith("#"):
+            continue
+        if line.replace("export ", "", 1).startswith("CANVAS_API_TOKEN="):
+            local = line.split("=", 1)[1].strip().strip("'\"")
+
+    have_global = _GLOBAL_CONFIG.is_file()
+    if not local:
+        # No usable local token — already migrated, or scaffolded-but-empty. If there
+        # is nowhere to put a token yet, still create the FILE. The moment anyone
+        # consolidates is the moment their token just expired (that's the reason they
+        # are here), so every local copy is stale by definition and there may be
+        # nothing worth seeding. An empty, correctly-permissioned file they can paste
+        # into beats "no-token" and no further guidance.
+        if have_global:
+            return "present"
+        if not apply:
+            return "would-scaffold"
+        _write_global_config(None)
+        return "scaffolded"
+    action = "consolidated" if have_global else "created"
+    if not apply:
+        return "would-consolidate" if have_global else "would-create"
+
+    if not have_global:
+        _write_global_config(local)
+
+    out = []
+    for raw in env_text.splitlines():
+        s = raw.strip()
+        if not s.startswith("#") and \
+                s.replace("export ", "", 1).startswith("CANVAS_API_TOKEN="):
+            out.append(f"# moved to {_GLOBAL_CONFIG} by cb_update (#288) — "
+                       f"rotate it there, once, for every course")
+            out.append(f"# {raw}")
+        else:
+            out.append(raw)
+    env_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+    return action
+
+
+def check_token(timeout: float = 8.0) -> str:
+    """Ask Canvas whether the resolved token actually works (#288).
+
+    Consolidating rotation into one file fixes N edits a month; it says nothing
+    about whether the token in it is CURRENT. Canvas expires them every 29 days, so
+    the failure mode is unchanged — you find out during a grading run.
+
+    One read-only GET /users/self turns that into a line of output. Distinguishes
+    the cases that look identical from the outside:
+      valid           - works
+      REJECTED        - Canvas doesn't recognise it (expired, revoked, or the
+                        string isn't the one Canvas issued — its UI shows a token's
+                        full value only once, so an 'active' entry can look healthy
+                        while the copy you hold is unusable)
+      no-token        - nothing resolved from any source
+      unreachable     - offline / DNS / timeout. NOT a token problem, and must not
+                        be reported as one; cb_update has always worked offline and
+                        a network call must not make it look broken.
+    Never prints or returns the token."""
+    import os
+    token = os.environ.get("CANVAS_API_TOKEN", "")
+    base = os.environ.get("CANVAS_BASE_URL", "").strip().rstrip("/")
+    if not token:
+        return "no-token"
+    if not base:
+        return "no-base-url"
+    if not base.startswith("http"):
+        base = "https://" + base
+    import urllib.error
+    import urllib.request
+    req = urllib.request.Request(f"{base}/api/v1/users/self",
+                                 headers={"Authorization": f"Bearer {token}"})
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as r:
+            return "valid" if 200 <= r.status < 300 else f"unexpected-{r.status}"
+    except urllib.error.HTTPError as e:
+        return "REJECTED" if e.code in (401, 403) else f"unexpected-{e.code}"
+    except Exception:                       # noqa: BLE001 — offline is not a failure
+        return "unreachable"
+
+
 def canvas_configured(course_root: Path) -> bool:
     """Whether this repo has a Canvas course wired up. Checks the environment and
     the course `.env` for a non-empty CANVAS_COURSE_ID."""
@@ -368,6 +524,17 @@ def main() -> int:
     ap.add_argument("--pull", action="store_true",
                     help="first `git pull` the VENDORED toolkit (the right repo), then "
                          "update — the one-command 'update canvas-toolbox'.")
+    creds = ap.add_mutually_exclusive_group()
+    creds.add_argument("--multi-course", action="store_true",
+                       help="you run several course repos: consolidate the Canvas token "
+                            f"into {_GLOBAL_CONFIG} so a 29-day rotation is ONE edit. "
+                            "Auto-detected from sibling repos; use this to force it.")
+    creds.add_argument("--single-course", action="store_true",
+                       help="never touch the global credentials file; keep the token "
+                            "in this repo's .env.")
+    ap.add_argument("--no-token-check", action="store_true",
+                    help="skip the read-only GET /users/self that verifies the Canvas "
+                         "token still works (the only network call cb_update makes).")
     args = ap.parse_args()
 
     course_root, is_subdir = detect_course_context()
@@ -426,6 +593,52 @@ def main() -> int:
                   "alone. Chain this in manually if you want both.")
 
     print_ignore_coverage(course_root)
+
+    # Canvas rotates API tokens every 29 days across all institutions now, so N course
+    # repos means N .env edits a month and a silent 401 on the one you forget (#288).
+    n_repos = count_sibling_course_repos(course_root)
+    multi = args.multi_course or (n_repos > 1 and not args.single_course)
+    cred = migrate_token_to_global(course_root, multi, args.apply)
+    print(f"\nCanvas credentials: {cred}"
+          + (f"  ({n_repos} course repos alongside this one)" if n_repos > 1 else ""))
+    if cred.startswith(("created", "would-create")):
+        print(f"  ↳ the token moves to {_GLOBAL_CONFIG} (chmod 600) and is commented "
+              f"out here. Rotate it THERE from now on — once, for every course.")
+        print("    Verify it's current: consolidating doesn't refresh an expired token, "
+              "it just gives you one place to fix it.")
+    elif cred.startswith(("consolidated", "would-consolidate")):
+        print(f"  ↳ this repo's .env shadowed {_GLOBAL_CONFIG}; the local copy is "
+              f"commented out so the global one is used.")
+    elif cred == "single-course" and n_repos == 1:
+        print("  ↳ one course repo here, so the token stays in .env. Running several? "
+              "`--multi-course` consolidates them.")
+    if _global_problems is not None:
+        for problem in _global_problems():
+            print(f"  ⚠ {problem}")
+
+    if not args.no_token_check:
+        status = check_token()
+        print(f"  token check: {status}")
+        if status == "REJECTED":
+            print("    ↳ Canvas returned 'Invalid access token' — it does not have this "
+                  "string. Three causes look identical from here:")
+            print("      1. NOT YET ACCEPTED. A user-generated token can need approving "
+                  "in Canvas → Account →")
+            print("         Settings before it works. It is listed as active the whole "
+                  "time. Check this FIRST —")
+            print("         it costs one click and looks exactly like an expired token "
+                  "until you do.")
+            print("      2. Expired or revoked (Canvas rotates every 29 days).")
+            print("      3. Not the string Canvas issued — the full value is shown ONCE, "
+                  "at generation; the entry")
+            print("         keeps showing a hint afterwards, so a saved copy can be "
+                  "unusable and still look healthy.")
+            print(f"      The token itself is fine to re-paste into {_GLOBAL_CONFIG} — "
+                  f"one edit covers every course.")
+        elif status == "unreachable":
+            print("    ↳ couldn't reach Canvas (offline?). This is NOT a token "
+                  "problem — nothing else here needs the network.")
+
     print_lms_mode(course_root)
 
     print("\nReminder: `cd " + toolkit_subdir + " && git pull` keeps the toolkit "

--- a/lib/tools/ferpa_pre_push.py
+++ b/lib/tools/ferpa_pre_push.py
@@ -65,9 +65,9 @@ except ImportError:
         pass
 
 try:
-    from grade_guardian import load_zone2, compile_zone2
+    from grade_guardian import load_zone2, compile_zone2, credential_path_re
 except ImportError:                      # standalone / partial vendoring
-    load_zone2 = compile_zone2 = None
+    load_zone2 = compile_zone2 = credential_path_re = None
 
 _NULL_SHA = "0" * 40
 _SCAN_CONTENT_FLAG = ".claude/ferpa_scan_content"
@@ -284,7 +284,13 @@ def main() -> int:
         return 0
 
     entries, _ = load_zone2(repo)
-    path_re, _ = compile_zone2(entries)
+    zone2_re, _ = compile_zone2(entries)
+    # Credentials too (#288). `.env` is gitignored today — but #285 exists because an
+    # ignore-rule restructure quietly stopped covering three paths, and a pushed token
+    # is usable by anyone who finds it the moment it lands.
+    cred_re = credential_path_re() if credential_path_re else None
+    path_re = re.compile(f"{zone2_re.pattern}|{cred_re.pattern}", re.IGNORECASE) \
+        if cred_re else zone2_re
     scan_on = (repo / _SCAN_CONTENT_FLAG).exists()
     roster = _load_roster(repo) if scan_on else []
 

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -187,6 +187,44 @@ def zone2_summary(course_root: Path | None = None) -> dict:
 
 _FERPA_PATH, _FERPA_FILE = compile_zone2(load_zone2()[0])
 
+
+# --------------------------------------------------------------------------
+# CREDENTIALS (#288). Zone-2 protects student data; nothing protected the API
+# token, and consolidating it into `~/.canvas/config` made that worse: five
+# repo-local gitignored files became ONE well-known path holding the single
+# credential for every course. More valuable, more predictable, and outside the
+# repo where repo-scoped protections don't reach.
+#
+# A leaked token is worse than a leaked name in one specific way — it is
+# immediately usable by anyone who finds it, with no institutional relationship
+# required, and revocation is the only remedy.
+#
+# GRADED ON PURPOSE, and the asymmetry is the point:
+#   ~/.canvas/config  holds a credential and nothing else -> block Read AND shell.
+#                     Nothing legitimate reads it except load_env(), which is
+#                     in-process Python and never a tool call.
+#   .env              holds course ids and settings an agent legitimately works
+#                     with -> block raw SHELL DISPLAY only, leave Read alone.
+#                     Blocking Read would also block Edit (the harness requires a
+#                     read first), leaving only blind whole-file overwrite, which
+#                     is worse than the leak it prevents.
+#
+# The escape hatch stays open: `grep -o '^[A-Z_]*=' .env` lists KEY NAMES without
+# values and isn't a raw-display verb, so checking what's configured still works.
+_CRED_READ = re.compile(r"\.canvas/config$", re.IGNORECASE)
+
+# `(?![\w.])` so `.env` matches but `.env.example` and `.envrc` do not — a
+# template and a direnv file carry no secret and blocking them is pure friction.
+_CRED_SHELL = re.compile(r"\.canvas/config|\.env(?![\w.])", re.IGNORECASE)
+
+# Shared with the pre-push guard: a credential must not reach a remote either.
+CREDENTIAL_PATTERNS = (r"\.canvas/config", r"\.env(?![\w.])")
+
+
+def credential_path_re() -> re.Pattern:
+    """Paths that carry a Canvas credential — for the git layer (#285/#288)."""
+    return re.compile("|".join(CREDENTIAL_PATTERNS), re.IGNORECASE)
+
 # Raw display / read of a file's contents. The constitution forbids these on Zone-2
 # files ("not with Read, cat, head, tail, or bare grep"). Deliberately EXCLUDES the
 # sanctioned filtered verification (`grep <code> .deid_master.csv | cut -d',' -f1,2`,
@@ -261,6 +299,19 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
         # that legitimately read these (grader_reidentify) run via lib/tools/ → exempt.
         # Metadata (`wc`/`ls`/`stat`) and the sanctioned `grep <code> … | cut -f1,2`
         # verification aren't raw-display verbs, so they still pass.
+        # Credentials (#288) — same raw-display test, different reason. A token
+        # printed into a transcript is exposed even if the transcript is private,
+        # and this fires on the python `open()`/`.read_text()` forms too, which is
+        # how it actually gets leaked in practice (a script that prints a file).
+        if ("/lib/tools/" not in cmd.replace("\\", "/")
+                and _RAW_READ.search(cmd) and _CRED_SHELL.search(cmd)):
+            return (
+                "⛔ Canvas credential file — never cat/head/print it. It holds an API "
+                "token; anything displayed here is in the transcript for good, and a "
+                "leaked token is usable by anyone who finds it. Tools read it in-process "
+                "via _env_loader.load_env() and never surface the value. To see WHICH "
+                "keys are set without values: grep -o '^[A-Z_]*=' <file>"
+            )
         if ("/lib/tools/" not in cmd.replace("\\", "/")
                 and _RAW_READ.search(cmd) and _FERPA_FILE.search(cmd)):
             return (
@@ -306,6 +357,14 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
 
     if tool_name == "Read":
         path = tool_input.get("file_path", "") or ""
+        if _CRED_READ.search(path):
+            return (
+                "⛔ Global Canvas credential file — do not Read it. It holds ONE API "
+                "token used by every course repo, and a Read puts it in the transcript "
+                "permanently. Tools load it in-process (_env_loader.load_env()) and "
+                "never surface the value; you don't need to see it. To check it's "
+                "configured: grep -o '^[A-Z_]*=' ~/.canvas/config"
+            )
         if _FERPA_PATH.search(path):
             return (
                 "⛔ FERPA Zone-2 file — do not Read it (AGENTS.md → FERPA discipline). "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.19.1"
+version = "1.20.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.19.1"
+version = "1.20.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #288. Verified end-to-end on a real six-repo installation before merging — migration applied, all repos resolving the global token, all authenticating.

Canvas now expires API tokens every 29 days across all institutions, so this lands on every consumer, not one. Five course repos meant five `.env` edits a month and a silent 401 on the one you forgot — which blocked eight courses on 2026-08-06.

## Where it goes

The issue proposed a new `get_canvas_token()` and guessed at `lib/canvas_api.py`. There's already a single source of truth — `_env_loader.load_env()`, called by **90 tools** — whose docstring anticipated exactly this: *"a future improvement (e.g. multi-file precedence) lands in ONE place instead of twelve."* Same ~30 min estimate, different location, and every tool inherits it.

## Three corrections to the proposal

**Precedence stays conventional.** The issue put the env var *last*; today `load_dotenv(override=False)` means an already-set env var wins, and demoting it would break CI and one-off `CANVAS_API_TOKEN=x uv run …` overrides. Order is env var → repo `.env` → global.

**No hand-rolled parser.** `export CANVAS_API_TOKEN="1234~ab#cd"` defeats `startswith()`, keeps the quotes, and truncates at the `#` — each **silently**, reporting "no token found" while the token sits in the file. python-dotenv already handles it.

**The global file never supplies a course id.** This is the safety property. `canvas_course_guard` (#27) exists because a stale `CANVAS_COURSE_ID` silently sends writes to the wrong course; a global one manufactures that. It's an **allowlist**, not a denylist, because one field repo carries *eight* course-id-ish keys (`S1`/`S2`/`S3_COURSE_ID`, `BLUEPRINT_`, `MASTER_`, `PROTECTED_`, `SANDBOX_`) — missing one means grades in the wrong course. A course id there is ignored **and reported**.

## Migrating the installed base

`cb_init` gets new repos right for free, so the interesting problem is existing ones. `cb_update` detects multi-course from sibling **directory names** (never reading another repo's `.env` to make a convenience decision), consolidates, and **comments out** the local token rather than deleting it. Idempotent and self-consolidating — any repo, any order, re-run freely.

Single-course operators are untouched: a repo tool writing secrets into `$HOME` needs positive evidence, and detection fails safe toward "single". `--multi-course` / `--single-course` override.

Two things came out of testing on a real machine:

- **Empty counts as absent.** `cb_init` scaffolds a bare `CANVAS_API_TOKEN=`; treating that as a value would have every new repo shadow the global file with an empty string. A repo already existed in exactly that state.
- **When there's nothing worth seeding, scaffold the file empty at `0600`.** The moment anyone consolidates is the moment their token expired — that's *why* they're there — so every local copy may be stale. The original design would have written a dead token and stopped.

## Token validation

Consolidating rotation says nothing about whether the token is *current*, so the failure mode was otherwise unchanged. One read-only `GET /users/self` → `valid` / `REJECTED` / `unreachable` / `no-token`.

`unreachable` is deliberately distinct from `REJECTED`: reporting a network blip as a bad credential sends someone to regenerate a working one, and `cb_update` has always worked offline. `--no-token-check` opts out.

The `REJECTED` message names three causes that are **indistinguishable from outside**, led by the one found the hard way during this work: a user-generated token can need **accepting** in Canvas → Account → Settings, and stays listed as active the entire time it doesn't work. That cost twenty minutes of diagnosis; it's now one line of output.

## The guardrails moved with the credential

Consolidation made the token a better target — five repo-local gitignored files became one well-known path, outside any repo, holding every course's key.

`grade_guardian` now covers credentials, **extending the existing hook rather than adding a second one** that could be missing or inert (the #278 / #285 lesson). Graded on purpose:

| | blocked |
|---|---|
| `Read` + shell display of `~/.canvas/config` | ✓ |
| shell display of `.env` (incl. python `.read_text()`) | ✓ |
| `Read .env`, `grep -o '^[A-Z_]*='`, `.env.example`, `.envrc` | allowed |

`~/.canvas/config` holds a credential and nothing else, so blocking it fully costs nothing. Blocking `Read` on `.env` would also block `Edit` — the harness requires a read first — leaving blind whole-file overwrite, which is worse than the leak it prevents.

It catches the form that **actually** leaks a token: not `cat`, but a script calling `.read_text()` and printing. I did exactly that during this session and nothing stopped me; mistake-proofing that only covered `cat`/`head` would have missed it and felt safe.

The pre-push guard blocks a committed credential too. A pushed token is worse than a pushed name in one way that matters: usable by anyone who finds it, no institutional relationship needed, revocation the only remedy.

## Verification

1186 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main` **and** with a known-good token — conclusively unrelated.

Field-verified: six repos migrated, `~/.canvas/config` at `0600`, all six resolving the global token, five authenticating (the sixth is an unconfigured scaffold with no base URL — correct, not a failure).

🤖 Generated with [Claude Code](https://claude.com/claude-code)