### PR TITLE
fix(credentials): make ~/.canvas/config source-able; tell scripts how to load it (#288)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,22 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.20.4] — 2026-08-07
+
+**`~/.canvas/config` is now `source`-able, and ad-hoc scripts are told how to load it (#288 follow-up).**
+
+Two field agents independently ran `source ~/.canvas/config && python …` and got nothing. A plain `KEY=value` line sources into a **shell variable**, which no child process inherits — so the token was there and invisible. Both concluded it was missing; one offered to put a token back in `.env`.
+
+The toolkit never noticed because it parses the file directly. The gap only appears for everything *outside* the toolkit — ad-hoc scripts, and course-local `tools/*.py` that read `os.environ` after loading `.env`. Those worked before consolidation and silently stopped afterward. That class of consumer wasn't considered when the migration was designed.
+
+- **The file is written with `export`.** Sourcing now works, and python-dotenv parses the prefix unchanged, so one file serves the toolkit, the shell, and any script that reads `os.environ`.
+- **`cb_update` adds the missing prefix to an existing config** (`--apply`), preserving comments and re-asserting `0600`. Idempotent; a commented-out line is left alone.
+- **The pointer block gives agents the two-line idiom** for loading credentials in an ad-hoc script, and states plainly that `env | grep CANVAS` showing only `CANVAS_BASE_URL`/`CANVAS_COURSE_ID` is normal — the token isn't exported into a session, and its absence there proves nothing. Both agents treated that output as evidence of misconfiguration.
+
+*Verified end-to-end: `source ~/.canvas/config` → child process sees the token → Canvas returns 200.*
+
+---
+
 ## [1.20.3] — 2026-08-07
 
 **Tell agents where the Canvas token actually lives (#288 follow-up).**

--- a/lib/tests/test_cb_update.py
+++ b/lib/tests/test_cb_update.py
@@ -58,6 +58,7 @@ from cb_update import (  # noqa: E402
     count_sibling_course_repos,
     migrate_token_to_global,
     check_token,
+    normalize_global_config,
     canvas_configured,
     refresh_pointer,
 )
@@ -582,3 +583,43 @@ def test_token_check_resolves_credentials_instead_of_reading_a_bare_environ(tmp_
     check_token()
     assert seen.get("auth") == "Bearer GLOBAL_tok", \
         "check_token must test the credential the tools resolve, not a bare environ"
+
+
+def test_global_config_is_written_with_export(tmp_path, monkeypatch):
+    """A plain `KEY=value` sources into a SHELL variable that no child process
+    inherits, so `source ~/.canvas/config && python script.py` silently finds
+    nothing — two field agents did exactly that and concluded the token was
+    missing. `export` makes sourcing work and python-dotenv still parses it."""
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    _cbu._write_global_config("TOK_abc")
+    body = target.read_text(encoding="utf-8")
+    assert "export CANVAS_API_TOKEN=TOK_abc" in body
+    assert target.stat().st_mode & 0o777 == 0o600
+
+
+def test_existing_config_without_export_is_normalized(tmp_path, monkeypatch):
+    """Files written before this change lack the prefix. The toolkit never noticed
+    (it parses the file directly) but every ad-hoc `source … && python …` got
+    nothing."""
+    target = tmp_path / "home" / ".canvas" / "config"
+    target.parent.mkdir(parents=True)
+    target.write_text("# comment\nCANVAS_API_TOKEN=TOK_abc\n", encoding="utf-8")
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+
+    assert normalize_global_config(apply=False) == "would-fix"
+    assert "export" not in target.read_text(encoding="utf-8")   # dry run wrote nothing
+    assert normalize_global_config(apply=True) == "fixed"
+    body = target.read_text(encoding="utf-8")
+    assert "export CANVAS_API_TOKEN=TOK_abc" in body
+    assert "# comment" in body                                   # comments preserved
+    assert normalize_global_config(apply=True) == "present"      # idempotent
+
+
+def test_normalize_ignores_commented_lines_and_missing_file(tmp_path, monkeypatch):
+    target = tmp_path / "home" / ".canvas" / "config"
+    monkeypatch.setattr(_cbu, "_GLOBAL_CONFIG", target)
+    assert normalize_global_config(apply=True) == "absent"
+    target.parent.mkdir(parents=True)
+    target.write_text("# CANVAS_API_TOKEN=commented_out\n", encoding="utf-8")
+    assert normalize_global_config(apply=True) == "present"      # a comment isn't a setting

--- a/lib/tools/cb_update.py
+++ b/lib/tools/cb_update.py
@@ -30,6 +30,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -322,18 +323,56 @@ def count_sibling_course_repos(course_root: Path) -> int:
 def _write_global_config(token: str | None) -> None:
     """Create `~/.canvas/config` at 0600. `token=None` scaffolds it empty for the
     operator to paste into — chmod happens either way, because the file is about to
-    hold a secret whether or not it does yet."""
+    hold a secret whether or not it does yet.
+
+    WRITTEN WITH `export`, which matters more than it looks. A plain `KEY=value` line
+    creates a SHELL variable that child processes never inherit, so
+    `source ~/.canvas/config && python script.py` silently finds nothing — two field
+    agents tried exactly that and concluded the token was missing. `export` makes
+    sourcing work, and python-dotenv parses the prefix fine, so the one file serves
+    both the toolkit and any ad-hoc script or course-local tool that reads os.environ."""
     _GLOBAL_CONFIG.parent.mkdir(parents=True, exist_ok=True)
     _GLOBAL_CONFIG.write_text(
         "# canvas-toolbox global credentials — rotate the token HERE, once, for\n"
         "# every course repo. Canvas expires tokens every 29 days.\n"
         "#\n"
+        "# `export` is deliberate: it lets `source ~/.canvas/config` work for ad-hoc\n"
+        "# scripts as well as the toolkit's own loader. Keep it.\n"
+        "#\n"
         "# Only CANVAS_API_TOKEN and CANVAS_BASE_URL are read from this file.\n"
         "# A CANVAS_COURSE_ID here is IGNORED on purpose: it belongs in each course's\n"
         "# own .env. A global one would silently send writes to whichever course was\n"
         "# configured last.\n"
-        f"CANVAS_API_TOKEN={token or ''}\n", encoding="utf-8")
+        f"export CANVAS_API_TOKEN={token or ''}\n", encoding="utf-8")
     _GLOBAL_CONFIG.chmod(0o600)
+
+
+def normalize_global_config(apply: bool) -> str:
+    """Add the missing `export` prefix to an existing `~/.canvas/config` (#288).
+
+    Files written before this change use a plain `KEY=value`, which sources into a
+    shell variable that no child process inherits. The toolkit never noticed — it
+    parses the file directly — but every ad-hoc `source … && python …` silently got
+    nothing. Returns present/would-fix/fixed/absent. Never logs the value."""
+    if not _GLOBAL_CONFIG.is_file():
+        return "absent"
+    try:
+        text = _GLOBAL_CONFIG.read_text(encoding="utf-8")
+    except (OSError, ValueError):
+        return "absent"
+    lines = text.splitlines()
+    needs = [i for i, ln in enumerate(lines)
+             if not ln.lstrip().startswith("#")
+             and re.match(r"\s*(CANVAS_API_TOKEN|CANVAS_BASE_URL)\s*=", ln)]
+    if not needs:
+        return "present"
+    if not apply:
+        return "would-fix"
+    for i in needs:
+        lines[i] = "export " + lines[i].lstrip()
+    _GLOBAL_CONFIG.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    _GLOBAL_CONFIG.chmod(0o600)
+    return "fixed"
 
 
 def migrate_token_to_global(course_root: Path, multi: bool, apply: bool) -> str:
@@ -625,6 +664,11 @@ def main() -> int:
     elif cred == "single-course" and n_repos == 1:
         print("  ↳ one course repo here, so the token stays in .env. Running several? "
               "`--multi-course` consolidates them.")
+    norm = normalize_global_config(args.apply)
+    if norm in ("fixed", "would-fix"):
+        print(f"  {'added' if norm == 'fixed' else 'would add'} the missing `export` "
+              f"prefix in {_GLOBAL_CONFIG} — without it `source` sets a shell variable "
+              f"that child processes never inherit.")
     if _global_problems is not None:
         for problem in _global_problems():
             print(f"  ⚠ {problem}")

--- a/lib/tools/sync_grading_protocol.py
+++ b/lib/tools/sync_grading_protocol.py
@@ -70,6 +70,19 @@ its `token check:` line (`valid` / `REJECTED` / `no-token`); don't inspect files
 says `REJECTED`, the token most often just needs **accepting** in Canvas → Account →
 Settings — it is listed as active the whole time it doesn't work.
 
+**Writing an ad-hoc script or running a course-local `tools/*.py`?** Load credentials
+the way the toolkit does — do NOT read `.env` yourself and do NOT assume `os.environ`
+is already populated:
+
+```python
+import sys; sys.path.insert(0, "canvas-toolbox/lib/tools")
+from _env_loader import load_env; load_env()   # env → .env → ~/.canvas/config
+```
+
+From a shell, `source ~/.canvas/config` also works (the file uses `export`).
+`env | grep CANVAS` showing only `CANVAS_BASE_URL`/`CANVAS_COURSE_ID` is normal — the
+token is not exported into your session and its absence there proves nothing.
+
 **Updating the toolkit — run ONE command, don't improvise git.** When the instructor
 says any of these (all mean the same thing):
 "update cb", "git pull cb", "pull cb", "update canvas-toolbox", "pull canvas-toolbox",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.20.3"
+version = "1.20.4"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.20.3"
+version = "1.20.4"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Follow-up to #292, from two more field transcripts.

Two agents independently ran `source ~/.canvas/config && python …` and got nothing:

```
⏺ Bash(source /Users/chazclar/.canvas/config && uv run python -c "import os…")
  ⎿  ❌ No CANVAS_API_TOKEN found
```

A plain `KEY=value` line sources into a **shell variable**, which no child process inherits. The token was present and invisible. Both agents concluded it was missing, and one offered to add a token back into `.env` — which would silently undo the consolidation and not surface until the next 29-day rotation.

## The consumer class I missed

The toolkit never hit this because it parses the file directly. The gap is everything **outside** the toolkit:

- ad-hoc scripts an agent writes to test access
- **course-local `tools/*.py`** — `itm327-master` has a whole directory of them, reading `os.environ` after loading `.env`

Those worked before consolidation and silently stopped after. When I designed the migration I assumed all Canvas access goes through toolkit tools. It doesn't.

## Fix

**Write the file with `export`.** Sourcing works, and python-dotenv parses the prefix unchanged — verified both ways — so one file serves the toolkit, the shell, and any script reading `os.environ`.

```
export CANVAS_API_TOKEN=…
```

**`cb_update --apply` adds the prefix to an existing config**, preserving comments and re-asserting `0600`. Idempotent, and a commented-out line is left alone.

**The pointer block gives agents the idiom** they kept failing to find:

```python
import sys; sys.path.insert(0, "canvas-toolbox/lib/tools")
from _env_loader import load_env; load_env()   # env → .env → ~/.canvas/config
```

It also states plainly that `env | grep CANVAS` showing only `CANVAS_BASE_URL`/`CANVAS_COURSE_ID` is **normal** — the token isn't exported into a session and its absence there proves nothing. Both agents read exactly that output as evidence of misconfiguration and went hunting.

## Verification

End-to-end on the real file:

```
source ~/.canvas/config → child process sees token (len 70) → Canvas HTTP 200
```

1213 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main`.

## Note

This is the third follow-up where the *code* was correct and the failure was that something outside the toolkit couldn't discover it. Consolidating a credential into a new location isn't done when the loader works — it's done when the shell, ad-hoc scripts, course-local tools, and the agent reading the repo's instructions all know where it went.

🤖 Generated with [Claude Code](https://claude.com/claude-code)