### PR TITLE
fix(canvas_sync): --rebind now re-points the quiz's linked assignment (#300)

### DIFF
--- a/lib/tests/test_course_rebind.py
+++ b/lib/tests/test_course_rebind.py
@@ -5,6 +5,7 @@ A bad remap silently aims every future push, and any grade sync, at a different
 assignment, and nothing surfaces until someone spots marks on the wrong item. So the
 refusal cases carry as much weight as the success cases.
 """
+import json
 import sys
 from pathlib import Path
 
@@ -200,3 +201,69 @@ def test_hint_stays_quiet_for_unrelated_errors(capsys):
     cs._REBIND_HINTED = False
     cs._hint_rebind("unsupported grading_type 'bogus'")
     assert capsys.readouterr().out == ""
+
+
+# --- the second id a classic quiz carries (#300) -----------------------------
+
+def Q(title, cid, aid=None):  # classic quiz in the target course
+    it = {"type": "Quiz", "title": title, "canvas_id": cid}
+    if aid is not None:
+        it["assignment_id"] = aid
+    return it
+
+
+def test_target_index_carries_the_linked_assignment_id():
+    """Matching only ever yields the QUIZ id. The assignment id behind it has to be
+    carried alongside, or the caller has no way to look it up."""
+    tgt = _target(Q("Quiz 1", 300, aid=400), A("Lab", 900))
+    assert tgt["assignment_by_id"] == {300: 400}
+
+
+def _quiz_case(tmp_path, monkeypatch, *, local_aid, target_aid):
+    """One rebound quiz on disk; returns the quiz file's JSON after the rewrite."""
+    monkeypatch.chdir(tmp_path)
+    qfile = tmp_path / "q.json"
+    payload = {"canvas_id": 100, "title": "Quiz 1", "due_at": "2026-01-05T23:59:00Z"}
+    if local_aid is not None:
+        payload["assignment_id"] = local_aid
+    qfile.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    index = {"course_id": "146406", "files": {
+        "q.json": {"type": "Quiz", "title": "Quiz 1", "canvas_id": 100}}}
+    tgt = _target(Q("Quiz 1", 300, aid=target_aid))
+    plan = plan_rebind(index["files"], tgt)
+    cs._rewrite_quiz_assignment_ids(index, plan, tgt, quiet=True)
+    return json.loads(qfile.read_text(encoding="utf-8"))
+
+
+def test_rebind_updates_the_quiz_assignment_id(tmp_path, monkeypatch):
+    """The reported bug: canvas_id rebinds, assignment_id doesn't, and every date
+    PUT then 404s against the old course."""
+    data = _quiz_case(tmp_path, monkeypatch, local_aid=200, target_aid=400)
+    assert data["assignment_id"] == 400
+
+
+def test_rebind_drops_a_stale_id_when_the_target_quiz_has_none(tmp_path, monkeypatch):
+    """Ungraded surveys and practice quizzes have no linked assignment. Keeping the
+    old id would aim the date PUT at the previous course; _push_quiz skips the call
+    entirely when the key is absent."""
+    data = _quiz_case(tmp_path, monkeypatch, local_aid=200, target_aid=None)
+    assert "assignment_id" not in data
+
+
+def test_rebind_preserves_the_rest_of_the_quiz_file(tmp_path, monkeypatch):
+    data = _quiz_case(tmp_path, monkeypatch, local_aid=200, target_aid=400)
+    assert data["title"] == "Quiz 1" and data["due_at"] == "2026-01-05T23:59:00Z"
+
+
+def test_rebind_leaves_non_quiz_files_alone(tmp_path, monkeypatch):
+    """Assignments carry a canvas_id in their JSON too; nothing here should touch it."""
+    monkeypatch.chdir(tmp_path)
+    afile = tmp_path / "a.json"
+    afile.write_text(json.dumps({"canvas_id": 11, "name": "Lab"}), encoding="utf-8")
+    index = {"course_id": "1", "files": {
+        "a.json": {"type": "Assignment", "title": "Lab", "canvas_id": 11}}}
+    tgt = _target(A("Lab", 900))
+    plan = plan_rebind(index["files"], tgt)
+    assert cs._rewrite_quiz_assignment_ids(index, plan, tgt, quiet=True) == 0
+    assert json.loads(afile.read_text())["canvas_id"] == 11

