### PR TITLE
docs(pointer): tell agents where the Canvas token lives (#288 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.20.3] — 2026-08-07
+
+**Tell agents where the Canvas token actually lives (#288 follow-up).**
+
+A field agent opened a course `.env`, found no `CANVAS_API_TOKEN`, and reported *"API Token: Missing — Canvas is not accessible."* The token was resolvable the whole time; the toolkit in that repo returns it correctly from `~/.canvas/config`. Nothing told the agent that file exists.
+
+Worse, its proposed fix was to add a token back into `.env` — which would shadow the global file and silently reinstate the stale-copy problem consolidation removed. One helpful agent could undo the migration on a repo and nobody would notice until a token rotation.
+
+- The **pointer block** injected into every consumer `AGENTS.md` now states the resolution order (environment variable → repo `.env` → `~/.canvas/config`), says plainly that a `.env` without a token is the *expected* state on a multi-course machine, and forbids adding one back.
+- It directs agents to check reachability by running `cb_update` and reading its `token check:` line rather than inspecting files — and notes that `REJECTED` most often means the token needs **accepting** in Canvas settings, since it stays listed as active the entire time it doesn't work.
+- The block is self-healing, so every consumer picks this up on their next `cb_update` without touching course-specific content. Verified against a real consumer `AGENTS.md`: detected as stale, refreshed, idempotent on re-run.
+
+*No code changed — the credential path was already correct. What was missing was any way for an agent to know it.*
+
+---
+
 ## [1.20.2] — 2026-08-07
 
 **The credential guard denied its own documented escape hatch (#288 follow-up).**

--- a/lib/tests/test_sync_grading_protocol.py
+++ b/lib/tests/test_sync_grading_protocol.py
@@ -103,3 +103,18 @@ def test_process_apply_writes_once(tmp_path):
     # second apply is a no-op
     assert process_agents_file(p, apply=True) == "present"
     assert p.read_text(encoding="utf-8").count(POINTER_MARKER) == 1
+
+
+def test_pointer_block_tells_agents_where_credentials_live():
+    """A field agent read a course .env, saw no CANVAS_API_TOKEN, and reported
+    'API Token: Missing' — then offered to add one back, which would silently
+    shadow ~/.canvas/config and reinstate the stale-copy problem consolidation
+    removed. The token WAS resolvable; nothing told the agent where to look.
+
+    This is the block every consumer AGENTS.md carries, so it's where the answer
+    has to be."""
+    new, _ = inject_grading_pointer("# Course\n\nContext.\n")
+    assert "~/.canvas/config" in new                  # where it actually lives
+    assert "never add a token back" in new            # don't recreate the shadow
+    assert "token check:" in new                      # how to check without reading files
+    assert "accepting" in new                         # the REJECTED cause that looks like expiry

--- a/lib/tools/sync_grading_protocol.py
+++ b/lib/tools/sync_grading_protocol.py
@@ -58,6 +58,18 @@ self-attest. When a gate blocks you, get the human — never stack `--force`/`--
 to route around it, and never hand-write a Canvas write (the `grade_guardian` hook
 blocks that at create/edit/run).
 
+**The Canvas token may not be in `.env` — that is normal, not a misconfiguration.**
+Credentials resolve in this order: environment variable → this repo's `.env` →
+**`~/.canvas/config`** (one file, all courses — Canvas expires tokens every 29 days,
+so it is rotated in ONE place). A `.env` with no `CANVAS_API_TOKEN` is the *expected*
+state on a multi-course machine. **Never conclude "token missing" by reading `.env`,
+and never add a token back into it** — a real value there shadows the global file and
+silently reinstates the stale-copy problem the consolidation removed. To check whether
+Canvas is reachable, run `uv run python canvas-toolbox/lib/tools/cb_update.py` and read
+its `token check:` line (`valid` / `REJECTED` / `no-token`); don't inspect files. If it
+says `REJECTED`, the token most often just needs **accepting** in Canvas → Account →
+Settings — it is listed as active the whole time it doesn't work.
+
 **Updating the toolkit — run ONE command, don't improvise git.** When the instructor
 says any of these (all mean the same thing):
 "update cb", "git pull cb", "pull cb", "update canvas-toolbox", "pull canvas-toolbox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.20.2"
+version = "1.20.3"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.20.2"
+version = "1.20.3"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Follow-up to #291, from a field report.

An agent in a course repo opened `.env`, found no `CANVAS_API_TOKEN`, and reported:

> **API Token: Missing** — Canvas is not accessible.

It was wrong. That repo resolves the token correctly from `~/.canvas/config` — verified directly: token present, base URL `byui.instructure.com`, course id `409936`. Nothing was missing. Nothing told the agent that file exists.

## Why this matters more than a wrong status line

Its proposed fix was **"add an API token to `.env`"**.

That would put a real value back into a repo `.env`, which by design wins over the global file. It silently reinstates exactly the stale-copy problem the consolidation removed — and it wouldn't surface until the next 29-day rotation, when that one repo keeps 401ing while the others work. One helpful agent could quietly undo the migration on a repo.

## Fix

The pointer block that `cb_update` injects into every consumer `AGENTS.md` now covers credentials:

- The resolution order: environment variable → repo `.env` → `~/.canvas/config`
- That a `.env` **without** a token is the *expected* state on a multi-course machine, not a misconfiguration
- **Never conclude "token missing" by reading `.env`, and never add one back**
- Check reachability by running `cb_update` and reading its `token check:` line, rather than inspecting files
- `REJECTED` most often means the token needs **accepting** in Canvas → Account → Settings — it stays listed as active the entire time it doesn't work

The block is self-healing, so every consumer picks this up on their next `cb_update` with no course-specific content touched. Verified against a real consumer `AGENTS.md`: detected stale, refreshed, content preserved, idempotent on re-run.

## Note

**No code changed.** The credential path was already correct — this is purely that an agent had no way to know it. Which is its own lesson: consolidating credentials into a new location isn't finished until the thing that reads the repo's instructions knows the location exists.

1210 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)