### PR TITLE
feat(canvas_sync): --rebind and --migrate-from for semester migration (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,24 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.21.0] — 2026-08-14
+
+**Semester migration: `--rebind` and `--migrate-from` (#294).**
+
+`canvas_id` is course-specific, so pull from course A and push to course B and every write becomes `PUT /courses/B/assignments/<A's id>` → *"The specified resource does not exist."* Four courses hit this in one week — 52, 131, 44 and 71 items — and it recurs three times a year plus on every master→section promotion.
+
+- **`canvas_sync.py --rebind NEW_COURSE_ID`** matches local sync state against the target course and re-points every id. Pages match on `page_url` (a real slug); assignments, quizzes and discussions match on title — exact first, then case/whitespace-normalized. Rewrites both places the id lives: `.canvas/index.json` **and** the markdown frontmatter. Dry-run by default.
+- **`canvas_sync.py --migrate-from OLD --to NEW --apply`** has Canvas copy the course (`course_copy_importer`), polls to completion, then rebinds. For the empty-course case, which is the normal one each semester.
+- **Ambiguous matches are refused, never guessed.** A duplicate title on either side stops that item and reports it. A wrong remap silently aims every future push — and any grade sync — at the wrong assignment, and nothing surfaces until someone spots marks on the wrong item. Unmatched and unidentifiable items are reported too; nothing is dropped silently.
+- **Stale `module_item_id` / `module_canvas_id` are cleared** on rebound entries rather than carried over. They belong to the old course, and a stale id is worse than an absent one because it looks valid.
+- **The course guard checks the TARGET**, not `CANVAS_COURSE_ID` — guarding the env var would verify the course you're migrating *away from*. `--migrate-from --apply` is guarded as a **write** (it creates content); `--rebind` as a read.
+
+**Why Canvas does the copying.** Stripping the ids and letting push create fresh was tried in the field and failed 44/44 with *"no canvas_id in index"* — every writer in `canvas_sync` is update-only, and there is no create path. Nor should there be: New Quizzes can't be created or edited through the classic API at all (`canvas_sync` already refuses them with *"Canvas-only: must be edited in Canvas UI"*), and a hand-rolled create path would silently drop them along with rubrics, question banks and file attachments. Both field workarounds — `create_content_migration()` and `.imscc` export/import — independently converged on Canvas's own copy. So Canvas creates the content; the toolkit re-points local state at it.
+
+*Verified against the live DS 460 migration: guard flagged the target correctly, 5 pages matched by slug, and it reported exactly the 52 unmatched assignments named in the issue.*
+
+---
+
 ## [1.20.4] — 2026-08-07
 
 **`~/.canvas/config` is now `source`-able, and ad-hoc scripts are told how to load it (#288 follow-up).**

--- a/lib/tests/test_course_rebind.py
+++ b/lib/tests/test_course_rebind.py
@@ -1,0 +1,158 @@
+"""Unit tests — course rebinding (#294).
+
+The dangerous failure here is not "didn't match" — it's "matched the WRONG thing".
+A bad remap silently aims every future push, and any grade sync, at a different
+assignment, and nothing surfaces until someone spots marks on the wrong item. So the
+refusal cases carry as much weight as the success cases.
+"""
+import sys
+from pathlib import Path
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from _course_rebind import (  # noqa: E402
+    apply_rebind,
+    index_target,
+    normalize_title,
+    plan_rebind,
+    summarize,
+)
+
+
+def _target(*items):
+    return index_target(list(items))
+
+
+def A(title, cid):          # assignment in the target course
+    return {"type": "Assignment", "title": title, "canvas_id": cid}
+
+
+def P(slug, cid, title="P"):  # page in the target course
+    return {"type": "Page", "title": title, "page_url": slug, "canvas_id": cid}
+
+
+# --- matching ---------------------------------------------------------------
+
+def test_assignments_match_on_exact_title():
+    tgt = _target(A("Week 1 Lab", 900), A("Week 2 Lab", 901))
+    local = {"a1.json": {"type": "Assignment", "title": "Week 1 Lab", "canvas_id": 11}}
+    plan = plan_rebind(local, tgt)
+    assert plan["matched"] == {"a1.json": (11, 900, "title")}
+
+
+def test_case_and_whitespace_differences_still_match():
+    """A Canvas copy can normalize whitespace; that shouldn't strand an item."""
+    tgt = _target(A("Week 1  Lab", 900))
+    local = {"a1.json": {"type": "Assignment", "title": "week 1 lab", "canvas_id": 11}}
+    assert plan_rebind(local, tgt)["matched"]["a1.json"][2] == "normalized"
+
+
+def test_pages_match_on_slug_not_title():
+    """Pages are addressed by URL slug in Canvas — a real identity, unlike a title."""
+    tgt = _target(P("syllabus", 700, title="Course Syllabus"))
+    local = {"p.html": {"type": "Page", "title": "RENAMED", "page_url": "syllabus",
+                        "canvas_id": 5}}
+    assert plan_rebind(local, tgt)["matched"]["p.html"] == (5, 700, "slug")
+
+
+def test_punctuation_is_not_normalized_away():
+    """"Quiz 1" and "Quiz 1 (Retake)" are different assessments. Over-eager
+    normalization here would silently merge them."""
+    assert normalize_title("Quiz 1") != normalize_title("Quiz 1 (Retake)")
+    tgt = _target(A("Quiz 1 (Retake)", 900))
+    local = {"q.json": {"type": "Assignment", "title": "Quiz 1", "canvas_id": 11}}
+    plan = plan_rebind(local, tgt)
+    assert plan["matched"] == {} and plan["unmatched"] == ["q.json"]
+
+
+def test_type_is_part_of_the_key():
+    """An Assignment and a Quiz can share a title and are not the same object."""
+    tgt = _target({"type": "Quiz", "title": "Midterm", "canvas_id": 800})
+    local = {"a.json": {"type": "Assignment", "title": "Midterm", "canvas_id": 11}}
+    assert plan_rebind(local, tgt)["unmatched"] == ["a.json"]
+
+
+# --- refusals (the ones that matter most) -----------------------------------
+
+def test_duplicate_title_in_TARGET_is_refused():
+    """Two assignments named the same in the new course: there is no way to tell
+    which one this local file is. Guessing sends grades to the wrong item."""
+    tgt = _target(A("Lab", 900), A("Lab", 901))
+    local = {"a.json": {"type": "Assignment", "title": "Lab", "canvas_id": 11}}
+    plan = plan_rebind(local, tgt)
+    assert plan["ambiguous"] == ["a.json"] and plan["matched"] == {}
+
+
+def test_duplicate_title_LOCALLY_is_refused():
+    """Two local files with the same title can't both take the one target id — and
+    picking either is a coin flip."""
+    tgt = _target(A("Lab", 900))
+    local = {"a.json": {"type": "Assignment", "title": "Lab", "canvas_id": 11},
+             "b.json": {"type": "Assignment", "title": "LAB", "canvas_id": 12}}
+    plan = plan_rebind(local, tgt)
+    assert sorted(plan["ambiguous"]) == ["a.json", "b.json"]
+    assert plan["matched"] == {}
+
+
+def test_unmatched_items_are_reported_not_dropped():
+    """The empty-course case: nothing to match against yet. Every item must be
+    accounted for, because a silent drop looks like success."""
+    tgt = _target()
+    local = {f"a{i}.json": {"type": "Assignment", "title": f"T{i}", "canvas_id": i}
+             for i in range(5)}
+    plan = plan_rebind(local, tgt)
+    assert len(plan["unmatched"]) == 5 and plan["matched"] == {}
+    assert "copy the content there first" in summarize(plan)
+
+
+def test_entries_without_identity_are_skipped_not_guessed():
+    tgt = _target(A("Lab", 900))
+    local = {"x.json": {"type": "Assignment", "title": "", "canvas_id": 11},
+             "y.html": {"type": "Page", "canvas_id": 12}}
+    plan = plan_rebind(local, tgt)
+    assert sorted(plan["skipped"]) == ["x.json", "y.html"]
+
+
+# --- applying ---------------------------------------------------------------
+
+def test_apply_repoints_ids_and_course_and_clears_stale_module_ids():
+    """Stale module ids belong to the OLD course. Carrying them over is worse than
+    dropping them, because a wrong id looks valid."""
+    index = {"course_id": "407908", "files": {
+        "a.json": {"type": "Assignment", "title": "Lab", "canvas_id": 11,
+                   "module_item_id": 555, "module_canvas_id": 777, "hash": "abc"}}}
+    plan = plan_rebind(index["files"], _target(A("Lab", 900)))
+    out = apply_rebind(index, plan, "422850")
+    e = out["files"]["a.json"]
+    assert out["course_id"] == "422850"
+    assert e["canvas_id"] == 900
+    assert "module_item_id" not in e and "module_canvas_id" not in e
+    assert e["hash"] == "abc"                       # unrelated fields preserved
+
+
+def test_apply_does_not_mutate_the_input_index():
+    index = {"course_id": "1", "files": {
+        "a.json": {"type": "Assignment", "title": "Lab", "canvas_id": 11}}}
+    plan = plan_rebind(index["files"], _target(A("Lab", 900)))
+    apply_rebind(index, plan, "2")
+    assert index["course_id"] == "1"
+    assert index["files"]["a.json"]["canvas_id"] == 11
+
+
+def test_apply_leaves_unmatched_and_ambiguous_entries_untouched():
+    index = {"course_id": "1", "files": {
+        "ok.json":   {"type": "Assignment", "title": "Lab", "canvas_id": 11},
+        "miss.json": {"type": "Assignment", "title": "Gone", "canvas_id": 12}}}
+    plan = plan_rebind(index["files"], _target(A("Lab", 900)))
+    out = apply_rebind(index, plan, "2")
+    assert out["files"]["ok.json"]["canvas_id"] == 900
+    assert out["files"]["miss.json"]["canvas_id"] == 12   # untouched, still stale
+
+
+def test_summary_calls_out_ambiguity_loudly():
+    tgt = _target(A("Lab", 900), A("Lab", 901))
+    local = {"a.json": {"type": "Assignment", "title": "Lab", "canvas_id": 11}}
+    s = summarize(plan_rebind(local, tgt))
+    assert "AMBIGUOUS" in s and "refused rather than guessed" in s

--- a/lib/tools/_course_rebind.py
+++ b/lib/tools/_course_rebind.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Course rebinding — re-point local sync state at a DIFFERENT Canvas course (#294).
+
+WHY THIS EXISTS
+  `.canvas/index.json` and the markdown frontmatter carry `canvas_id` values that are
+  COURSE-SPECIFIC. Pull from course A, then push to course B, and every write is
+  `PUT /courses/B/assignments/<A's id>` → "The specified resource does not exist."
+  Four courses hit this in one week migrating Spring→Fall (52, 131, 44 and 71 items),
+  and it recurs 3x/year plus on every master→section promotion.
+
+WHY STRIPPING THE IDS DOESN'T WORK
+  The obvious fix — delete the ids and let push create fresh — was tried in the field
+  and failed 44/44 with "no canvas_id in index". Every writer in canvas_sync
+  (`_push_assignment`, `_push_quiz`, `_push_discussion`) is UPDATE-ONLY: it requires an
+  existing id and issues a PUT. There is no create path.
+
+  Nor should there be. New Quizzes (quizzes.next) cannot be created or edited through
+  the classic API at all — the field report shows canvas_sync already refusing them
+  with "Canvas-only: must be edited in Canvas UI". Any hand-rolled create path would
+  silently drop them, along with rubrics, question banks and file attachments.
+
+  Canvas's OWN copy (content migration / .imscc import) carries all of it. Both field
+  workarounds independently converged on it. So the division of labour is:
+
+      Canvas creates the content.   This module re-points local state at it.
+
+WHAT MATCHING IS ALLOWED TO DO
+  A wrong match is worse than no match: it silently aims every future push — and any
+  grade sync — at the wrong item, and nothing surfaces until someone notices marks on
+  the wrong assignment. So:
+
+    - Pages match on `page_url` (a real slug, stable across copies).
+    - Everything else matches on TITLE: exact first, then case/whitespace-normalized.
+    - Anything ambiguous on EITHER side is refused and reported, never guessed.
+    - Unmatched items are reported and left untouched, never silently dropped.
+
+  Nothing here writes. `plan_rebind()` is pure; the caller decides whether to apply.
+"""
+from __future__ import annotations
+
+import re
+
+# Types whose identity is a slug rather than a title.
+_SLUG_TYPES = {"Page"}
+
+_WS = re.compile(r"\s+")
+
+
+def normalize_title(title: str) -> str:
+    """Case- and whitespace-insensitive key. Deliberately conservative — it does NOT
+    strip punctuation, because "Quiz 1" and "Quiz 1 (Retake)" must stay distinct."""
+    return _WS.sub(" ", (title or "").strip()).casefold()
+
+
+def _dupes(keys: list[str]) -> set[str]:
+    seen, dupe = set(), set()
+    for k in keys:
+        (dupe if k in seen else seen).add(k)
+    return dupe
+
+
+def index_target(items: list[dict]) -> dict:
+    """Build lookup tables from a target-course inventory.
+
+    `items` are dicts with at least: type, canvas_id, title, and page_url for Pages.
+    Returns {"by_slug", "by_title", "by_norm", "ambiguous"} where `ambiguous` holds
+    normalized titles that appear more than once IN THE TARGET — those can never be
+    matched safely, whatever the local side looks like."""
+    by_slug, by_title, by_norm = {}, {}, {}
+    norm_keys = []
+    for it in items:
+        t, cid = it.get("type"), it.get("canvas_id")
+        if not cid:
+            continue
+        if t in _SLUG_TYPES and it.get("page_url"):
+            by_slug[(t, it["page_url"])] = cid
+            continue
+        title = it.get("title") or ""
+        if not title:
+            continue
+        by_title[(t, title)] = cid
+        n = normalize_title(title)
+        norm_keys.append((t, n))
+        by_norm[(t, n)] = cid
+    ambiguous = {k for k in _dupes([f"{t}\x00{n}" for t, n in norm_keys])}
+    return {"by_slug": by_slug, "by_title": by_title, "by_norm": by_norm,
+            "ambiguous": ambiguous}
+
+
+def plan_rebind(local_files: dict, target: dict) -> dict:
+    """Work out the new canvas_id for each local entry. PURE — writes nothing.
+
+    `local_files` is `.canvas/index.json["files"]`: path -> entry.
+
+    Returns {"matched": {path: (old_id, new_id, how)}, "unmatched": [...],
+             "ambiguous": [...], "skipped": [...]}.
+
+      matched    — safe to re-point. `how` is "slug" | "title" | "normalized".
+      unmatched  — exists locally, not found in the target. Left alone; the content
+                   must be copied into the target first.
+      ambiguous  — the title is duplicated on one side or the other. REFUSED, because
+                   guessing here aims future pushes at the wrong item.
+      skipped    — no usable identity (no title and no slug) — nothing to match on."""
+    matched, unmatched, ambiguous, skipped = {}, [], [], []
+    local_norm = [f"{e.get('type')}\x00{normalize_title(e.get('title') or '')}"
+                  for e in local_files.values()
+                  if e.get("type") not in _SLUG_TYPES and e.get("title")]
+    local_dupes = _dupes(local_norm)
+
+    for path, entry in local_files.items():
+        typ = entry.get("type")
+        old = entry.get("canvas_id")
+
+        if typ in _SLUG_TYPES:
+            slug = entry.get("page_url")
+            if not slug:
+                skipped.append(path)
+                continue
+            new = target["by_slug"].get((typ, slug))
+            if new:
+                matched[path] = (old, new, "slug")
+            else:
+                unmatched.append(path)
+            continue
+
+        title = entry.get("title") or ""
+        if not title:
+            skipped.append(path)
+            continue
+        key = f"{typ}\x00{normalize_title(title)}"
+        if key in target["ambiguous"] or key in local_dupes:
+            ambiguous.append(path)
+            continue
+        new = target["by_title"].get((typ, title))
+        how = "title"
+        if not new:
+            new = target["by_norm"].get((typ, normalize_title(title)))
+            how = "normalized"
+        if new:
+            matched[path] = (old, new, how)
+        else:
+            unmatched.append(path)
+
+    return {"matched": matched, "unmatched": unmatched,
+            "ambiguous": ambiguous, "skipped": skipped}
+
+
+def apply_rebind(index: dict, plan: dict, new_course_id: str) -> dict:
+    """Return a NEW index with matched entries re-pointed. Does not mutate the input
+    and does not touch the filesystem.
+
+    Stale `module_item_id` / `module_canvas_id` are CLEARED on every rebound entry
+    rather than carried over: they belong to the old course, and a stale value is
+    worse than an absent one because it looks valid."""
+    import copy
+    out = copy.deepcopy(index)
+    out["course_id"] = str(new_course_id)
+    for path, (_old, new, _how) in plan["matched"].items():
+        entry = out["files"].get(path)
+        if entry is None:
+            continue
+        entry["canvas_id"] = new
+        entry.pop("module_item_id", None)
+        entry.pop("module_canvas_id", None)
+    return out
+
+
+def summarize(plan: dict) -> str:
+    """One-line-per-bucket summary. Never prints a canvas_id — the counts are what an
+    operator acts on, and the detail lives in the index."""
+    m = plan["matched"]
+    by_how = {}
+    for _old, _new, how in m.values():
+        by_how[how] = by_how.get(how, 0) + 1
+    bits = ", ".join(f"{n} by {how}" for how, n in sorted(by_how.items()))
+    lines = [f"  matched   : {len(m)}" + (f"  ({bits})" if bits else "")]
+    if plan["ambiguous"]:
+        lines.append(f"  AMBIGUOUS : {len(plan['ambiguous'])}  — duplicate titles; "
+                     f"refused rather than guessed")
+    if plan["unmatched"]:
+        lines.append(f"  unmatched : {len(plan['unmatched'])}  — not in the target "
+                     f"course; copy the content there first")
+    if plan["skipped"]:
+        lines.append(f"  skipped   : {len(plan['skipped'])}  — no title or slug to "
+                     f"match on")
+    return "\n".join(lines)

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -48,10 +48,14 @@ import json
 import os
 import re
 import sys
+import time
 from pathlib import Path
 from typing import Optional
 
 import requests
+
+from _course_rebind import (apply_rebind, index_target, plan_rebind,
+                             summarize)
 
 from __toolbox_version__ import __version__
 from canvas_course_guard import enforce as _course_guard
@@ -1263,6 +1267,145 @@ def _cleanup_stale_files(course_dir: Path, tracked_paths: set, meta_paths: set) 
     return deleted
 
 
+def _fetch_course_inventory(course_id: str) -> list[dict]:
+    """Everything in `course_id` that local sync state can point at (#294).
+
+    Normalized to the shape `_course_rebind` expects: type/title/canvas_id, plus
+    page_url for Pages. New Quizzes surface through the assignments endpoint with a
+    quiz_lti flag — they're included so a rebind can re-point them even though
+    canvas_sync can't EDIT them (they're Canvas-UI-only)."""
+    out: list[dict] = []
+    for a in _get(f"/courses/{course_id}/assignments", {"per_page": 100}) or []:
+        out.append({"type": "Assignment", "title": a.get("name"),
+                    "canvas_id": a.get("id")})
+    for q in _get(f"/courses/{course_id}/quizzes", {"per_page": 100}) or []:
+        out.append({"type": "Quiz", "title": q.get("title"), "canvas_id": q.get("id")})
+    for p in _get(f"/courses/{course_id}/pages", {"per_page": 100}) or []:
+        out.append({"type": "Page", "title": p.get("title"),
+                    "page_url": p.get("url"), "canvas_id": p.get("page_id")})
+    for d in _get(f"/courses/{course_id}/discussion_topics", {"per_page": 100}) or []:
+        out.append({"type": "Discussion", "title": d.get("title"),
+                    "canvas_id": d.get("id")})
+    return out
+
+
+def _rewrite_frontmatter_ids(index: dict, plan: dict, quiet: bool = False) -> int:
+    """Update the `canvas_id:` line in each rebound markdown file.
+
+    The id lives in TWO places — the index and the frontmatter — and leaving the
+    frontmatter stale would make the next pull/build disagree with the index."""
+    n = 0
+    for path, (_old, new, _how) in plan["matched"].items():
+        md = (index["files"].get(path) or {}).get("markdown_path")
+        if not md:
+            continue
+        p = Path(md)
+        if not p.is_file():
+            continue
+        text = p.read_text(encoding="utf-8")
+        new_text, subs = re.subn(r"(?m)^canvas_id:\s*\d+\s*$", f"canvas_id: {new}", text)
+        if subs:
+            p.write_text(new_text, encoding="utf-8")
+            n += 1
+    if not quiet and n:
+        print(f"  updated canvas_id in {n} markdown file(s)")
+    return n
+
+
+def cmd_rebind(new_course_id: str, apply: bool = False) -> int:
+    """Re-point local sync state at a different Canvas course (#294).
+
+    Requires the content to ALREADY EXIST in the target — this matches and remaps, it
+    does not create. For an empty target, run `--migrate-from` instead, which has
+    Canvas copy the content first."""
+    index = _load_index()
+    files = index.get("files") or {}
+    if not files:
+        print("No .canvas/index.json — run --pull against the source course first.")
+        return 2
+    old_course = index.get("course_id", "?")
+    print(f"Rebind: course {old_course} → {new_course_id}"
+          f"  ({'APPLYING' if apply else 'DRY RUN — pass --apply to write'})")
+
+    inventory = _fetch_course_inventory(new_course_id)
+    if not inventory:
+        print(f"  Target course {new_course_id} returned NO content.")
+        print("  If it's a new empty course, use:  --migrate-from "
+              f"{old_course} --to {new_course_id}")
+        return 2
+    print(f"  target course holds {len(inventory)} item(s)")
+
+    plan = plan_rebind(files, index_target(inventory))
+    print(summarize(plan))
+    for bucket, label in (("ambiguous", "AMBIGUOUS"), ("unmatched", "unmatched")):
+        for p in plan[bucket][:10]:
+            print(f"    {label}: {p}")
+        if len(plan[bucket]) > 10:
+            print(f"    … and {len(plan[bucket]) - 10} more")
+
+    if not apply:
+        print("\nRe-run with --apply to write the new ids.")
+        return 0
+    if not plan["matched"]:
+        print("\nNothing matched — refusing to rewrite the index.")
+        return 2
+    _save_index(apply_rebind(index, plan, new_course_id))
+    _rewrite_frontmatter_ids(index, plan)
+    print(f"\n✓ rebound {len(plan['matched'])} item(s) to course {new_course_id}.")
+    if plan["unmatched"] or plan["ambiguous"]:
+        print("  Items listed above were NOT rebound and will still fail to push.")
+    return 0
+
+
+def cmd_migrate_from(source_course_id: str, new_course_id: str,
+                     apply: bool = False, timeout_s: int = 900) -> int:
+    """Copy a course via Canvas, then rebind local state to the copy (#294).
+
+    Canvas's own content migration does the creating. That is deliberate: New Quizzes
+    cannot be created through the classic API at all, and a hand-rolled create path
+    would also drop rubrics, question banks and file attachments. Both field
+    workarounds — `create_content_migration()` and .imscc export/import — are this
+    same mechanism, done by hand."""
+    if not apply:
+        print(f"DRY RUN — would copy course {source_course_id} → {new_course_id} "
+              f"via Canvas content migration, then rebind local state to it.")
+        print("  Canvas creates the content (including New Quizzes); the rebind "
+              "re-points local ids at it.")
+        print("  Re-run with --apply to start the copy.")
+        return 0
+
+    print(f"Starting Canvas content migration {source_course_id} → {new_course_id} …")
+    res = _post(f"/courses/{new_course_id}/content_migrations", {
+        "migration_type": "course_copy_importer",
+        "settings": {"source_course_id": str(source_course_id)},
+    })
+    mig_id = (res or {}).get("id")
+    if not mig_id:
+        print(f"  ERROR: could not start migration: {str(res)[:300]}")
+        return 2
+
+    waited = 0
+    while waited < timeout_s:
+        time.sleep(5)
+        waited += 5
+        st = _get(f"/courses/{new_course_id}/content_migrations/{mig_id}") or {}
+        state = st.get("workflow_state", "?")
+        if state in ("completed", "failed"):
+            print(f"  migration {state} after {waited}s")
+            if state == "failed":
+                print(f"  {str(st.get('migration_issues_url') or st)[:200]}")
+                return 2
+            break
+        print(f"  … {state} ({waited}s)")
+    else:
+        print(f"  TIMED OUT after {timeout_s}s. The copy may still finish — re-run "
+              f"`--rebind {new_course_id}` once Canvas reports it complete.")
+        return 2
+
+    print("\nCopy complete. Rebinding local state to the new course …")
+    return cmd_rebind(new_course_id, apply=True)
+
+
 def _push_summary(pushed_course_level: list) -> str:
     """The line cmd_push prints when no index["files"] entry needed pushing.
 
@@ -2088,6 +2231,18 @@ Change log:  .canvas/push_log.md  (appended on every --push and --pull <path>)
     parser.add_argument("--pull", nargs="?", const="", metavar="PATH",
                         help="Full course pull (no path) or re-pull one file from Canvas (with path)")
     parser.add_argument("--build", action="store_true", help="Convert course_src/*.md to course/*.html")
+    parser.add_argument("--rebind", metavar="NEW_COURSE_ID",
+                        help="Re-point local sync state at a DIFFERENT course by "
+                             "matching titles/slugs (#294). The content must already "
+                             "exist there — for an empty course use --migrate-from.")
+    parser.add_argument("--migrate-from", metavar="OLD_COURSE_ID",
+                        help="Have Canvas copy OLD_COURSE_ID into --to, then rebind "
+                             "local state to the copy. Use for an EMPTY new course.")
+    parser.add_argument("--to", metavar="NEW_COURSE_ID",
+                        help="Target course id for --migrate-from")
+    parser.add_argument("--apply", action="store_true",
+                        help="Write changes for --rebind / --migrate-from "
+                             "(both are dry-run by default)")
     parser.add_argument("--upload", metavar="PATH", help="Upload a local file or folder to Canvas Files")
     parser.add_argument("--folder", default="course_assets", metavar="FOLDER",
                         help="Canvas folder to upload into (default: course_assets)")
@@ -2113,6 +2268,22 @@ Change log:  .canvas/push_log.md  (appended on every --push and --pull <path>)
 
     if args.quiet:
         globals()["QUIET"] = True
+
+    # Migration paths target a DIFFERENT course than CANVAS_COURSE_ID, so the guard
+    # (#27) has to check the TARGET — guarding the env var would verify the course we
+    # are migrating away from. --migrate-from CREATES content in the target, which is
+    # the largest write this tool makes; --rebind only reads it (its writes are local).
+    if args.migrate_from and not args.to:
+        print("ERROR: --migrate-from requires --to NEW_COURSE_ID", file=sys.stderr)
+        sys.exit(2)
+    _mig_target = args.to if args.migrate_from else args.rebind
+    if _mig_target:
+        _course_guard(CANVAS_BASE_URL, _headers(), _mig_target,
+                      "write" if (args.migrate_from and args.apply) else "read",
+                      allow_override=args.allow_enrolled, label="target course")
+        sys.exit(cmd_migrate_from(args.migrate_from, args.to, apply=args.apply)
+                 if args.migrate_from
+                 else cmd_rebind(args.rebind, apply=args.apply))
 
     # Startup safety guard (#27) — never block --build (local-only, no Canvas call).
     if not args.build:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.20.4"
+version = "1.21.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.20.4"
+version = "1.21.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #294. Four courses in the thread, 52 / 131 / 44 / 71 items, recurring 3×/year plus every master→section promotion.

## One premise in the issue had to change

Option A proposed stripping the ids so push would "create fresh". **ITM 327 already tried that** — `44/44 failed: "no canvas_id in index"`. Every writer in `canvas_sync` (`_push_assignment`, `_push_quiz`, `_push_discussion`) is **update-only**: it requires an existing id and issues a `PUT`. There is no create path.

Nor should one be added. The same comment reports `NewQuizzes: "Canvas-only: must be edited in Canvas UI"` — quizzes.next can't be created or edited through the classic API at all, so a hand-rolled create path would silently drop them, along with rubrics, question banks and file attachments.

Both successful field workarounds — MATH 119's `create_content_migration()` and ITM 327's `.imscc` export/import — are the same Canvas mechanism underneath. So the division of labour is: **Canvas creates the content; the toolkit re-points local state at it.**

## What shipped

**`--rebind NEW_COURSE_ID`** — matches local sync state against the target and remaps every id.

- Pages match on `page_url`, a real slug. (Worth noting: `_push_page` already addresses by slug, so pages were never broken — the failure was always assignments/quizzes/discussions.)
- Everything else matches on title: exact first, then case/whitespace-normalized.
- Rewrites **both** places the id lives — `.canvas/index.json` and the markdown frontmatter. Leaving the frontmatter stale would make the next pull disagree with the index.
- Dry-run by default.

**`--migrate-from OLD --to NEW --apply`** — starts `course_copy_importer`, polls to completion, then rebinds. This is the empty-course case, which per the maintainer is the normal one every semester.

## Refusals, which matter more than matches here

A wrong remap silently aims every future push — and any grade sync — at a different assignment, and nothing surfaces until someone notices marks on the wrong item. So:

- **Duplicate title on either side → refused and reported**, never guessed.
- Normalization is deliberately conservative: it does **not** strip punctuation, so `Quiz 1` and `Quiz 1 (Retake)` stay distinct.
- Type is part of the key — an Assignment and a Quiz sharing a title aren't the same object.
- Unmatched and unidentifiable items are reported, never silently dropped.
- Stale `module_item_id` / `module_canvas_id` are **cleared** on rebound entries. They belong to the old course, and a stale id is worse than an absent one because it looks valid.

## Guard

The course guard now checks the **target**, not `CANVAS_COURSE_ID` — guarding the env var would have verified the course you're migrating *away from*. `--migrate-from --apply` guards as a **write**, since it creates content; `--rebind` as a read.

## Verification

13 unit tests on the matching engine, weighted toward the refusal cases. Plus a live dry run against the actual DS 460 migration:

```
⚠️  canvas_course_guard: target course 422850 ('Big Data Programming') flagged as enrolled — 24 enrolled students.
    Read-only operation — proceeding with advisory.
Rebind: course 407908 → 422850  (DRY RUN — pass --apply to write)
  target course holds 28 item(s)
  matched   : 5  (5 by slug)
  unmatched : 52  — not in the target course; copy the content there first
```

The guard flagged the right course, the 5 matches are pages-by-slug exactly as predicted, and it independently arrived at **52 unmatched** — the same number the issue reports as failing.

1226 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main`.

## Not in this PR

The issue's five "related" items. Two are cheap and worth doing next — the `syllabus_body is None` TypeError on empty-course pull (which a semester migration hits immediately) and the missing markdown dependency on `--build`. The other three (date shifting, `--template`, `--validate-master`) are their own features. Happy to file them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)