### PR TITLE
fix(canvas_sync): empty-course pull crash, markdown dep message, stale-id hint (#294)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.21.1] — 2026-08-14
+
+**The three things a semester migration trips over on the way in (#294 related).**
+
+- **Pull no longer crashes on an empty course.** Canvas sends an explicit `null` for empty rich-text fields, and `.get(key, "")` only defaults when the key is **absent** — a present-but-null passes `None` straight through to `write_text()`. An empty course nulls `syllabus_body`, which is the first thing a semester migration pulls.
+
+  Fixed the whole class rather than the reported instance: the same shape appears in **15 places** across `description`, `message` and `body`, so an assignment with no description, a discussion with no message, or a blank homepage crashed identically. All now use `.get(key) or ""`.
+
+- **A missing `markdown` package now says what to do.** It's a declared dependency, so `ModuleNotFoundError` on `--build` means the vendored toolkit was never synced after a pull — but the bare traceback sends people hunting for a package instead of running `cd canvas-toolbox && uv sync`.
+
+- **A stale-id push failure now names the fix.** Canvas answers a cross-course `PUT` with *"The specified resource does not exist"*, which reads like the assignment was deleted rather than like the ids belong to a different course. Four courses lost time to that before anyone identified it. The error now points at `--rebind` / `--migrate-from` with the current course id filled in — printed **once per run**, since 52 failing assignments would otherwise bury it 52 times.
+
+---
+
 ## [1.21.0] — 2026-08-14
 
 **Semester migration: `--rebind` and `--migrate-from` (#294).**

--- a/lib/tests/test_course_rebind.py
+++ b/lib/tests/test_course_rebind.py
@@ -156,3 +156,47 @@ def test_summary_calls_out_ambiguity_loudly():
     local = {"a.json": {"type": "Assignment", "title": "Lab", "canvas_id": 11}}
     s = summarize(plan_rebind(local, tgt))
     assert "AMBIGUOUS" in s and "refused rather than guessed" in s
+
+
+# --- the small bugs a semester migration hits first (#294 related) -----------
+
+import canvas_sync as cs  # noqa: E402
+
+
+def test_canvas_null_bodies_do_not_crash_the_pull(tmp_path):
+    """Canvas sends an explicit null for empty rich-text fields, and `.get(k, "")`
+    only defaults when the key is ABSENT — a present-but-null passes None straight
+    through to write_text(). An EMPTY course nulls syllabus_body, which is the first
+    thing a semester migration pulls. The same shape hits description/message/body,
+    so an assignment with no description crashed identically."""
+    for payload, key in (({"syllabus_body": None}, "syllabus_body"),
+                         ({"description": None}, "description"),
+                         ({"message": None}, "message"),
+                         ({"body": None}, "body")):
+        assert (payload.get(key) or "") == ""          # the corrected idiom
+        assert payload.get(key, "") is None            # the broken one, for contrast
+
+
+def test_stale_id_error_names_the_fix(capsys):
+    """Canvas answers a cross-course PUT with "The specified resource does not
+    exist", which reads like the assignment was deleted rather than like the ids
+    belong to another course. Four courses lost time to that."""
+    cs._REBIND_HINTED = False
+    cs._hint_rebind("The specified resource does not exist.")
+    out = capsys.readouterr().out
+    assert "--rebind" in out and "--migrate-from" in out
+    assert "DIFFERENT course" in out
+
+
+def test_hint_prints_once_per_run(capsys):
+    """52 assignments failing means 52 identical hints, which buries it."""
+    cs._REBIND_HINTED = False
+    for _ in range(5):
+        cs._hint_rebind("The specified resource does not exist.")
+    assert capsys.readouterr().out.count("--rebind") == 1
+
+
+def test_hint_stays_quiet_for_unrelated_errors(capsys):
+    cs._REBIND_HINTED = False
+    cs._hint_rebind("unsupported grading_type 'bogus'")
+    assert capsys.readouterr().out == ""

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -412,7 +412,19 @@ def _html_to_md(html: str, title: str = "", canvas_id: int = 0, page_url: str = 
 
 def _md_to_html(md_text: str) -> str:
     """Convert markdown (with optional YAML frontmatter) to Canvas-ready HTML."""
-    import markdown as md_lib
+    try:
+        import markdown as md_lib
+    except ImportError:
+        # `markdown` IS a declared dependency, so this means the vendored toolkit's
+        # deps were never synced after a pull — a bare ModuleNotFoundError sends
+        # people hunting for a missing package instead of running one command.
+        raise SystemExit(
+            "ERROR: the `markdown` package isn't installed.\n"
+            "  It is a declared dependency, so this usually means the vendored\n"
+            "  toolkit hasn't been synced since its last update. Run:\n"
+            "      cd canvas-toolbox && uv sync\n"
+            "  and re-run --build."
+        ) from None
 
     # Strip YAML frontmatter block if present
     body = md_text
@@ -430,7 +442,7 @@ def _assignment_json_to_md(assignment: dict) -> str:
     import markdownify
 
     # Extract description HTML and convert to markdown
-    description_html = assignment.get("description", "")
+    description_html = assignment.get("description") or ""
     body_md = ""
     if description_html:
         soup = BeautifulSoup(description_html, "lxml")
@@ -467,7 +479,7 @@ def _quiz_json_to_md(quiz: dict) -> str:
     import markdownify
 
     # Extract description HTML and convert to markdown
-    description_html = quiz.get("description", "")
+    description_html = quiz.get("description") or ""
     body_md = ""
     if description_html:
         soup = BeautifulSoup(description_html, "lxml")
@@ -505,7 +517,7 @@ def _discussion_json_to_md(discussion: dict) -> str:
     import markdownify
 
     # Extract message HTML and convert to markdown
-    message_html = discussion.get("message", "")
+    message_html = discussion.get("message") or ""
     body_md = ""
     if message_html:
         soup = BeautifulSoup(message_html, "lxml")
@@ -538,7 +550,7 @@ def _pull_page(course_id: str, page_url: str) -> Optional[str]:
     data = _get(f"/courses/{course_id}/pages/{page_url}")
     if isinstance(data, list) or "body" not in data:
         return None
-    return data.get("body", "")
+    return data.get("body") or ""
 
 
 def _pull_assignment(course_id: str, assignment_id: int) -> Optional[dict]:
@@ -548,7 +560,7 @@ def _pull_assignment(course_id: str, assignment_id: int) -> Optional[dict]:
     return {
         "canvas_id": data.get("id"),
         "name": data.get("name"),
-        "description": data.get("description", ""),
+        "description": data.get("description") or "",
         "points_possible": data.get("points_possible"),
         "grading_type": data.get("grading_type"),
         "due_at": data.get("due_at"),
@@ -568,7 +580,7 @@ def _pull_discussion(course_id: str, topic_id: int) -> Optional[dict]:
     return {
         "canvas_id": data.get("id"),
         "title": data.get("title"),
-        "message": data.get("message", ""),
+        "message": data.get("message") or "",
         "todo_date": data.get("todo_date"),
         "published": data.get("published", False),
     }
@@ -582,7 +594,7 @@ def _pull_quiz(course_id: str, quiz_id: int) -> Optional[dict]:
         "canvas_id": data.get("id"),
         "assignment_id": data.get("assignment_id"),
         "title": data.get("title"),
-        "description": data.get("description", ""),
+        "description": data.get("description") or "",
         "points_possible": data.get("points_possible"),
         "quiz_type": data.get("quiz_type"),
         "time_limit": data.get("time_limit"),
@@ -697,7 +709,7 @@ def cmd_init():
     # Homepage (Canvas front_page — not a module item)
     homepage = _get(f"/courses/{course_id}/front_page")
     if homepage and not homepage.get("errors"):
-        homepage_body = homepage.get("body", "")
+        homepage_body = homepage.get("body") or ""
         homepage_url = homepage.get("url", "front-page")
         homepage_path = COURSE_DIR / "homepage.html"
         homepage_path.write_text(homepage_body, encoding="utf-8")
@@ -713,7 +725,7 @@ def cmd_init():
         _vprint(f"  [homepage] homepage.html ({len(homepage_body)} chars)")
 
     # Syllabus (Canvas left-sidebar Syllabus tab — not a module item)
-    syllabus_body = course.get("syllabus_body", "")
+    syllabus_body = course.get("syllabus_body") or ""
     syllabus_path = COURSE_DIR / "syllabus.html"
     syllabus_path.write_text(syllabus_body, encoding="utf-8")
     for fid in _extract_file_refs(syllabus_body):
@@ -834,7 +846,7 @@ def cmd_init():
                 data = _pull_assignment(course_id, content_id)
                 if data:
                     filepath.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
-                    for fid in _extract_file_refs(data.get("description", "")):
+                    for fid in _extract_file_refs(data.get("description") or ""):
                         referenced_by.setdefault(fid, []).append(str(filepath))
                     item_record["filename"] = filename
                     h = _file_hash(filepath)
@@ -889,7 +901,7 @@ def cmd_init():
                 data = _pull_discussion(course_id, content_id)
                 if data:
                     filepath.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
-                    for fid in _extract_file_refs(data.get("message", "")):
+                    for fid in _extract_file_refs(data.get("message") or ""):
                         referenced_by.setdefault(fid, []).append(str(filepath))
                     item_record["filename"] = filename
                     h = _file_hash(filepath)
@@ -926,7 +938,7 @@ def cmd_init():
                 data = _pull_quiz(course_id, content_id)
                 if data:
                     filepath.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
-                    for fid in _extract_file_refs(data.get("description", "")):
+                    for fid in _extract_file_refs(data.get("description") or ""):
                         referenced_by.setdefault(fid, []).append(str(filepath))
                     item_record["filename"] = filename
                     h = _file_hash(filepath)
@@ -1267,6 +1279,29 @@ def _cleanup_stale_files(course_dir: Path, tracked_paths: set, meta_paths: set) 
     return deleted
 
 
+_REBIND_HINTED = False
+
+
+def _hint_rebind(error_text: str) -> None:
+    """Name the fix when a push fails on an id from another course (#294).
+
+    "The specified resource does not exist" is Canvas's answer to
+    `PUT /courses/B/assignments/<A's id>`, and it reads like the assignment is gone
+    rather than like the ids belong to a different course. Four courses spent real
+    time on that. Printed ONCE per run — repeating it 52 times buries it."""
+    global _REBIND_HINTED
+    if _REBIND_HINTED or "does not exist" not in (error_text or "").lower():
+        return
+    _REBIND_HINTED = True
+    print("    ↳ this usually means the local canvas_ids belong to a DIFFERENT "
+          "course.")
+    print(f"      If you are migrating into {CANVAS_COURSE_ID}, run:")
+    print(f"          canvas_sync.py --rebind {CANVAS_COURSE_ID}          "
+          f"# content already there")
+    print(f"          canvas_sync.py --migrate-from <OLD_ID> --to {CANVAS_COURSE_ID} "
+          f"--apply   # empty course")
+
+
 def _fetch_course_inventory(course_id: str) -> list[dict]:
     """Everything in `course_id` that local sync state can point at (#294).
 
@@ -1529,7 +1564,7 @@ def _push_assignment(filepath: Path, meta: dict) -> bool:
     data = json.loads(filepath.read_text(encoding="utf-8"))
     payload: dict = {
         "name": data.get("name", ""),
-        "description": data.get("description", ""),
+        "description": data.get("description") or "",
         "points_possible": data.get("points_possible"),
         "published": data.get("published", True),
     }
@@ -1555,6 +1590,7 @@ def _push_assignment(filepath: Path, meta: dict) -> bool:
     })
     if result.get("error"):
         print(f"    ERROR: {result['error']}")
+        _hint_rebind(result["error"])
         return False
     return True
 
@@ -1566,7 +1602,7 @@ def _push_quiz(filepath: Path, meta: dict) -> bool:
         print(f"    ERROR: no canvas_id in index for {filepath}")
         return False
     data = json.loads(filepath.read_text(encoding="utf-8"))
-    payload: dict = {"description": data.get("description", "")}
+    payload: dict = {"description": data.get("description") or ""}
     if "title" in data:
         payload["title"] = data["title"]
     if "points_possible" in data:
@@ -1582,6 +1618,7 @@ def _push_quiz(filepath: Path, meta: dict) -> bool:
     })
     if result.get("error"):
         print(f"    ERROR: {result['error']}")
+        _hint_rebind(result["error"])
         return False
     # Dates must go to the linked assignment endpoint — quiz endpoint ignores due_at
     assignment_id = data.get("assignment_id")
@@ -1607,12 +1644,13 @@ def _push_discussion(filepath: Path, meta: dict) -> bool:
     data = json.loads(filepath.read_text(encoding="utf-8"))
     result = _put(f"/courses/{CANVAS_COURSE_ID}/discussion_topics/{canvas_id}", {
         "title": data.get("title", ""),
-        "message": data.get("message", ""),
+        "message": data.get("message") or "",
         "todo_date": data.get("todo_date"),
         "published": data.get("published", True),
     })
     if result.get("error"):
         print(f"    ERROR: {result['error']}")
+        _hint_rebind(result["error"])
         return False
     return True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.21.0"
+version = "1.21.1"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.21.0"
+version = "1.21.1"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Follow-up to #295 — the three items from #294's "related issues" list that a semester migration hits on the way in.

## Pull crashed on an empty course

```python
syllabus_body = course.get("syllabus_body", "")   # -> None
syllabus_path.write_text(syllabus_body)           # TypeError
```

Canvas sends an explicit `null` for empty rich-text fields, and `.get(key, "")` only defaults when the key is **absent** — a present-but-null value passes `None` straight through. An empty course nulls `syllabus_body`, which is the very first thing a semester migration pulls, so this blocks the workflow at step one.

**Fixed the class, not the instance.** The same shape appears in **15 places** across `description`, `message` and `body` — so an assignment with no description, a discussion with no message, or a blank homepage crashed identically and nobody had reported those yet. All now use `.get(key) or ""`.

## `--build` failed with a bare ModuleNotFoundError

`markdown` **is** a declared dependency, so hitting this means the vendored toolkit was never synced after a pull. The traceback sent people looking for a missing package rather than at the one command that fixes it. Now:

```
ERROR: the `markdown` package isn't installed.
  It is a declared dependency, so this usually means the vendored
  toolkit hasn't been synced since its last update. Run:
      cd canvas-toolbox && uv sync
```

## A stale-id failure now names the fix

Canvas answers a cross-course `PUT` with *"The specified resource does not exist"* — which reads like the assignment was **deleted**, not like the local ids belong to a different course. Four courses in #294 spent real time on that before anyone worked out the cause.

Now the failure points at the remedy, with the current course id filled in:

```
    ERROR: The specified resource does not exist.
    ↳ this usually means the local canvas_ids belong to a DIFFERENT course.
      If you are migrating into 422850, run:
          canvas_sync.py --rebind 422850                                    # content already there
          canvas_sync.py --migrate-from <OLD_ID> --to 422850 --apply        # empty course
```

**Printed once per run.** 52 failing assignments would otherwise repeat it 52 times and bury it — which is how the original error got scrolled past in the first place. Wired into all three update-only writers (`_push_assignment`, `_push_quiz`, `_push_discussion`), and silent for unrelated errors.

## Verification

4 new tests covering the null idiom, the hint's content, once-per-run suppression, and that it stays quiet for unrelated failures.

1230 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main`.

## Remaining from #294's list

Three left, all genuine features rather than papercuts: a date-shifting utility for semester remapping, `--template`, and `--validate-master`. Worth their own issues — the date shifter especially, since both DS 460 and MATH 119 hand-wrote one (`+147 days` with Thanksgiving adjustments in the MATH 119 case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)