### PR TITLE
feat(canvas_sync): push course dates, verified by read-back (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,21 @@ For migration help between versions, see [UPGRADING.md](docs/UPGRADING.md).
 
 ---
 
+## [1.22.0] — 2026-08-15
+
+**Course dates push — and are verified, because Canvas may silently ignore them (#182).**
+
+`--migrate-from` (#294) made semester migration one command except for course dates, which still needed a manual trip to the Canvas UI. `_course.json` carried `start_at`/`end_at` and `--push` ignored them.
+
+- **`cmd_push` now writes course dates** via `PUT /courses/:id` when they change in `_course.json`.
+- **The write is confirmed by reading it back**, and this is the point rather than a nicety. Many institutions enable the account setting `prevent_course_availability_editing_by_teachers`, under which Canvas **returns 200 and keeps the old dates** for a teacher token — the operator who requested this feature hit exactly that ("dates not updated", no error). A fire-and-forget PUT would print *"✓ Course dates updated"* while nothing happened, which is #182's original bug — push claims success, the edit is discarded — reproduced one layer out. When the dates don't stick, the output names the account setting and points at Canvas → Settings → Course Details.
+- **`restrict_enrollments_to_course_dates` now round-trips too.** Without it, course dates govern nothing — the term dates win — so setting dates alone can "succeed" and change nothing an instructor can see.
+- **Timestamps are compared by instant, not string.** Canvas may echo an equivalent-but-differently-formatted date; a textual compare would report a successful write as a failure and send someone to their admin for nothing.
+- **`course_hash` only advances when everything round-trips.** Advancing it after a partial push is what made a discarded edit look clean in the first place.
+- `_course_late_policy_hash` → **`_course_pushable_hash`**, now covering late_policy *and* dates. #182's invariant is unchanged: the hash must cover exactly what push writes — too much and an unpushable edit (a course rename) shows as modified forever, too little and a real edit is silently dropped. Both directions are pinned by tests.
+
+---
+
 ## [1.21.2] — 2026-08-14
 
 **`grade_guardian` read a docstring as evidence of a grade write (#297).**

--- a/lib/tests/test_canvas_sync_status_course_level.py
+++ b/lib/tests/test_canvas_sync_status_course_level.py
@@ -31,10 +31,11 @@ def _write(path: Path, text: str) -> str:
 
 def _write_course(path: Path, late_policy: dict, **fields) -> str:
     """Write a realistic _course.json (late_policy + course-level fields) and
-    return its late_policy-ONLY hash — what --status/--push actually compare (#182)."""
+    return the PUSHABLE-subset hash — late_policy + course dates, i.e. exactly
+    what --status/--push compare (#182)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps({"late_policy": late_policy, **fields}), encoding="utf-8")
-    return canvas_sync._course_late_policy_hash(path)
+    return canvas_sync._course_pushable_hash(path)
 
 
 def test_no_changes_on_a_freshly_pulled_mirror(tmp_path):
@@ -166,3 +167,64 @@ def test_push_summary_lists_every_file_pushed():
 
 def test_push_summary_still_says_nothing_to_push_when_nothing_was():
     assert canvas_sync._push_summary([]) == "Nothing to push — all files match Canvas."
+
+
+# --- course dates: pushed, and VERIFIED (#182) -------------------------------
+
+def test_pushable_hash_covers_dates_so_a_date_edit_shows_as_modified(tmp_path):
+    """#182's invariant: the hash must cover exactly what push round-trips. Before
+    dates were pushable they were excluded on purpose; now that push writes them,
+    excluding them would make a real edit look clean and be silently discarded."""
+    c = tmp_path / "_course.json"
+    before = _write_course(c, {}, start_at="2026-01-05T00:00:00Z", end_at="2026-04-20T00:00:00Z")
+    after = _write_course(c, {}, start_at="2026-09-14T00:00:00Z", end_at="2026-12-16T00:00:00Z")
+    assert before != after
+
+
+def test_pushable_hash_ignores_fields_push_cannot_write(tmp_path):
+    """The other half of the invariant. A course rename is not pushable, so it must
+    NOT show as modified — otherwise --status nags forever about something no
+    command can resolve."""
+    c = tmp_path / "_course.json"
+    a = _write_course(c, {}, name="DS 460 Spring", course_code="DS460")
+    b = _write_course(c, {}, name="RENAMED", course_code="DS460")
+    assert a == b
+
+
+def test_dates_are_confirmed_by_read_back_not_by_status_code(monkeypatch):
+    """The trap this feature had to avoid. Under the account setting
+    `prevent_course_availability_editing_by_teachers` Canvas returns 200 and
+    silently keeps the old dates — the reporter hit exactly that. A fire-and-forget
+    PUT would print "✓ Course dates updated" while nothing changed, which is #182's
+    original bug (push claims success, edit discarded) one layer out."""
+    monkeypatch.setattr(canvas_sync, "_put", lambda *a, **k: {})
+    # Canvas echoes back the OLD dates — the write was ignored
+    monkeypatch.setattr(canvas_sync, "_get",
+                        lambda *a, **k: {"start_at": "2026-01-05T00:00:00Z",
+                                         "end_at": "2026-04-20T00:00:00Z"})
+    ok, msg = canvas_sync._push_course_dates(
+        {"start_at": "2026-09-14T00:00:00Z", "end_at": "2026-12-16T00:00:00Z"})
+    assert ok is False
+    assert "did NOT apply" in msg
+    assert "prevent_course_availability_editing_by_teachers" in msg
+
+
+def test_dates_report_success_only_when_canvas_actually_took_them(monkeypatch):
+    monkeypatch.setattr(canvas_sync, "_put", lambda *a, **k: {})
+    monkeypatch.setattr(canvas_sync, "_get",
+                        lambda *a, **k: {"start_at": "2026-09-14T00:00:00Z",
+                                         "end_at": "2026-12-16T00:00:00Z"})
+    ok, msg = canvas_sync._push_course_dates(
+        {"start_at": "2026-09-14T00:00:00Z", "end_at": "2026-12-16T00:00:00Z"})
+    assert ok is True and "2026-09-14 → 2026-12-16" in msg
+
+
+def test_equivalent_timestamp_formats_are_not_read_as_a_failure(monkeypatch):
+    """Canvas may echo a date in a different but equivalent format. A textual
+    compare would call that "the write didn't take" and send someone to their admin
+    for nothing."""
+    monkeypatch.setattr(canvas_sync, "_put", lambda *a, **k: {})
+    monkeypatch.setattr(canvas_sync, "_get",
+                        lambda *a, **k: {"start_at": "2026-09-14T00:00:00+00:00"})
+    ok, _ = canvas_sync._push_course_dates({"start_at": "2026-09-14T00:00:00Z"})
+    assert ok is True

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -180,22 +180,79 @@ def _file_hash(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()[:16]
 
 
-def _course_late_policy_hash(path: Path) -> str:
-    """Hash ONLY the late_policy sub-object of _course.json.
+def _course_pushable_hash(path: Path) -> str:
+    """Hash exactly the fields `cmd_push` round-trips: late_policy + course dates.
 
-    cmd_push round-trips only late_policy (PATCH .../late_policy) — never name,
-    course_code, dates, or grading_standard_id. So status and the stored
-    course_hash must reflect exactly that. Hashing the whole file instead made an
-    edit to a non-pushable field (e.g. name) show as `M [Course]` in --status and
-    then get silently dropped by --push, which still reported OK (#182). Scoping
-    the hash to late_policy keeps status honest: [Course] appears only when
-    something push can actually write has changed.
-    """
+    Renamed from `_course_late_policy_hash` when date pushing landed (#182). The
+    invariant is the one that issue was filed about: the hash must cover what push
+    actually writes and nothing else. Cover too much and an unpushable edit (a course
+    rename) shows as modified forever; cover too little and a real edit looks clean
+    while being silently discarded."""
+    d = json.loads(path.read_text(encoding="utf-8"))
+    subset = {"late_policy": d.get("late_policy", {})}
+    for f in _COURSE_DATE_FIELDS:
+        if f in d:
+            subset[f] = d[f]
+    return hashlib.sha256(
+        json.dumps(subset, sort_keys=True, default=str).encode("utf-8")
+    ).hexdigest()[:16]
+
+
+_COURSE_DATE_FIELDS = ("start_at", "end_at", "restrict_enrollments_to_course_dates")
+
+
+def _norm_dt(v):
+    """Compare Canvas timestamps by instant, not by string. Canvas may echo a date
+    back in a different but equivalent format, and a textual compare would read that
+    as "the write didn't take"."""
+    if v is None or isinstance(v, bool):
+        return v
+    s = str(v).strip()
+    if not s:
+        return None
     try:
-        lp = json.loads(path.read_text(encoding="utf-8")).get("late_policy", {})
-    except (OSError, json.JSONDecodeError):
-        return ""
-    return hashlib.sha256(json.dumps(lp, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+        from datetime import datetime
+        return datetime.fromisoformat(s.replace("Z", "+00:00"))
+    except ValueError:
+        return s
+
+
+def _push_course_dates(meta: dict) -> tuple[bool, str]:
+    """Push course start/end dates — and VERIFY Canvas actually took them (#182).
+
+    The verification is the whole point. Many institutions enable the account setting
+    `prevent_course_availability_editing_by_teachers`, under which Canvas **silently
+    ignores** `start_at` / `end_at` / `restrict_enrollments_to_course_dates` from a
+    teacher token: the PUT returns 200 and the dates are unchanged. The operator who
+    asked for this feature hit exactly that ("dates not updated", no error).
+
+    So a fire-and-forget PUT would report "✓ Course dates updated" while nothing
+    happened — which is #182's original bug (push claims success, edit is discarded)
+    reproduced one layer out. Read back, compare by instant, and say which it was.
+
+    `restrict_enrollments_to_course_dates` is included because course dates do not
+    govern anything without it — the term dates win — so setting dates alone can
+    "succeed" and change nothing an instructor can see."""
+    payload = {f: meta[f] for f in _COURSE_DATE_FIELDS if f in meta}
+    if not payload:
+        return True, "no date fields in _course.json"
+
+    _put(f"/courses/{CANVAS_COURSE_ID}", {"course": payload})
+    after = _get(f"/courses/{CANVAS_COURSE_ID}") or {}
+    stuck = [f for f in payload if _norm_dt(after.get(f)) != _norm_dt(payload[f])]
+    if not stuck:
+        s, e = payload.get("start_at"), payload.get("end_at")
+        return True, f"course dates updated ({str(s)[:10]} → {str(e)[:10]})"
+    return False, (
+        f"Canvas did NOT apply {', '.join(stuck)} — it returned success and kept the "
+        f"old value.\n"
+        f"      This is normally the account setting "
+        f"`prevent_course_availability_editing_by_teachers`,\n"
+        f"      under which a teacher token cannot set course availability dates. "
+        f"Set them in\n"
+        f"      Canvas → Settings → Course Details, or ask a Canvas admin. The local "
+        f"file is unchanged."
+    )
 
 
 def _push_late_policy(lp: dict) -> tuple:
@@ -690,6 +747,10 @@ def cmd_init():
         "grading_standard_id": course.get("grading_standard_id"),
         "start_at": course.get("start_at"),
         "end_at": course.get("end_at"),
+        # Without this, course dates do not govern anything — the term
+        # dates win — so a date push can "succeed" and change nothing.
+        "restrict_enrollments_to_course_dates":
+            course.get("restrict_enrollments_to_course_dates", False),
         "late_policy": {
             "late_submission_deduction_enabled": late_policy.get("late_submission_deduction_enabled", False),
             "late_submission_deduction": late_policy.get("late_submission_deduction", 0.0),
@@ -703,7 +764,7 @@ def cmd_init():
     course_path = COURSE_DIR / "_course.json"
     course_path.write_text(json.dumps(course_meta, indent=2))
     index["course"] = course_meta  # summary in index for agent lookup
-    index["course_hash"] = _course_late_policy_hash(course_path)  # only late_policy pushes (#182)
+    index["course_hash"] = _course_pushable_hash(course_path)  # late_policy + dates (#182)
     print(f"Course: {course.get('name')}")
 
     # Homepage (Canvas front_page — not a module item)
@@ -1466,7 +1527,7 @@ def _special_file_changes(index: dict, course_path: Optional[Path] = None) -> li
     will do is the dangerous direction to be wrong in on a live course.
 
     _course.json is diffed by its late_policy sub-object ONLY (via
-    _course_late_policy_hash), because that is the only field cmd_push writes.
+    _course_pushable_hash), because those are the only fields cmd_push writes.
     Edits to name/dates/grading_standard_id are not pushable and must not show as
     a pending [Course] change (#182).
 
@@ -1483,7 +1544,7 @@ def _special_file_changes(index: dict, course_path: Optional[Path] = None) -> li
         if path.exists() and _file_hash(path) != meta.get("hash"):
             changes.append((label, str(path)))
 
-    if course_path.exists() and _course_late_policy_hash(course_path) != index.get("course_hash"):
+    if course_path.exists() and _course_pushable_hash(course_path) != index.get("course_hash"):
         changes.append(("Course", str(course_path)))
 
     return changes
@@ -1693,22 +1754,35 @@ def cmd_push(target: Optional[str] = None):
     # Check _course.json — late_policy and other course-level settings
     course_path = COURSE_DIR / "_course.json"
     if course_path.exists() and (not target or "_course" in target or "course" == target):
-        course_hash = _course_late_policy_hash(course_path)  # only late_policy pushes (#182)
+        course_hash = _course_pushable_hash(course_path)  # what push round-trips (#182)
         stored_hash = index.get("course_hash")
         if course_hash != stored_hash:
             print(f"  [Course] {course_path}")
             data = json.loads(course_path.read_text(encoding="utf-8"))
+            ok = True
             lp = data.get("late_policy", {})
             if lp:
                 resp, created = _push_late_policy(lp)
                 if resp.status_code < 400:
-                    index["course_hash"] = course_hash
-                    index["course"] = data
-                    pushed_course_level.append("Course")
                     print(f"    OK (late_policy {'created' if created else 'updated'})")
                 else:
+                    ok = False
                     print(f"    FAILED late_policy: {resp.text[:200]}")
-                _save_index(index)
+            # Course dates (#182). Verified by read-back — see _push_course_dates.
+            dates_ok, msg = _push_course_dates(data)
+            if msg != "no date fields in _course.json":
+                print(f"    {'OK (' + msg + ')' if dates_ok else 'NOT APPLIED: ' + msg}")
+            ok = ok and dates_ok
+            if ok:
+                # Only advance the hash when EVERYTHING round-tripped. Advancing it
+                # after a partial push is what made a discarded edit look clean (#182).
+                index["course_hash"] = course_hash
+                index["course"] = data
+                pushed_course_level.append("Course")
+            else:
+                print("    (course_hash NOT advanced — --status will keep showing "
+                      "this as modified until it applies)")
+            _save_index(index)
 
     # Check syllabus separately — it's tracked under index["syllabus"], not index["files"]
     syllabus_meta = index.get("syllabus")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "canvas-toolbox"
-version = "1.21.2"
+version = "1.22.0"
 description = "Canvas LMS course-design audits + safe sync paths + AoL course-map generation. Read-only audits cover rubric coverage/quality, syllabus completeness (BYU-I 25-item rubric), CLO quality, content representation, and workload distribution. Sync paths cover master→Blueprint, Page-level orphan cleanup, and per-resource pulls. Agent-facing knowledge surfaces in `lib/agents/`."
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/uv.lock
+++ b/uv.lock
@@ -70,7 +70,7 @@ wheels = [
 
 [[package]]
 name = "canvas-toolbox"
-version = "1.21.2"
+version = "1.22.0"
 source = { virtual = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
Implements Option 2 from #182, requested in [this comment](https://github.com/chaz-clark/canvas-toolbox/issues/182#issuecomment-5299408587) — the last manual step left in the `--migrate-from` workflow from #294.

## The trap this had to avoid

The request included a suggested log line:

> `"✓ Course dates updated (2026-09-14 → 2026-12-16)"`

On the requester's own Canvas instance, that line would be a **lie**. Their report says it plainly:

> *"Attempted direct API call (`PUT /courses/:id`) with instructor token → dates not updated"*

Not an error — **silently ignored**. Many institutions enable the account setting `prevent_course_availability_editing_by_teachers`, under which Canvas returns `200` and keeps the old dates for a teacher token. ([Manage Courses permissions](https://developerdocs.instructure.com/services/canvas/permissions/details/file.permissions_manage_courses), [Courses API](https://www.canvas.instructure.com/doc/api/courses.html).)

A fire-and-forget PUT would report success while nothing happened — which is **#182's original bug reproduced one layer out**: push claims success, the edit is discarded, and `course_hash` advances so `--status` says everything is clean.

## So the write is verified, not assumed

`_push_course_dates` PUTs, then **reads back and compares**. If Canvas kept the old values it says so and names the cause:

```
    NOT APPLIED: Canvas did NOT apply start_at, end_at — it returned success and kept the old value.
      This is normally the account setting `prevent_course_availability_editing_by_teachers`,
      under which a teacher token cannot set course availability dates. Set them in
      Canvas → Settings → Course Details, or ask a Canvas admin. The local file is unchanged.
```

And `course_hash` is **not** advanced, so `--status` keeps showing it as modified rather than pretending it landed.

## Two things the request didn't mention

**`restrict_enrollments_to_course_dates` now round-trips.** Without it, course dates govern nothing — the term dates win — so setting `start_at`/`end_at` alone can "succeed" and change nothing an instructor can see. It's also blocked by the same account setting, so it belongs in the same payload and the same verification.

**Timestamps compare by instant, not string.** Canvas may echo back an equivalent-but-differently-formatted date; a textual compare would report a *successful* write as a failure and send someone to their Canvas admin for nothing.

## Scope

Took the requester's suggested scope: `start_at` / `end_at` only, not `name` / `course_code` / `workflow_state`. Those stay manual.

`_course_late_policy_hash` → `_course_pushable_hash`, now covering late_policy **and** dates. #182's invariant is unchanged — the hash must cover exactly what push writes. Cover too much and an unpushable edit (a course rename) shows as modified forever; too little and a real edit is silently discarded. Both directions have a test. The old function was orphaned by the rename and removed; its test now targets the new one.

## Verification

5 new tests, including the silently-ignored case, the genuine-success case, and format-equivalent timestamps.

1240 pass. The 2 `test_sprint1.py` failures are live-Canvas integration tests that fail identically on unmodified `main`.

## Note

Given that a ~30-day token cap looks likely to become standard, and that course-date writes are already admin-gated at BYU-I, this feature will report `NOT APPLIED` for most teacher tokens there. That's the correct outcome — it turns a silent no-op into a one-line diagnosis naming the setting to ask an admin about, rather than a manual UI step nobody knows is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)