--- a/lib/tools/_course_rebind.py
+++ b/lib/tools/_course_rebind.py
@@ -63,15 +63,23 @@ def index_target(items: list[dict]) -> dict:
     """Build lookup tables from a target-course inventory.
 
     `items` are dicts with at least: type, canvas_id, title, and page_url for Pages.
-    Returns {"by_slug", "by_title", "by_norm", "ambiguous"} where `ambiguous` holds
-    normalized titles that appear more than once IN THE TARGET — those can never be
-    matched safely, whatever the local side looks like."""
-    by_slug, by_title, by_norm = {}, {}, {}
+    Returns {"by_slug", "by_title", "by_norm", "ambiguous", "assignment_by_id"} where
+    `ambiguous` holds normalized titles that appear more than once IN THE TARGET —
+    those can never be matched safely, whatever the local side looks like.
+
+    `assignment_by_id` maps a target canvas_id to the linked assignment id, for the
+    types that carry a second id (#300). A classic quiz has two: the quiz, and the
+    assignment Canvas keeps behind it — which is where its dates actually live. The
+    caller needs the new one to re-point the quiz's JSON file; matching only ever
+    yields the quiz id, so the pairing has to be carried here."""
+    by_slug, by_title, by_norm, assignment_by_id = {}, {}, {}, {}
     norm_keys = []
     for it in items:
         t, cid = it.get("type"), it.get("canvas_id")
         if not cid:
             continue
+        if it.get("assignment_id"):
+            assignment_by_id[cid] = it["assignment_id"]
         if t in _SLUG_TYPES and it.get("page_url"):
             by_slug[(t, it["page_url"])] = cid
             continue
@@ -84,7 +92,7 @@ def index_target(items: list[dict]) -> dict:
         by_norm[(t, n)] = cid
     ambiguous = {k for k in _dupes([f"{t}\x00{n}" for t, n in norm_keys])}
     return {"by_slug": by_slug, "by_title": by_title, "by_norm": by_norm,
-            "ambiguous": ambiguous}
+            "ambiguous": ambiguous, "assignment_by_id": assignment_by_id}
 
 
 def plan_rebind(local_files: dict, target: dict) -> dict:

--- a/lib/tools/canvas_sync.py
+++ b/lib/tools/canvas_sync.py
@@ -1369,13 +1369,17 @@ def _fetch_course_inventory(course_id: str) -> list[dict]:
     Normalized to the shape `_course_rebind` expects: type/title/canvas_id, plus
     page_url for Pages. New Quizzes surface through the assignments endpoint with a
     quiz_lti flag — they're included so a rebind can re-point them even though
-    canvas_sync can't EDIT them (they're Canvas-UI-only)."""
+    canvas_sync can't EDIT them (they're Canvas-UI-only).
+
+    Quizzes also carry `assignment_id` — the linked assignment behind a classic quiz,
+    which is the endpoint its dates are pushed to (#300)."""
     out: list[dict] = []
     for a in _get(f"/courses/{course_id}/assignments", {"per_page": 100}) or []:
         out.append({"type": "Assignment", "title": a.get("name"),
                     "canvas_id": a.get("id")})
     for q in _get(f"/courses/{course_id}/quizzes", {"per_page": 100}) or []:
-        out.append({"type": "Quiz", "title": q.get("title"), "canvas_id": q.get("id")})
+        out.append({"type": "Quiz", "title": q.get("title"), "canvas_id": q.get("id"),
+                    "assignment_id": q.get("assignment_id")})
     for p in _get(f"/courses/{course_id}/pages", {"per_page": 100}) or []:
         out.append({"type": "Page", "title": p.get("title"),
                     "page_url": p.get("url"), "canvas_id": p.get("page_id")})
@@ -1408,6 +1412,44 @@ def _rewrite_frontmatter_ids(index: dict, plan: dict, quiet: bool = False) -> in
     return n
 
 
+def _rewrite_quiz_assignment_ids(index: dict, plan: dict, target: dict,
+                                 quiet: bool = False) -> int:
+    """Re-point the SECOND id a classic quiz carries — its linked assignment (#300).
+
+    A classic quiz is two objects in Canvas: the quiz, and an assignment kept behind
+    it. `_push_quiz` sends metadata to the quiz endpoint but DATES to the assignment
+    endpoint, and that `assignment_id` lives in the quiz's own JSON file rather than
+    in the index — so `apply_rebind()`, which only rewrites index entries, cannot
+    reach it. Left alone the quiz rebinds cleanly and then every date PUT 404s
+    against the old course, which reads like the assignment was deleted.
+
+    A target quiz with no linked assignment (ungraded surveys, practice quizzes) has
+    the stale key REMOVED rather than kept: `_push_quiz` skips the date PUT when it's
+    absent, and a stale id that looks valid is worse than none at all."""
+    n = 0
+    for path, (_old, new, _how) in plan["matched"].items():
+        if (index["files"].get(path) or {}).get("type") != "Quiz":
+            continue
+        p = Path(path)
+        if not p.is_file():
+            continue
+        data = json.loads(p.read_text(encoding="utf-8"))
+        new_aid = (target.get("assignment_by_id") or {}).get(new)
+        if new_aid:
+            if data.get("assignment_id") == new_aid:
+                continue
+            data["assignment_id"] = new_aid
+        elif "assignment_id" in data:
+            data.pop("assignment_id")
+        else:
+            continue
+        p.write_text(json.dumps(data, indent=2, default=str), encoding="utf-8")
+        n += 1
+    if not quiet and n:
+        print(f"  updated assignment_id in {n} quiz file(s)")
+    return n
+
+
 def cmd_rebind(new_course_id: str, apply: bool = False) -> int:
     """Re-point local sync state at a different Canvas course (#294).
 
@@ -1431,7 +1473,8 @@ def cmd_rebind(new_course_id: str, apply: bool = False) -> int:
         return 2
     print(f"  target course holds {len(inventory)} item(s)")
 
-    plan = plan_rebind(files, index_target(inventory))
+    target = index_target(inventory)
+    plan = plan_rebind(files, target)
     print(summarize(plan))
     for bucket, label in (("ambiguous", "AMBIGUOUS"), ("unmatched", "unmatched")):
         for p in plan[bucket][:10]:
@@ -1447,6 +1490,7 @@ def cmd_rebind(new_course_id: str, apply: bool = False) -> int:
         return 2
     _save_index(apply_rebind(index, plan, new_course_id))
     _rewrite_frontmatter_ids(index, plan)
+    _rewrite_quiz_assignment_ids(index, plan, target)
     print(f"\n✓ rebound {len(plan['matched'])} item(s) to course {new_course_id}.")
     if plan["unmatched"] or plan["ambiguous"]:
         print("  Items listed above were NOT rebound and will still fail to push.")


### PR DESCRIPTION
Fixes #300.

## The bug

A classic quiz is two objects in Canvas: the quiz, and an assignment kept behind it. `_push_quiz` sends metadata to the quiz endpoint but **dates** to the assignment endpoint ([canvas_sync.py:1687](../blob/main/lib/tools/canvas_sync.py#L1687)).

After `--rebind`, the quiz id was correct and the assignment id was not, so every quiz date PUT 404'd against the old course — `"The specified resource does not exist"`, which reads like the assignment was deleted rather than like the id belongs elsewhere.

## Why the reported fix wouldn't have worked

The issue proposed updating `entry["assignment_id"]` in `apply_rebind()`. That field isn't in the index:

```
index entry : {canvas_id, type, title, module_item_id, hash, markdown_path}
quiz file   : {canvas_id, assignment_id, title, description, due_at, ...}
```

`_push_quiz` reads `canvas_id` from the **index** but `assignment_id` from the **quiz's JSON file**. Writing it to the index would have set a field nothing reads and left the 404 in place.

## The fix

The pairing travels through the target inventory instead — no network call added to `_course_rebind`, which stays pure:

- `_fetch_course_inventory` keeps `assignment_id` off `/quizzes`
- `index_target` exposes `assignment_by_id` — matching only ever yields the quiz id, so the pairing has to be carried alongside it
- `_rewrite_quiz_assignment_ids` re-points the quiz JSON files, mirroring how `_rewrite_frontmatter_ids` already re-points the markdown

A target quiz with **no** linked assignment (ungraded surveys, practice quizzes) has the stale key **removed** rather than kept — `_push_quiz` skips the date PUT when it's absent, and a stale id that looks valid is worse than none. Same rule the module already applies to `module_item_id`.

`--migrate-from` is covered too; it calls `cmd_rebind(apply=True)`.

## Verification

Simulated with the exact ids from the report (course 146406 → 422668):

```
index canvas_id    : 2312219  (was 6247938)
file  assignment_id: 2318844  (was 6249153)

  PUT /courses/422668/assignments/2318844   ✓
  before: PUT /courses/422668/assignments/6249153  -> 404
```

Full suite: **1245 passed**. Two pre-existing failures in `test_sprint1.py` are live-API tests failing on a 401 (expired token) — confirmed identical with these changes stashed.

Five new tests in `test_course_rebind.py` cover the reported case, the survey/practice-quiz case, field preservation, and non-quiz files being left alone.

## Adjacent finding — not fixed here

Every `course/*.json` also carries a `canvas_id` that goes stale on rebind (27 quiz files + 118 others in DS250). Push doesn't read it — it uses the index — so nothing fails today. Left alone deliberately rather than bundled into a bug fix; rewriting all 145 would change their hashes and mark them dirty. Worth its own issue if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)