### PR TITLE
feat(grading_scheme_setup): create a Canvas grading standard, verified (#302)

### DIFF
--- a/.claude/skills/course-build/SKILL.md
+++ b/.claude/skills/course-build/SKILL.md
@@ -38,6 +38,7 @@ defends against it, but naming the target explicitly is on you.
 | Master → Blueprint propagation | `blueprint_sync.py` |
 | Validate a blueprint sync | `validate_blueprint_sync.py` + `blueprint_exception_report.py` |
 | Module prerequisites / completion | `module_settings_sync.py` |
+| Create a custom grading scheme | `grading_scheme_setup.py --title ... --tiers ... --apply` |
 | Multi-course wrapper | `sync_context.sh` |
 | Post-push structural audit | `course_quality_check.py` *(then hand off to the `audit` skill)* |
 

--- a/lib/tests/test_grading_scheme_setup.py
+++ b/lib/tests/test_grading_scheme_setup.py
@@ -1,0 +1,130 @@
+"""Unit tests — grading scheme creation (#302).
+
+The dangerous failure here is not "refused to create" — it's a scheme Canvas
+ACCEPTS and then renders wrong. A gap under the lowest tier leaves scores with no
+letter at all, and an out-of-order scale silently reassigns every grade in the
+course. So the validation cases carry more weight than the happy path.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOLS_DIR = Path(__file__).resolve().parent.parent / "tools"
+if str(_TOOLS_DIR) not in sys.path:
+    sys.path.insert(0, str(_TOOLS_DIR))
+
+from grading_scheme_setup import (  # noqa: E402
+    entries_match,
+    parse_tiers,
+    validate_tiers,
+)
+
+_TIERS = "Leading:90,Strong:80,Solid:70,Building:60,Insufficient:0"
+
+
+# --- parsing ----------------------------------------------------------------
+
+def test_parses_name_and_lower_bound():
+    t = parse_tiers(_TIERS)
+    assert [x["name"] for x in t] == ["Leading", "Strong", "Solid", "Building",
+                                      "Insufficient"]
+    assert [x["percent"] for x in t] == [90, 80, 70, 60, 0]
+
+
+def test_tier_names_may_contain_a_colon():
+    """rpartition on the LAST colon, so "Tier A: Leading:90" keeps its label."""
+    assert parse_tiers("Tier A: Leading:90,Rest:0")[0]["name"] == "Tier A: Leading"
+
+
+def test_whitespace_and_trailing_commas_are_tolerated():
+    assert len(parse_tiers(" Pass:60 , Fail:0 ,")) == 2
+
+
+@pytest.mark.parametrize("spec, fragment", [
+    ("", "no tiers"),
+    ("Leading", "expected NAME:PERCENT"),
+    (":90,Rest:0", "missing tier name"),
+    ("Leading:high,Rest:0", "not a number"),
+])
+def test_malformed_specs_are_refused(spec, fragment):
+    with pytest.raises(ValueError, match=fragment):
+        parse_tiers(spec)
+
+
+# --- validation (the ones that matter) --------------------------------------
+
+def test_a_well_formed_scale_passes():
+    validate_tiers(parse_tiers(_TIERS))
+
+
+def test_scale_not_reaching_zero_is_refused():
+    """Canvas accepts this and then has no letter for 0-59%, which renders blank
+    in the gradebook rather than failing loudly."""
+    with pytest.raises(ValueError, match="lowest tier must start at 0"):
+        validate_tiers(parse_tiers("Leading:90,Strong:80,Building:60"))
+
+
+def test_ascending_scale_is_refused():
+    """Listed low-to-high, every tier boundary lands on the wrong letter."""
+    with pytest.raises(ValueError, match="high to low"):
+        validate_tiers(parse_tiers("Insufficient:0,Solid:70,Leading:90"))
+
+
+def test_repeated_bound_is_refused():
+    with pytest.raises(ValueError, match="high to low"):
+        validate_tiers(parse_tiers("Leading:90,Strong:90,Rest:0"))
+
+
+def test_duplicate_names_are_refused():
+    with pytest.raises(ValueError, match="duplicate tier name"):
+        validate_tiers(parse_tiers("Pass:90,Pass:60,Fail:0"))
+
+
+@pytest.mark.parametrize("spec", ["Over:101,Rest:0", "Under:-5,Rest:0"])
+def test_bounds_outside_zero_to_hundred_are_refused(spec):
+    with pytest.raises(ValueError, match="outside 0-100"):
+        validate_tiers(parse_tiers(spec))
+
+
+def test_a_two_tier_pass_fail_scale_is_valid():
+    """Specifications grading is a legitimate shape, not an error."""
+    validate_tiers(parse_tiers("Pass:80,Fail:0"))
+
+
+# --- read-back comparison ---------------------------------------------------
+
+def _canvas_echo(*pairs):
+    return {"grading_scheme_entry": [{"name": n, "value": v} for n, v in pairs]}
+
+
+def test_read_back_matches_when_canvas_echoes_fractions():
+    """Percent goes out, fraction comes back — the comparison has to convert."""
+    assert entries_match(_canvas_echo(("Pass", 0.8), ("Fail", 0.0)),
+                         parse_tiers("Pass:80,Fail:0"))
+
+
+def test_read_back_tolerates_canvas_rounding():
+    assert entries_match(_canvas_echo(("Pass", 0.80001), ("Fail", 0.0)),
+                         parse_tiers("Pass:80,Fail:0"))
+
+
+def test_read_back_detects_a_changed_bound():
+    """The failure this guards: Canvas answers 200, stores something else."""
+    assert not entries_match(_canvas_echo(("Pass", 0.7), ("Fail", 0.0)),
+                             parse_tiers("Pass:80,Fail:0"))
+
+
+def test_read_back_detects_a_dropped_tier():
+    assert not entries_match(_canvas_echo(("Pass", 0.8)),
+                             parse_tiers("Pass:80,Fail:0"))
+
+
+def test_read_back_detects_a_renamed_tier():
+    assert not entries_match(_canvas_echo(("Passing", 0.8), ("Fail", 0.0)),
+                             parse_tiers("Pass:80,Fail:0"))
+
+
+def test_read_back_of_an_empty_response_is_not_a_match():
+    """A create that silently did nothing must not read as success."""
+    assert not entries_match({}, parse_tiers("Pass:80,Fail:0"))

--- a/lib/tools/grading_scheme_setup.py
+++ b/lib/tools/grading_scheme_setup.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""
+grading_scheme_setup.py — create a Canvas grading standard, verified by read-back.
+
+WHY THIS EXISTS (#302)
+  The toolkit could already READ a course's `grading_standard_id` (canvas_sync
+  cmd_init) and PROPAGATE it master -> blueprint -> section (blueprint_sync,
+  course_mirror). What it could not do is CREATE the standard those ids point at.
+  So a course using a custom scale — competency tiers, specifications grading,
+  anything that isn't A/B/C/D/F — had to be set up by hand in the Canvas UI before
+  any of the propagation was usable.
+
+  This closes that gap and nothing more. It creates ONE course-level grading
+  standard and, on request, sets it as the course default. It deliberately does
+  NOT batch-configure assignments: that is per-assignment policy, it changes how
+  already-earned grades DISPLAY to enrolled students, and it belongs behind the
+  same review the grading push surface gets rather than in a setup helper.
+
+WHY THE WRITE IS READ BACK
+  Same reason course dates are (#182): Canvas can answer 200 and not apply the
+  change. `manage_grades` is restricted at some institutions, and a create that
+  "succeeds" while leaving nothing behind is the worst outcome — the operator
+  moves on and discovers it when grades render wrong. So the standard is fetched
+  back and its entries compared before this reports success.
+
+WHY THE SCALE IS VALIDATED BEFORE IT IS SENT
+  Canvas accepts a scheme with a gap under the lowest tier and then has no letter
+  for scores that fall in it. A refused command costs a retype; a silently
+  incomplete scale costs a semester of wrong letters. So: descending, unique,
+  within 0-100, and floored at 0.
+
+Usage:
+  # dry run (default) — validates and shows what would be created
+  uv run python lib/tools/grading_scheme_setup.py \
+      --title "Industry Performance Tiers" \
+      --tiers "Leading:90,Strong:80,Solid:70,Building:60,Insufficient:0"
+
+  # write it
+  uv run python lib/tools/grading_scheme_setup.py --title ... --tiers ... --apply
+
+  # write it and make it the course default
+  uv run python lib/tools/grading_scheme_setup.py --title ... --tiers ... \
+      --apply --set-course-default
+
+Requires in .env: CANVAS_API_TOKEN, CANVAS_BASE_URL, and the env var named by
+--target (default CANVAS_COURSE_ID).
+
+Exit codes:
+  0  created (or already present) and verified
+  1  Canvas did not apply the write, or read-back disagreed
+  2  configuration / validation error
+"""
+
+from __future__ import annotations
+
+import argparse
+
+try:
+    from _env_loader import force_utf8_console
+except ImportError:
+    def force_utf8_console() -> None:
+        pass  # No-op if _env_loader not available
+import os
+import sys
+
+import requests
+from dotenv import load_dotenv
+
+import canvas_course_guard as guard
+from __toolbox_version__ import __version__
+
+load_dotenv()
+
+CANVAS_API_TOKEN = os.environ.get("CANVAS_API_TOKEN", "")
+# The .env convention is scheme-less ("byui.instructure.com"); requests needs a
+# scheme. Matches canvas_sync.py / rubric_quality_audit.py.
+_raw_url = os.environ.get("CANVAS_BASE_URL", "").strip().rstrip("/")
+if _raw_url and not _raw_url.startswith("http"):
+    _raw_url = "https://" + _raw_url
+CANVAS_BASE_URL = _raw_url
+
+_TIMEOUT = 30
+# Canvas stores tier lower bounds as fractions and may echo them rounded, so
+# read-back compares within a tolerance rather than by equality.
+_VALUE_TOL = 1e-4
+
+
+def _headers() -> dict:
+    return {"Authorization": f"Bearer {CANVAS_API_TOKEN}"}
+
+
+def _get(endpoint: str) -> list | dict | None:
+    try:
+        resp = requests.get(f"{CANVAS_BASE_URL}/api/v1{endpoint}",
+                            headers=_headers(), params={"per_page": 100},
+                            timeout=_TIMEOUT)
+    except Exception:
+        return None
+    if resp.status_code >= 400:
+        return None
+    try:
+        return resp.json()
+    except Exception:
+        return None
+
+
+def _post(endpoint: str, payload: dict) -> tuple[dict | None, str]:
+    """Returns (json, error_text). Canvas error bodies name the real cause
+    (permissions, duplicate title), so they are surfaced rather than swallowed."""
+    try:
+        resp = requests.post(f"{CANVAS_BASE_URL}/api/v1{endpoint}",
+                             headers=_headers(), json=payload, timeout=_TIMEOUT)
+    except Exception as e:
+        return None, str(e)
+    if resp.status_code >= 400:
+        return None, f"HTTP {resp.status_code}: {resp.text[:300]}"
+    try:
+        return resp.json(), ""
+    except Exception:
+        return None, "response was not JSON"
+
+
+# ---------------------------------------------------------------------------
+# Scale parsing + validation
+# ---------------------------------------------------------------------------
+
+def parse_tiers(spec: str) -> list[dict]:
+    """Parse "Leading:90,Strong:80,...". PURE — raises ValueError, writes nothing.
+
+    The value is the tier's LOWER BOUND in percent, which is how Canvas models a
+    scheme: each entry claims everything from its bound up to the next one."""
+    tiers: list[dict] = []
+    for chunk in (spec or "").split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if ":" not in chunk:
+            raise ValueError(f"expected NAME:PERCENT, got {chunk!r}")
+        name, _, raw = chunk.rpartition(":")
+        name = name.strip()
+        if not name:
+            raise ValueError(f"missing tier name in {chunk!r}")
+        try:
+            pct = float(raw)
+        except ValueError:
+            raise ValueError(f"{raw!r} in {chunk!r} is not a number") from None
+        tiers.append({"name": name, "percent": pct})
+    if not tiers:
+        raise ValueError("no tiers given")
+    return tiers
+
+
+def validate_tiers(tiers: list[dict]) -> None:
+    """Refuse a scale Canvas would accept but render wrong. Raises ValueError."""
+    names = [t["name"] for t in tiers]
+    dupes = {n for n in names if names.count(n) > 1}
+    if dupes:
+        raise ValueError(f"duplicate tier name(s): {', '.join(sorted(dupes))}")
+
+    for t in tiers:
+        if not 0 <= t["percent"] <= 100:
+            raise ValueError(f"{t['name']}: {t['percent']} is outside 0-100")
+
+    pcts = [t["percent"] for t in tiers]
+    if pcts != sorted(pcts, reverse=True) or len(set(pcts)) != len(pcts):
+        raise ValueError(
+            "tiers must be listed high to low with no repeated bound; got "
+            + ", ".join(f"{t['name']}:{t['percent']:g}" for t in tiers))
+
+    if pcts[-1] != 0:
+        raise ValueError(
+            f"the lowest tier must start at 0, but {tiers[-1]['name']} starts at "
+            f"{pcts[-1]:g}. Canvas has no letter for scores below the lowest tier, "
+            f"so 0-{pcts[-1]:g}% would render blank.")
+
+
+def find_existing(course_id: str, title: str) -> dict | None:
+    """A standard already carrying this title, if any. Account-level standards are
+    visible here too and are reused rather than shadowed by a course-level copy of
+    the same name — two same-named scales is a support ticket waiting to happen."""
+    for s in _get(f"/courses/{course_id}/grading_standards") or []:
+        if isinstance(s, dict) and (s.get("title") or "").strip() == title.strip():
+            return s
+    return None
+
+
+def entries_match(standard: dict, tiers: list[dict]) -> bool:
+    got = standard.get("grading_scheme_entry") or []
+    if len(got) != len(tiers):
+        return False
+    for g, t in zip(got, tiers):
+        if (g.get("name") or "").strip() != t["name"]:
+            return False
+        if abs(float(g.get("value", -1)) - t["percent"] / 100.0) > _VALUE_TOL:
+            return False
+    return True
+
+
+def create_standard(course_id: str, title: str,
+                    tiers: list[dict]) -> tuple[dict | None, str]:
+    return _post(f"/courses/{course_id}/grading_standards", {
+        "title": title,
+        "grading_scheme_entry": [
+            {"name": t["name"], "value": t["percent"] / 100.0} for t in tiers
+        ],
+    })
+
+
+def set_course_default(course_id: str, standard_id: int) -> tuple[bool, str]:
+    """Point the course at the standard, then READ IT BACK (#182's lesson)."""
+    try:
+        requests.put(f"{CANVAS_BASE_URL}/api/v1/courses/{course_id}",
+                     headers=_headers(),
+                     json={"course": {"grading_standard_id": standard_id}},
+                     timeout=_TIMEOUT)
+    except Exception as e:
+        return False, str(e)
+    after = _get(f"/courses/{course_id}") or {}
+    if isinstance(after, dict) and after.get("grading_standard_id") == standard_id:
+        return True, ""
+    return False, (
+        f"Canvas reported success but the course still shows "
+        f"grading_standard_id={after.get('grading_standard_id')!r}. This is normally "
+        f"a permissions restriction on the token — set it in Canvas -> Settings -> "
+        f"Course Details, or ask a Canvas admin.")
+
+
+def main() -> int:
+    force_utf8_console()  # #123 — Windows cp1252 console crash
+
+    ap = argparse.ArgumentParser(
+        description="Create a Canvas grading standard (custom grading scheme).")
+    ap.add_argument("--version", action="version",
+                    version=f"canvas-toolbox {__version__}")
+    ap.add_argument("--title", required=True, help="Scheme name as it appears in Canvas")
+    ap.add_argument("--tiers", required=True,
+                    metavar="NAME:PCT,...",
+                    help='Lower bounds, high to low, ending at 0. '
+                         'e.g. "Leading:90,Strong:80,Solid:70,Building:60,Insufficient:0"')
+    ap.add_argument("--target", default="CANVAS_COURSE_ID",
+                    help="Env var holding the course id (default CANVAS_COURSE_ID)")
+    ap.add_argument("--course-id", default=None, help="Literal course id; overrides --target")
+    ap.add_argument("--apply", action="store_true",
+                    help="Write to Canvas. Without this the run is a dry run.")
+    ap.add_argument("--set-course-default", action="store_true",
+                    help="Also point the course's grading_standard_id at this scheme")
+    ap.add_argument("--allow-enrolled", action="store_true",
+                    help="Proceed even if the course has enrolled students")
+    args = ap.parse_args()
+
+    if not CANVAS_API_TOKEN or not CANVAS_BASE_URL:
+        print("ERROR: CANVAS_API_TOKEN and CANVAS_BASE_URL must be set.")
+        return 2
+    course_id = (args.course_id or os.environ.get(args.target, "")).strip()
+    if not course_id:
+        source = "--course-id" if args.course_id else f"${args.target}"
+        print(f"ERROR: course ID not found via {source}.")
+        print("       Set the env var, or pass --course-id <id> directly.")
+        return 2
+
+    try:
+        tiers = parse_tiers(args.tiers)
+        validate_tiers(tiers)
+    except ValueError as e:
+        print(f"ERROR: {e}")
+        return 2
+
+    print(f"Grading scheme: {args.title}"
+          f"   ({'APPLYING' if args.apply else 'DRY RUN — pass --apply to write'})")
+    for i, t in enumerate(tiers):
+        upper = 100.0 if i == 0 else tiers[i - 1]["percent"]
+        print(f"  {t['name']:<20} {t['percent']:g}% – {upper:g}%")
+
+    guard.enforce(base_url=CANVAS_BASE_URL, headers=_headers(), course_id=course_id,
+                  mode="write" if args.apply else "read",
+                  allow_override=args.allow_enrolled, label="scheme target")
+
+    existing = find_existing(course_id, args.title)
+    if existing:
+        where = (existing.get("context_type") or "Course").lower()
+        same = entries_match(existing, tiers)
+        print(f"\n  already exists at {where} level (id {existing.get('id')}) — "
+              f"{'tiers match' if same else 'TIERS DIFFER from what you passed'}")
+        if not same:
+            print("  Canvas has no scheme-edit endpoint; rename this run's --title "
+                  "or change the scheme in the Canvas UI.")
+            return 1
+        standard_id = existing.get("id")
+    else:
+        if not args.apply:
+            print("\nRe-run with --apply to create it.")
+            return 0
+        created, err = create_standard(course_id, args.title, tiers)
+        if not created:
+            print(f"\nERROR creating scheme: {err}")
+            return 1
+        standard_id = created.get("id")
+        # Read back — a 200 is not proof it landed (#182).
+        back = find_existing(course_id, args.title)
+        if not back or not entries_match(back, tiers):
+            print("\nCanvas reported success but the scheme did not read back "
+                  "intact. Nothing here retries automatically; check "
+                  "Canvas -> Settings -> Grading Schemes before re-running.")
+            return 1
+        standard_id = back.get("id")
+        print(f"\n  ✓ created and verified (id {standard_id})")
+
+    if args.set_course_default:
+        if not args.apply:
+            print("  would set it as the course default")
+        else:
+            ok, err = set_course_default(course_id, standard_id)
+            print("  ✓ course default set" if ok else f"\n  {err}")
+            if not ok:
+                return 1
+
+    if args.apply:
+        print(f"\nUse it on an assignment with grading_type=letter_grade and "
+              f"grading_standard_id={standard_id}.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Refs #302.

## The gap this fills

The toolkit already **reads** a course's `grading_standard_id` ([canvas_sync.py:747](../blob/main/lib/tools/canvas_sync.py#L747)) and **propagates** it master → blueprint → section ([blueprint_sync.py:521](../blob/main/lib/tools/blueprint_sync.py#L521), [course_mirror.py:323](../blob/main/lib/tools/course_mirror.py#L323)). It had no way to **create** the standard those ids point at — so any course on a custom scale had to be set up by hand in the Canvas UI before the propagation was usable.

```bash
uv run python lib/tools/grading_scheme_setup.py \
    --title "Industry Performance Tiers" \
    --tiers "Leading:90,Strong:80,Solid:70,Building:60,Insufficient:0" \
    --apply --set-course-default
```

Dry run by default, `--apply` to write — matching `--rebind`.

## What I deliberately left out

The share also included batch assignment configuration (`grading_type` + `lock_at` + peer review across an assignment list). Not taken, for three reasons:

- It's per-assignment **policy**, not course setup.
- It changes how **already-earned grades display** to enrolled students — that belongs behind the review the grading push surface gets, not in a setup helper.
- The shared version drove it from hardcoded assignment IDs and course-specific name patterns (`KC1`/`WC1`/`S1`), so generalizing it means designing a config format — a design task, not a cleanup.

## Two safety properties, both load-bearing

**The write is read back.** Same reason course dates are (#182/#299): Canvas can answer `200` and apply nothing when the token lacks `manage_grades`. A create that "succeeds" while leaving nothing behind is the worst outcome — the operator moves on and finds out when grades render wrong.

**The scale is validated before it's sent.** Canvas accepts a scheme with a gap under the lowest tier and then has no letter for scores inside it:

```
$ ... --tiers "Leading:90,Building:60"
ERROR: the lowest tier must start at 0, but Building starts at 60. Canvas has
no letter for scores below the lowest tier, so 0-60% would render blank.
```

Also refused: ascending order, repeated bounds, duplicate names, bounds outside 0–100. A refused command costs a retype; a silently incomplete scale costs a semester of wrong letters.

## Verification

21 new tests, weighted toward the validation and read-back cases rather than the happy path. Full suite **1266 passed** (was 1245). The two `test_sprint1.py` failures are pre-existing live-API 401s — the Canvas token in this environment is revoked, confirmed unchanged with these commits stashed.

No live-course exercise: the revoked token means the create path hasn't run against real Canvas. The scheme-entry shape follows what the reporter ran successfully in ds460.

## Also

Registered in the `course-build` skill catalog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)