### PR TITLE
fix(cb_update): token check never read ~/.canvas/config (#288 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,23 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.20.1] — 2026-08-07
+
+**`cb_update`'s token check was testing the wrong thing (#288 follow-up).**
+
+Five consumer repos reported `token check: REJECTED` on the same day the operator's `curl` against `~/.canvas/config` returned `200`. The tool was right that *something* was wrong and wrong about what.
+
+`cb_update` is not a Canvas tool and never called `load_env()`. `check_token()` read a bare `os.environ` that nothing had populated — so it **never looked at `~/.canvas/config` at all**. On a clean environment it reported `no-token`; where a stale value happened to be present in the process environment, it reported `REJECTED` against that. The credential it was supposed to be verifying was never sent.
+
+A check that tests something other than what the tools use is worse than no check: it sent an operator to regenerate a working token, twice.
+
+- `check_token()` now resolves credentials through `load_env()` first — the same environment variable → repo `.env` → `~/.canvas/config` chain every tool uses. Verified on a real repo: `no-token` before, `valid` after, same file and same token.
+- A test pins that the credential actually reaching Canvas is the resolved one, by capturing the `Authorization` header rather than trusting the returned status.
+
+*Also worth knowing:* `load_env()`'s `__file__`-anchored fallback walks up from `lib/tools/` and finds a **vendored toolkit's own `.env`** before the course root's. Consumers don't normally have one, but a maintainer checkout does — and it silently wins over the global file. If `canvas-toolbox/.env` exists on your machine and carries a token, delete that line.
+
+---
+
 ## [1.20.0] — 2026-08-06
 
 **One place to rotate the Canvas token — and the guardrails follow it there (#288).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -509,9 +509,18 @@ def test_scaffolds_an_empty_config_when_there_is_no_token_to_seed(tmp_path, monk
     assert migrate_token_to_global(root, multi=True, apply=True) == "present"
 
 
-def test_token_check_reports_no_token_without_a_network_call(monkeypatch):
+def test_token_check_reports_no_token_without_a_network_call(tmp_path, monkeypatch):
+    """Must isolate BOTH sources now that check_token resolves credentials properly —
+    otherwise it reads the developer's real ~/.canvas/config and this passes or fails
+    depending on whose machine runs it."""
+    import _env_loader
     for v in ("CANVAS_API_TOKEN", "CANVAS_BASE_URL"):
         monkeypatch.delenv(v, raising=False)
+    # load_env()'s __file__-anchored fallback walks up from lib/tools/ and finds the
+    # TOOLKIT's own .env before anything else — on a maintainer's machine that holds a
+    # real token, so without this the test asserts against their credential.
+    monkeypatch.setattr(_env_loader, "load_env", lambda: None)
+    monkeypatch.setattr(_env_loader, "GLOBAL_CONFIG", tmp_path / "nope" / "config")
     assert check_token() == "no-token"
 
 
@@ -542,3 +551,34 @@ def test_token_check_never_returns_the_token(monkeypatch):
     monkeypatch.setattr(urllib.request, "urlopen",
                         lambda *a, **kw: (_ for _ in ()).throw(OSError("x")))
     assert "SECRET" not in check_token()
+
+
+def test_token_check_resolves_credentials_instead_of_reading_a_bare_environ(tmp_path, monkeypatch):
+    """cb_update is not a Canvas tool and never called load_env(), so check_token()
+    read an os.environ nothing had populated — it never looked at ~/.canvas/config.
+    Five consumer repos reported a rejected token on the same day the operator's curl
+    against that file returned 200. A check that tests something other than what the
+    tools use is worse than no check."""
+    import _env_loader
+    monkeypatch.delenv("CANVAS_API_TOKEN", raising=False)
+    monkeypatch.delenv("CANVAS_BASE_URL", raising=False)
+    cfg = tmp_path / ".canvas" / "config"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("CANVAS_API_TOKEN=GLOBAL_tok\n", encoding="utf-8")
+    monkeypatch.setattr(_env_loader, "GLOBAL_CONFIG", cfg)
+    repo = tmp_path / "course"
+    repo.mkdir()
+    (repo / ".env").write_text("CANVAS_BASE_URL=byui.instructure.com\n", encoding="utf-8")
+    monkeypatch.chdir(repo)
+
+    seen = {}
+    import urllib.request
+
+    def _capture(req, *a, **kw):
+        seen["auth"] = req.get_header("Authorization")
+        raise OSError("stop before the network")
+    monkeypatch.setattr(urllib.request, "urlopen", _capture)
+
+    check_token()
+    assert seen.get("auth") == "Bearer GLOBAL_tok", \
+        "check_token must test the credential the tools resolve, not a bare environ"

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -420,8 +420,21 @@ def check_token(timeout: float = 8.0) -> str:
       unreachable     - offline / DNS / timeout. NOT a token problem, and must not
                         be reported as one; cb_update has always worked offline and
                         a network call must not make it look broken.
+    RESOLVES CREDENTIALS FIRST. cb_update is not a Canvas tool and never called
+    load_env(), so this read a bare os.environ that nothing had populated — it never
+    looked at ~/.canvas/config at all. It reported `no-token` on a clean environment,
+    or `REJECTED` against whatever stale value happened to be in the process env,
+    while the real credential sat unread. Five consumer repos reported a rejected
+    token on the same day the operator's `curl` against that file returned 200.
+    A check that tests something other than what the tools use is worse than none.
+
     Never prints or returns the token."""
     import os
+    try:
+        from _env_loader import load_env
+        load_env()                      # env var -> repo .env -> ~/.canvas/config
+    except ImportError:
+        pass
     token = os.environ.get("CANVAS_API_TOKEN", "")
     base = os.environ.get("CANVAS_BASE_URL", "").strip().rstrip("/")
     if not token:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.20.0"
+version = "1.20.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.20.0"
+version = "1.20.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Follow-up to #289. Found from field reports across five consumer repos.

Every repo reported `token check: REJECTED` on the same day the operator's `curl` against `~/.canvas/config` returned `200`. The tool was right that *something* was wrong, and wrong about what.

## The bug

`cb_update` is not a Canvas tool and never called `load_env()`. `check_token()` read a bare `os.environ` that nothing had populated — so it **never looked at `~/.canvas/config` at all**.

- Clean environment → `no-token`
- Any stale value present in the process environment → `REJECTED` against *that*

Either way the credential it was meant to verify was never sent. I added this check in #289 specifically so nobody would waste time diagnosing a token by hand — and it then sent the operator to regenerate a working token twice. A check that tests something other than what the tools use is worse than no check.

One of the field agents reasoned its way to the right answer unaided ("the environment variable is stale — the token in `.canvas/config` works fine") while the tool kept insisting otherwise.

## The fix

`check_token()` resolves through `load_env()` first — the same environment variable → repo `.env` → `~/.canvas/config` chain every other tool uses.

Verified on a real repo, same file and same token:

```
token check: no-token     # before
token check: valid        # after
```

The test captures the `Authorization` header rather than trusting the returned status, so it pins **which credential actually reaches Canvas** rather than just that some call was made. Trusting the status is what let the original bug through — it "worked", it just worked on the wrong input.

## A second hazard, surfaced while fixing it

`load_env()`'s `__file__`-anchored fallback walks up from `lib/tools/` and finds a **vendored toolkit's own `.env`** before the course root's. Consumers don't normally have one — but a maintainer checkout does, and on this machine it holds an expired token that silently wins over the global file.

It's also what made the pre-existing `no-token` test fail once the fix landed: with no `.env` in the CWD, `check_token()` started authenticating as the toolkit repo's stale credential. Noted in the changelog rather than changed here — narrowing that fallback is a separate decision with its own blast radius (it exists for tools invoked from outside the repo tree).

1187 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main` and with a known-good token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)