### PR TITLE
fix(grade_guardian): a docstring is not a grade write (#297)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,25 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.21.2] — 2026-08-14
+
+**`grade_guardian` read a docstring as evidence of a grade write (#297).**
+
+A legitimate course-setup script — creating unpublished Classic Quiz mirrors, writing no grades or comments — was blocked. The trigger was a line of **prose in its own docstring**:
+
+> *"the missed-stand-up justification comes in as a Canvas submission COMMENT instead"*
+
+`_CANVAS_CTX` carried a `canvas.*submission` catch-all that matched any line containing both words. The script's documentation of what it deliberately does **not** do was read as evidence that it does, and the operator had to run it outside Claude Code — defeating the point of the hook.
+
+- **Comments and docstrings are stripped before a body is matched.** The run-catch reads source looking for grade-write *code*; prose isn't executable and can't be evidence. Real payload literals (`"posted_grade"`) are kept — only `#` comments and bare-expression docstrings go. Fails open on anything unparseable, so a syntax error or a non-Python file can never quietly disable the check.
+- **`canvas.*submission` is replaced** with `/assignments/<anything>/submissions`, which matches the endpoint whether the ids are literal or interpolated in an f-string — the case the catch-all actually existed for — without matching English.
+
+**Deliberately not implemented:** the issue's Option 1 (whitelist by script name) and Option 3 (marker comment). Both are bypass vectors — an agent routing around the guard would name its script accordingly or add the marker. That trades a false positive for a hole in the guard's entire purpose.
+
+*A near-miss worth recording:* the first implementation rebuilt the source from tokens, which re-joined `requests.put(` as `requests . put (` and stopped `_WRITE_VERB` matching — silently disabling the guard completely. All three bypass fixtures passed straight through. The fix blanks spans in place so offsets survive; a test now pins it.
+
+---
+
 ## [1.21.1] — 2026-08-14
 
 **The three things a semester migration trips over on the way in (#294 related).**

--- a/lib/tests/test_grade_guardian.py
+++ b/lib/tests/test_grade_guardian.py
@@ -584,3 +584,70 @@ def test_credential_reads_are_still_blocked(cmd, label):
     emits contents is denied — including plain `grep`, which was never in the
     raw-read set and so slipped through before this."""
     assert evaluate("Bash", {"command": cmd}) is not None, label
+
+
+# --- prose is not executable (#297) ------------------------------------------
+
+_SETUP_SCRIPT = '''\
+"""Create Classic Quiz mirrors of NewQuiz stand-ups (unpublished).
+
+- NO essay question — the missed-stand-up justification comes in as a Canvas
+  submission COMMENT instead, handled elsewhere.
+"""
+import requests
+def make_quiz(base, course, title):
+    return requests.post(f"{base}/api/v1/courses/{course}/quizzes",
+                         json={"quiz": {"title": title, "published": False}})
+'''
+
+_LYING_SCRIPT = '''\
+"""This script does NOT write grades. Honest."""
+import requests
+def push(b, cid, aid, uid, g):
+    requests.put(f"{b}/api/v1/courses/{cid}/assignments/{aid}/submissions/{uid}",
+                 json={"submission": {"posted_grade": g}})
+'''
+
+
+def test_a_docstring_describing_grades_is_not_a_grade_write(tmp_path):
+    """The reported false positive. A legitimate setup script was blocked because
+    its docstring said the justification "comes in as a Canvas submission COMMENT
+    instead" — documentation of what it deliberately does NOT do, read as evidence
+    that it does. No code in it touches a submission."""
+    s = tmp_path / "mirror_standups_classic.py"
+    s.write_text(_SETUP_SCRIPT, encoding="utf-8")
+    assert evaluate("Bash", {"command": f"python3 {s}"}) is None
+
+
+def test_a_reassuring_docstring_does_not_launder_a_real_grade_write(tmp_path):
+    """The other direction: stripping prose must not let a script talk its way out.
+    What matters is the code, and this one writes a grade."""
+    s = tmp_path / "innocent.py"
+    s.write_text(_LYING_SCRIPT, encoding="utf-8")
+    assert evaluate("Bash", {"command": f"python3 {s}"}) is not None
+
+
+def test_code_only_preserves_offsets_so_write_verbs_still_match():
+    """The regression this nearly shipped with: rebuilding the source from tokens
+    re-joins them with whitespace, turning `requests.put(` into `requests . put (`
+    so _WRITE_VERB stops matching — silently disabling the guard entirely. Blank
+    the spans in place instead."""
+    from grade_guardian import _WRITE_VERB, _code_only
+    stripped = _code_only(_LYING_SCRIPT)
+    assert "requests.put" in stripped and _WRITE_VERB.search(stripped)
+    assert "Honest" not in stripped              # the docstring IS gone
+
+
+def test_code_only_fails_open_on_unparseable_input():
+    """A guardrail must never be disabled by a syntax error or a non-Python file."""
+    from grade_guardian import _code_only
+    broken = 'def f(:\n  requests.put("/assignments/1/submissions/2")\n'
+    assert "requests.put" in _code_only(broken)
+    assert _code_only("not python at all {{{") == "not python at all {{{"
+
+
+def test_payload_strings_are_kept_not_stripped():
+    """Only comments and BARE docstrings go. A real payload literal is evidence."""
+    from grade_guardian import _code_only
+    src = 'import requests\nd = {"submission": {"posted_grade": "95"}}\n'
+    assert "posted_grade" in _code_only(src)

--- a/lib/tools/grade_guardian.py
+++ b/lib/tools/grade_guardian.py
@@ -71,15 +71,75 @@ _WRITE_VERB = re.compile(
 )
 
 # Canvas grade-write context: the submissions endpoint or a grade/comment payload.
+#
+# `/assignments/<anything>/submissions` rather than `/assignments/\d+/submissions`
+# because real code builds the path with an f-string — `/assignments/{aid}/submissions`
+# has no literal digits and the anchored form misses it entirely.
+#
+# There used to be a `canvas.*submission` catch-all here. It matched any line
+# containing both words, including PROSE: a legitimate setup script was blocked
+# because its docstring said "the justification comes in as a Canvas submission
+# COMMENT instead" — documentation of what the script deliberately does NOT do,
+# read as evidence that it does (#297). The endpoint pattern below covers the real
+# cases it was there for, without matching English.
 _CANVAS_CTX = re.compile(
     r"/api/v1/courses/\d+/assignments/\d+/submissions"
+    r"|/assignments/[^/\s\"']+/submissions"
     r"|/submissions/\d+"
     r"|posted_grade"
     r"|submission\[submission\]"
-    r"|comment\[text_comment\]"
-    r"|canvas.*submission",
+    r"|comment\[text_comment\]",
     re.IGNORECASE,
 )
+
+
+def _code_only(body: str) -> str:
+    """Strip comments and docstrings from a Python source body (#297).
+
+    The run-catch reads a script's SOURCE looking for grade-write code. A docstring
+    describing the script — including one saying it does *not* write grades — is not
+    executable and must not be evidence. Real payload strings (`"posted_grade"`) are
+    kept: only `#` comments and bare-expression docstrings are removed.
+
+    Fails OPEN: anything unparseable returns the original text, so a syntax error or
+    a non-Python file can never quietly disable the check.
+
+    BLANKS the offending spans in place rather than rebuilding from tokens.
+    Rebuilding re-joins tokens with whitespace, which turns `requests.put(` into
+    `requests . put (` and stops `_WRITE_VERB` matching — silently disabling the
+    guard. Caught by running the bypass fixtures; offsets must survive untouched."""
+    try:
+        import io
+        import tokenize
+        chars = list(body)
+        # absolute offset of the start of each 1-indexed line
+        starts, off = {}, 0
+        for i, line in enumerate(body.splitlines(keepends=True), 1):
+            starts[i] = off
+            off += len(line)
+
+        def blank(tok):
+            a = starts[tok.start[0]] + tok.start[1]
+            b = starts[tok.end[0]] + tok.end[1]
+            for i in range(a, min(b, len(chars))):
+                if chars[i] != "\n":           # keep line structure intact
+                    chars[i] = " "
+
+        at_stmt_start = True
+        for tok in tokenize.generate_tokens(io.StringIO(body).readline):
+            if tok.type == tokenize.COMMENT:
+                blank(tok)
+                continue
+            if tok.type == tokenize.STRING and at_stmt_start:
+                blank(tok)                     # bare string statement == docstring
+            if tok.type in (tokenize.NEWLINE, tokenize.NL, tokenize.INDENT,
+                            tokenize.DEDENT, tokenize.ENCODING):
+                at_stmt_start = True
+            else:
+                at_stmt_start = False
+        return "".join(chars)
+    except Exception:                          # noqa: BLE001 — fail open, always
+        return body
 
 # The sanctioned tool source. Writing Canvas-write code here is legitimate — this
 # IS the reviewed tooling; running these scripts is the safe path.
@@ -372,7 +432,7 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
         for script in _extract_script_paths(cmd):
             if "/lib/tools/" in ("/" + script.replace("\\", "/")):
                 continue  # the reviewed tooling — running it is the safe path
-            body = _read_script(script)
+            body = _code_only(_read_script(script))   # prose is not executable (#297)
             if body and _WRITE_VERB.search(body) and _CANVAS_CTX.search(body):
                 return _redirect(f"running {script} — it writes grades to Canvas directly")
         return None
@@ -390,6 +450,9 @@ def evaluate(tool_name: str, tool_input: dict) -> str | None:
         # while the real payload used `content`). Check every plausible key.
         body = (tool_input.get("content") or tool_input.get("file_contents")
                 or tool_input.get("new_string") or "")
+        body = _code_only(body)              # prose is not executable (#297); an Edit
+        #                                      fragment that won't tokenize falls back
+        #                                      to the raw text, so nothing is weakened.
         if _WRITE_VERB.search(body) and _CANVAS_CTX.search(body):
             target = path or "a new file"
             return _redirect(f"Canvas grade-write code being written into {target}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.21.1"
+version = "1.21.2"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.21.1"
+version = "1.21.2"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Closes #297.

I read the actual script rather than guessing at the trigger. It's a line of **prose in the docstring**:

> `- NO essay question — the missed-stand-up justification comes in as a Canvas submission COMMENT instead`

`_CANVAS_CTX` carried a `canvas.*submission` catch-all that matched any line containing both words. The script's own documentation of what it deliberately does **not** do was read as evidence that it does. No code in that file touches a submission.

## Fix

**Comments and docstrings are stripped before a body is matched.** The run-catch reads source looking for grade-write *code*; prose isn't executable and can't be evidence. Real payload literals (`"posted_grade"`) are kept — only `#` comments and bare-expression docstrings go. Fails open on anything unparseable, so a syntax error or a non-Python file can never quietly disable the check.

**`canvas.*submission` → `/assignments/<anything>/submissions`.** The catch-all existed to cover endpoints built with f-strings, where `/assignments/\d+/submissions` finds no literal digits. The new pattern covers that case precisely without matching English.

## What I deliberately did not do

The issue's **Option 1** (whitelist by script name) and **Option 3** (marker comment) are both bypass vectors. An agent routing around the guard would name its script `mirror_standups_classic.py` or add the marker — trading a false positive for a hole in the guard's entire purpose. Option 2 was the only sound one.

## A near-miss worth recording

My first implementation rebuilt the source from tokens. That re-joined `requests.put(` as `requests . put (`, so `_WRITE_VERB` stopped matching and **all three bypass fixtures sailed straight through** — the guard was completely disabled and every test-shaped thing still looked fine.

It was caught only because I ran the real bypass scripts in both directions rather than just checking that the false positive went away. The fix blanks spans in place so offsets survive, and `test_code_only_preserves_offsets_so_write_verbs_still_match` now pins it.

## Verification

Both directions, on real files:

| | result |
|---|---|
| `mirror_standups_classic.py` (the report) | allowed |
| f-string endpoint + literal payload | **blocked** |
| f-string endpoint + payload in a variable | **blocked** |
| *"This script does NOT write grades. Honest."* + a real grade write | **blocked** |

5 new tests, including that a reassuring docstring can't launder a real write, that payload literals survive stripping, and that unparseable input fails open.

1235 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)